### PR TITLE
Remove desynchronized webgl context hint

### DIFF
--- a/docs/picom-nixos-i3.md
+++ b/docs/picom-nixos-i3.md
@@ -1,0 +1,45 @@
+# Tear-free picom on NixOS + i3
+
+Add to `/etc/nixos/configuration.nix`:
+
+```nix
+services.picom = {
+  enable = true;
+  backend = "egl";        # most reliable on AMD (amdgpu/Mesa); use "glx" if egl misbehaves
+  vSync = true;           # NOTE capital S — module default is FALSE, which causes tearing
+  settings = {
+    unredir-if-possible = true;
+  };
+};
+```
+
+Apply:
+
+```bash
+sudo nixos-rebuild switch
+systemctl --user daemon-reload
+systemctl --user restart picom
+```
+
+That's it — the module generates a systemd user unit (`picom.service`) that
+autostarts with your graphical session, so **no i3 config / `exec picom` line is
+needed**.
+
+Verify:
+
+```bash
+pgrep -ax picom   # should show: picom --config /nix/store/...-picom.conf
+```
+
+## Gotchas learned the hard way
+
+- The module's default `vsync = false` is the #1 reason people still see
+  tearing — always set `vSync = true` (capital S).
+- These picom builds have **no default backend**; bare `picom` fails with
+  "Backend not specified". The service passes `--config`, so only the module's
+  invocation works.
+- `unredir-if-possible = true` lets fullscreen windows skip picom (direct
+  scanout), so adaptive sync/VRR still works and the app's own vsync handles
+  fullscreen. If you see fullscreen-only tearing, flip it to `false`.
+- If a browser/game still tears, check the WebGL context —
+  `desynchronized: true` bypasses the compositor and needs removing.

--- a/src/classic/state.ts
+++ b/src/classic/state.ts
@@ -148,7 +148,6 @@ const game: GameState = {
         this.canvas.addEventListener('mouseup', this.mouseUpHandler.bind(this), false);
 
         const gl = this.canvas.getContext('webgl', {
-            desynchronized: true,
             preserveDrawingBuffer: true,
         });
 


### PR DESCRIPTION
The `desynchronized: true` hint skips the browser compositor for lower latency, but presents without vblank sync, so the canvas tears on setups with no desktop compositor (bare X11 + i3). Removing it routes presentation through the normal compositor path for tear-free output on any platform.

(this patch was generated in some part by `opencode` using `deepseek-v4-flash-free` (`opencode`))