### PR TITLE
Add height-based 3d terrain rendering engine

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -32,14 +32,17 @@
                 "projectionMatrix",
                 "texSampler",
                 "tileIdFlat",
-                "tileSetSize"
+                "tileSetSize",
+                "useIsoDepth",
+                "isoDepth",
+                "ghostAlpha"
             ]
         },
         {
             "name": "isoTilemap",
             "vertex": "/shaders/iso_tilemap.vert",
             "fragment": "/shaders/iso_tilemap.frag",
-            "attr": ["vertexPos", "mapCoord"],
+            "attr": ["vertexPos", "mapCoord", "tileId"],
             "unif": [
                 "isoMatrix",
                 "modelMatrix",
@@ -54,7 +57,9 @@
                 "selectedTile",
                 "selectionBegin",
                 "selectionMode",
-                "selectionColor"
+                "selectionColor",
+                "wallColor",
+                "slopeDarken"
             ]
         }
     ],

--- a/public/state.json
+++ b/public/state.json
@@ -110,13 +110,13 @@
                 },
                 {
                     "type": "IsoAgent",
-                    "position": [14.019686629424593, 12, 0],
+                    "position": [95, 90, 0],
                     "scale": [1, 1, 1],
                     "texture": "humanoid",
                     "tilemap": "tilemap",
                     "frame": 333,
                     "tileSetSize": [32, 16],
-                    "anchor": [0, 0.98],
+                    "anchor": [0.5, 0.98],
                     "speed": 2.6,
                     "animSpeed": 1
                 }

--- a/src/classic/isometric.ts
+++ b/src/classic/isometric.ts
@@ -30,6 +30,12 @@ export class Tilemap extends Drawable {
     invScale: vec3;
     _isoToCartesian: mat4;
     _cartesianToIso: mat4;
+    heightData: number[];
+    heightScale: number;
+    _meshVertBuffer: WebGLBuffer | null = null;
+    _meshVertCount: number = 0;
+    _meshDirty: boolean = true;
+    _needsBufferResize: boolean = true;
 
     constructor(
         entity: IEntity,
@@ -65,6 +71,9 @@ export class Tilemap extends Drawable {
         this.maxTile = maxTile;
         this.dataUrl = dataUrl;
 
+        this.heightData = Array(sizeX * sizeY).fill(1);
+        this.heightScale = tilePixelSize[0];
+
         if (dataUrl != null) {
             this.data = [];
             this.loadMap(dataUrl);
@@ -75,6 +84,7 @@ export class Tilemap extends Drawable {
                     this.data[x + sizeX * y] = 0;
                 }
             }
+            this._meshDirty = true;
         }
 
         this.mouseIsoPos = vec3.fromValues(-1, -1, -1);
@@ -99,12 +109,43 @@ export class Tilemap extends Drawable {
         vec3.add(this.mouseIsoPos, this.mouseIsoPos, this.game.camera.getFix());
         vec3.div(this.mouseIsoPos, this.mouseIsoPos, this.game.camera.scale as vec3);
         this.cartesianToIso(this.mouseIsoPos);
+
+        const hd = this.heightData;
+        const sX = this.sizeX;
+        const sY = this.sizeY;
+        const at = (tx: number, ty: number) =>
+            hd[
+                Math.min(Math.max(Math.floor(tx), 0), sX - 1) +
+                    Math.min(Math.max(Math.floor(ty), 0), sY - 1) * sX
+            ] ?? 0;
+        const tileStep = (this.scale[0] as number) * 0.7071;
+
+        let isoX = this.mouseIsoPos[0];
+        let isoY = this.mouseIsoPos[1];
+
+        for (let i = 0; i < 3; i++) {
+            const ftx = Math.floor(isoX);
+            const fty = Math.floor(isoY);
+            const fx = isoX - ftx;
+            const fy = isoY - fty;
+            const hNW = at(ftx, fty);
+            const hNE = at(ftx + 1, fty);
+            const hSW = at(ftx, fty + 1);
+            const hSE = at(ftx + 1, fty + 1);
+            const h = hNW + (hNE - hNW) * fx + (hSW - hNW) * fy + (hNW - hNE - hSW + hSE) * fx * fy;
+            if (h <= 0) break;
+            const zOffset = (h * this.heightScale) / tileStep;
+            isoX = this.mouseIsoPos[0] - zOffset;
+            isoY = this.mouseIsoPos[1] + zOffset;
+        }
+
+        this.mouseIsoPos[0] = isoX;
+        this.mouseIsoPos[1] = isoY;
     }
 
     modelMatrix(): mat4 {
         const modelMatrix = mat4.create();
         mat4.translate(modelMatrix, modelMatrix, this.position);
-        mat4.scale(modelMatrix, modelMatrix, [...this.mapSize, 1] as vec3);
         return modelMatrix;
     }
 
@@ -126,8 +167,11 @@ export class Tilemap extends Drawable {
         fetch(url)
             .then((res) => res.text())
             .then((text) => {
-                this.data = JSON.parse(atob(text));
+                this.data = JSON.parse(atob(text.trim()));
                 this.uploadToGPU();
+            })
+            .catch((err) => {
+                console.error('[Tilemap] Failed to load map data:', err);
             });
     }
 
@@ -139,6 +183,7 @@ export class Tilemap extends Drawable {
         minObj.tilePixelSize = this.tilePixelSize;
         minObj.maxTile = this.maxTile;
         minObj.data = this.dataUrl;
+        minObj.heightScale = this.heightScale;
         return minObj;
     }
 
@@ -162,19 +207,13 @@ export class Tilemap extends Drawable {
         vec3.transformMat4(v as vec3, v as vec3, this._isoToCartesian);
     }
 
-    isoDistanceToCam(pos: vec3): number {
-        const camPos = vec3.clone(game.camera.position as vec3);
-        vec3.add(camPos, camPos, [0, -game.camera.size[1] / 2, 0]);
-        this.cartesianToIso(camPos);
-        return vec3.distance(camPos, pos);
-    }
-
     generateNoiseMap(): void {
         for (let y = 0; y < this.sizeY; y++) {
             for (let x = 0; x < this.sizeX; x++) {
                 this.data[x + this.sizeX * y] = Math.floor(getNoiseRange(x, y, 0, this.maxTile));
             }
         }
+        this._meshDirty = true;
     }
 
     getSelection(): [vec2, vec2] {
@@ -196,6 +235,7 @@ export class Tilemap extends Drawable {
                 this.data[x + this.sizeX * y] = value;
             }
         }
+        this._meshDirty = true;
     }
 
     uploadToGPU(): void {
@@ -230,89 +270,336 @@ export class Tilemap extends Drawable {
         this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
         this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
         this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+
+        this._meshDirty = true;
+    }
+
+    setHeight(x: number, y: number, value: number): void {
+        if (x < 0 || x >= this.sizeX || y < 0 || y >= this.sizeY) return;
+        this.heightData[x + this.sizeX * y] = value;
+        this._meshDirty = true;
+    }
+
+    buildMesh(): void {
+        const sX = this.sizeX;
+        const sY = this.sizeY;
+        const hs = this.heightScale;
+
+        const maxVerts = sX * sY * 180; // worst case: face + 4 walls = 30 vertices = 180 floats
+        const verts = new Float32Array(maxVerts);
+        let vi = 0;
+
+        const mx = new Float32Array(sX + 1);
+        const my = new Float32Array(sY + 1);
+        for (let i = 0; i <= sX; i++) mx[i] = i / sX;
+        for (let i = 0; i <= sY; i++) my[i] = i / sY;
+
+        for (let ty = 0; ty < sY; ty++) {
+            for (let tx = 0; tx < sX; tx++) {
+                const idx = tx + ty * sX;
+                const tid = this.data[idx];
+                const hThis = this.heightData[idx];
+
+                const hNW = hThis;
+                const hNE = tx + 1 < sX ? this.heightData[tx + 1 + ty * sX] : hThis;
+                const hSW = ty + 1 < sY ? this.heightData[tx + (ty + 1) * sX] : hThis;
+                const hSE =
+                    tx + 1 < sX && ty + 1 < sY ? this.heightData[tx + 1 + (ty + 1) * sX] : hThis;
+
+                const hasFace = tid !== 0 || hNW !== 0 || hNE !== 0 || hSW !== 0 || hSE !== 0;
+                if (!hasFace) continue;
+
+                const zNW = hNW * hs;
+                const zNE = hNE * hs;
+                const zSW = hSW * hs;
+                const zSE = hSE * hs;
+
+                const zMax = Math.max(zNW, zNE, zSW, zSE);
+                const zMin = Math.min(zNW, zNE, zSW, zSE);
+                const steepness = Math.min((zMax - zMin) / hs, 1.0);
+                const faceTileId = -steepness;
+
+                const mxNW = mx[tx];
+                const myNW = my[ty];
+                const mxNE = mx[tx + 1];
+                const myNE = my[ty];
+                const mxSW = mx[tx];
+                const mySW = my[ty + 1];
+                const mxSE = mx[tx + 1];
+                const mySE = my[ty + 1];
+
+                verts[vi++] = tx;
+                verts[vi++] = ty;
+                verts[vi++] = zNW;
+                verts[vi++] = mxNW;
+                verts[vi++] = myNW;
+                verts[vi++] = faceTileId;
+                verts[vi++] = tx + 1;
+                verts[vi++] = ty;
+                verts[vi++] = zNE;
+                verts[vi++] = mxNE;
+                verts[vi++] = myNE;
+                verts[vi++] = faceTileId;
+                verts[vi++] = tx;
+                verts[vi++] = ty + 1;
+                verts[vi++] = zSW;
+                verts[vi++] = mxSW;
+                verts[vi++] = mySW;
+                verts[vi++] = faceTileId;
+                verts[vi++] = tx + 1;
+                verts[vi++] = ty;
+                verts[vi++] = zNE;
+                verts[vi++] = mxNE;
+                verts[vi++] = myNE;
+                verts[vi++] = faceTileId;
+                verts[vi++] = tx + 1;
+                verts[vi++] = ty + 1;
+                verts[vi++] = zSE;
+                verts[vi++] = mxSE;
+                verts[vi++] = mySE;
+                verts[vi++] = faceTileId;
+                verts[vi++] = tx;
+                verts[vi++] = ty + 1;
+                verts[vi++] = zSW;
+                verts[vi++] = mxSW;
+                verts[vi++] = mySW;
+                verts[vi++] = faceTileId;
+
+                const wallTileId = tid || 1;
+
+                if (tx + 1 >= sX && hThis > 0) {
+                    const zTop = hThis * hs;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxNE;
+                    verts[vi++] = myNE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxNE;
+                    verts[vi++] = myNE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxSE;
+                    verts[vi++] = mySE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxNE;
+                    verts[vi++] = myNE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxSE;
+                    verts[vi++] = mySE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxSE;
+                    verts[vi++] = mySE;
+                    verts[vi++] = wallTileId;
+                }
+
+                if (ty + 1 >= sY && hThis > 0) {
+                    const zTop = hThis * hs;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxSW;
+                    verts[vi++] = mySW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxSW;
+                    verts[vi++] = mySW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxSE;
+                    verts[vi++] = mySE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxSW;
+                    verts[vi++] = mySW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxSE;
+                    verts[vi++] = mySE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxSE;
+                    verts[vi++] = mySE;
+                    verts[vi++] = wallTileId;
+                }
+
+                if (tx === 0 && hThis > 0) {
+                    const zTop = hThis * hs;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxSW;
+                    verts[vi++] = mySW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxSW;
+                    verts[vi++] = mySW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxNW;
+                    verts[vi++] = myNW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty + 1;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxSW;
+                    verts[vi++] = mySW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxNW;
+                    verts[vi++] = myNW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxNW;
+                    verts[vi++] = myNW;
+                    verts[vi++] = wallTileId;
+                }
+
+                if (ty === 0 && hThis > 0) {
+                    const zTop = hThis * hs;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxNE;
+                    verts[vi++] = myNE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxNE;
+                    verts[vi++] = myNE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxNW;
+                    verts[vi++] = myNW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx + 1;
+                    verts[vi++] = ty;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxNE;
+                    verts[vi++] = myNE;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty;
+                    verts[vi++] = zTop;
+                    verts[vi++] = mxNW;
+                    verts[vi++] = myNW;
+                    verts[vi++] = wallTileId;
+                    verts[vi++] = tx;
+                    verts[vi++] = ty;
+                    verts[vi++] = 0;
+                    verts[vi++] = mxNW;
+                    verts[vi++] = myNW;
+                    verts[vi++] = wallTileId;
+                }
+            }
+        }
+
+        const floatCount = vi;
+        this._meshVertCount = floatCount / 6;
+
+        if (this._meshVertBuffer == null || this._needsBufferResize) {
+            if (this._meshVertBuffer != null) this.gl.deleteBuffer(this._meshVertBuffer);
+            this._meshVertBuffer = this.gl.createBuffer();
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this._meshVertBuffer);
+            this.gl.bufferData(this.gl.ARRAY_BUFFER, maxVerts * 4, this.gl.DYNAMIC_DRAW);
+            this._needsBufferResize = false;
+        }
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this._meshVertBuffer);
+        this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, verts.subarray(0, floatCount));
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, null);
+        this._meshDirty = false;
     }
 
     rawDraw(): void {
-        // Verts
-        this.game.buffers.quad.verts.bind();
-        this.gl.vertexAttribPointer(
-            this.game.shaders.isoTilemap.attr.vertexPos,
-            3,
-            this.gl.FLOAT,
-            false,
-            0,
-            0,
-        );
-        this.gl.enableVertexAttribArray(this.game.shaders.isoTilemap.attr.vertexPos);
+        if (this._meshDirty) {
+            this.buildMesh();
+        }
 
-        // UVs
-        this.game.buffers.quad.uvs.bind();
-        this.gl.vertexAttribPointer(
-            this.game.shaders.isoTilemap.attr.mapCoord,
-            2,
-            this.gl.FLOAT,
-            false,
-            0,
-            0,
-        );
-        this.gl.enableVertexAttribArray(this.game.shaders.isoTilemap.attr.mapCoord);
+        if (this._meshVertBuffer == null || this._meshVertCount === 0) return;
+        if (this.mapDataTexture == null) return;
 
-        // Indices
-        this.game.buffers.quad.indices.bind();
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this._meshVertBuffer);
+        const stride = 6 * 4;
+        const shader = this.game.shaders.isoTilemap;
 
-        this.game.shaders.isoTilemap.bind();
+        this.gl.vertexAttribPointer(shader.attr.vertexPos, 3, this.gl.FLOAT, false, stride, 0);
+        this.gl.enableVertexAttribArray(shader.attr.vertexPos);
+
+        this.gl.vertexAttribPointer(shader.attr.mapCoord, 2, this.gl.FLOAT, false, stride, 12);
+        this.gl.enableVertexAttribArray(shader.attr.mapCoord);
+
+        this.gl.vertexAttribPointer(shader.attr.tileId, 1, this.gl.FLOAT, false, stride, 20);
+        this.gl.enableVertexAttribArray(shader.attr.tileId);
+
+        shader.bind();
 
         this.gl.activeTexture(this.gl.TEXTURE0);
         this.gl.bindTexture(this.gl.TEXTURE_2D, this.mapDataTexture);
 
         this.tileSet.bind(this.gl.TEXTURE1);
 
-        this.gl.uniform1i(this.game.shaders.isoTilemap.unif.mapData, 0);
-        this.gl.uniform1i(this.game.shaders.isoTilemap.unif.tileSet, 1);
+        this.gl.uniform1i(shader.unif.mapData, 0);
+        this.gl.uniform1i(shader.unif.tileSet, 1);
 
-        this.gl.uniformMatrix4fv(
-            this.game.shaders.isoTilemap.unif.projectionMatrix,
-            false,
-            this.game.projectionMatrix,
-        );
-        this.gl.uniformMatrix4fv(
-            this.game.shaders.isoTilemap.unif.cameraMatrix,
-            false,
-            this.game.camera.matrix(),
-        );
-        this.gl.uniformMatrix4fv(
-            this.game.shaders.isoTilemap.unif.modelMatrix,
-            false,
-            this.modelMatrix(),
-        );
-        this.gl.uniformMatrix4fv(
-            this.game.shaders.isoTilemap.unif.isoMatrix,
-            false,
-            this._isoToCartesian,
-        );
+        this.gl.uniformMatrix4fv(shader.unif.projectionMatrix, false, this.game.projectionMatrix);
+        this.gl.uniformMatrix4fv(shader.unif.cameraMatrix, false, this.game.camera.matrix());
+        this.gl.uniformMatrix4fv(shader.unif.modelMatrix, false, this.modelMatrix());
+        this.gl.uniformMatrix4fv(shader.unif.isoMatrix, false, this._isoToCartesian);
 
-        this.gl.uniform2fv(this.game.shaders.isoTilemap.unif.tileSetSize, this.tileSetSize);
-        this.gl.uniform2fv(this.game.shaders.isoTilemap.unif.tilePixelSize, this.tilePixelSize);
+        this.gl.uniform2fv(shader.unif.tileSetSize, this.tileSetSize);
+        this.gl.uniform2fv(shader.unif.tilePixelSize, this.tilePixelSize);
+        this.gl.uniform2fv(shader.unif.mapSize, this.mapSize);
 
-        this.gl.uniform2fv(this.game.shaders.isoTilemap.unif.mapSize, this.mapSize);
-
-        this.gl.uniform2fv(this.game.shaders.isoTilemap.unif.selectedTile, [
-            this.mouseIsoPos[0],
-            this.mouseIsoPos[1],
-        ]);
-
-        this.gl.uniform2fv(this.game.shaders.isoTilemap.unif.selectionBegin, [
+        this.gl.uniform2fv(shader.unif.selectedTile, [this.mouseIsoPos[0], this.mouseIsoPos[1]]);
+        this.gl.uniform2fv(shader.unif.selectionBegin, [
             this.selectionIsoBegin[0],
             this.selectionIsoBegin[1],
         ]);
+        this.gl.uniform1i(shader.unif.selectionMode, this.game.selectionMode);
+        this.gl.uniform4fv(shader.unif.selectionColor, this.game.selectionColor);
 
-        this.gl.uniform1i(this.game.shaders.isoTilemap.unif.selectionMode, this.game.selectionMode);
-        this.gl.uniform4fv(
-            this.game.shaders.isoTilemap.unif.selectionColor,
-            this.game.selectionColor,
-        );
+        this.gl.uniform4fv(shader.unif.wallColor, [0.3, 0.2, 0.15, 1.0]);
+        this.gl.uniform1f(shader.unif.slopeDarken, 0.4);
 
-        this.gl.drawElements(this.gl.TRIANGLES, 6, this.gl.UNSIGNED_SHORT, 0);
+        this.gl.enable(this.gl.DEPTH_TEST);
+        this.gl.drawArrays(this.gl.TRIANGLES, 0, this._meshVertCount);
+        this.gl.disable(this.gl.DEPTH_TEST);
     }
 }
 
@@ -399,6 +686,29 @@ export class IsometricNavMesh extends Tilemap {
         return minObj;
     }
 
+    syncHeights(): void {
+        const hd = this.map.heightData;
+        const sX = this.sizeX;
+        const sY = this.sizeY;
+        let changed = false;
+        for (let ty = 0; ty < sY; ty++) {
+            for (let tx = 0; tx < sX; tx++) {
+                const h = hd[tx + ty * sX];
+                let walkable = 1;
+                if (tx > 0 && Math.abs(h - hd[tx - 1 + ty * sX]) > 2) walkable = 0;
+                if (tx + 1 < sX && Math.abs(h - hd[tx + 1 + ty * sX]) > 2) walkable = 0;
+                if (ty > 0 && Math.abs(h - hd[tx + (ty - 1) * sX]) > 2) walkable = 0;
+                if (ty + 1 < sY && Math.abs(h - hd[tx + (ty + 1) * sX]) > 2) walkable = 0;
+                if (this.data[tx + ty * sX] !== walkable) changed = true;
+                this.data[tx + ty * sX] = walkable;
+            }
+        }
+        if (changed) {
+            this.uploadToGPU();
+            this.updateMap([0, 0], [sX, sY], this.data);
+        }
+    }
+
     sendMsg(op: string, args: unknown): Promise<unknown> {
         const msgId = this._msgId++;
         const msg = {
@@ -445,13 +755,32 @@ class IsometricDrawable extends Drawable {
         const cartPos = vec3.clone(this.position);
         this.tilemap.isoToCartesian(cartPos);
         vec3.add(cartPos, cartPos, this.tilemap.position);
+
+        const px = this.position[0];
+        const py = this.position[1];
+        const ftx = Math.floor(px);
+        const fty = Math.floor(py);
+        const fx = px - ftx;
+        const fy = py - fty;
+        const hd = this.tilemap.heightData;
+        const sX = this.tilemap.sizeX;
+        const sY = this.tilemap.sizeY;
+        const at = (tx: number, ty: number) =>
+            hd[Math.min(Math.max(tx, 0), sX - 1) + Math.min(Math.max(ty, 0), sY - 1) * sX] ?? 0;
+        const hNW = at(ftx, fty);
+        const hNE = at(ftx + 1, fty);
+        const hSW = at(ftx, fty + 1);
+        const hSE = at(ftx + 1, fty + 1);
+        const h = hNW + (hNE - hNW) * fx + (hSW - hNW) * fy + (hNW - hNE - hSW + hSE) * fx * fy;
+        cartPos[1] -= h * this.tilemap.heightScale;
+
         mat4.translate(modelMatrix, modelMatrix, cartPos);
         mat4.scale(modelMatrix, modelMatrix, this.scale);
         return modelMatrix;
     }
 
     order(): number {
-        return this.tilemap.order() - this.tilemap.isoDistanceToCam(this.position);
+        return this.position[0] - this.position[1] - this.tilemap.sizeX - this.tilemap.sizeY;
     }
 }
 
@@ -567,7 +896,30 @@ export class IsoSprite extends IsometricDrawable {
             this.tileSetSize as number[],
         );
 
+        this.gl.uniform1f(this.game.shaders.imageSheet.unif.useIsoDepth, 1.0);
+
+        const depth =
+            (this.position[0] - this.position[1]) / 400.0 +
+            0.5 -
+            this.position[2] / 14500.0 -
+            0.001;
+        this.gl.uniform1f(this.game.shaders.imageSheet.unif.isoDepth, depth);
+
+        this.gl.enable(this.gl.DEPTH_TEST);
+
+        // Ghost pass: visible through occluding terrain
+        this.gl.uniform1f(this.game.shaders.imageSheet.unif.ghostAlpha, 0.4);
+        this.gl.depthFunc(this.gl.ALWAYS);
+        this.gl.depthMask(false);
         this.gl.drawElements(this.gl.TRIANGLES, 6, this.gl.UNSIGNED_SHORT, 0);
+
+        // Normal pass: on top of terrain
+        this.gl.uniform1f(this.game.shaders.imageSheet.unif.ghostAlpha, 0.0);
+        this.gl.depthFunc(this.gl.LEQUAL);
+        this.gl.depthMask(true);
+        this.gl.drawElements(this.gl.TRIANGLES, 6, this.gl.UNSIGNED_SHORT, 0);
+
+        this.gl.disable(this.gl.DEPTH_TEST);
     }
 }
 
@@ -640,6 +992,8 @@ export class IsoAgent extends IsoSprite {
     }
 
     followPath(path: Vec2Like[]): void {
+        if (!path || path.length < 2) return;
+
         this._path = path;
 
         this._init_dist = vec2.distance(this.position as vec2, this._path[1] as vec2);
@@ -665,7 +1019,16 @@ export class IsoAgent extends IsoSprite {
                 break;
 
             case AgentStates.followPath:
-                this._delta += (this.speed * this.game.deltaTime) / this._init_dist;
+                if (
+                    this._target_index >= this._path.length ||
+                    this._start_index >= this._path.length ||
+                    !this._path[this._target_index] ||
+                    !this._path[this._start_index]
+                ) {
+                    this.idle();
+                    return;
+                }
+
                 if (this._delta >= 1) {
                     this.nextTarget();
                     this._delta = 0;
@@ -707,6 +1070,35 @@ export class IsoAgent extends IsoSprite {
                     [...this._path[this._target_index], this.position[2]] as vec3,
                     this._delta,
                 );
+
+                const px = this.position[0];
+                const py = this.position[1];
+                const tx = Math.floor(px);
+                const ty = Math.floor(py);
+                const fx = px - tx;
+                const fy = py - ty;
+                const sX = this.tilemap.sizeX;
+                const sY = this.tilemap.sizeY;
+                const hd = this.tilemap.heightData;
+                const cx = Math.min(tx, sX - 1);
+                const cy = Math.min(ty, sY - 1);
+                const cx1 = Math.min(tx + 1, sX - 1);
+                const cy1 = Math.min(ty + 1, sY - 1);
+                const hNW = hd[cx + cy * sX] ?? 0;
+                const hNE = hd[cx1 + cy * sX] ?? 0;
+                const hSW = hd[cx + cy1 * sX] ?? 0;
+                const hSE = hd[cx1 + cy1 * sX] ?? 0;
+                const hi =
+                    hNW + (hNE - hNW) * fx + (hSW - hNW) * fy + (hNW - hNE - hSW + hSE) * fx * fy;
+                const targetZ = hi * this.tilemap.heightScale;
+                const zSpeed = Math.min(1, this.game.deltaTime * 4);
+                this.position[2] += (targetZ - this.position[2]) * zSpeed;
+
+                const dx = (hNE - hNW) * (1 - fy) + (hSE - hSW) * fy;
+                const dy = (hSW - hNW) * (1 - fx) + (hSE - hNE) * fx;
+                const steepness = Math.sqrt(dx * dx + dy * dy);
+                const speedFactor = 1.0 - (Math.min(steepness, 3.0) / 3.0) * 0.5;
+                this._delta += (this.speed * speedFactor * this.game.deltaTime) / this._init_dist;
                 break;
         }
     }

--- a/src/classic/pathfinder.ts
+++ b/src/classic/pathfinder.ts
@@ -227,7 +227,7 @@ function aStarPath(mapName: string, from: Vec2, to: Vec2): Vec2[] | null {
 
     function reconstructPath(node: Vec2): Vec2[] {
         let current: Vec2 | false = node;
-        const path: Vec2[] = [];
+        const path: Vec2[] = [[node[0], node[1]]];
         do {
             current = cameFrom.get(current as Vec2);
             if (current !== false) {

--- a/src/classic/state.ts
+++ b/src/classic/state.ts
@@ -149,6 +149,7 @@ const game: GameState = {
 
         const gl = this.canvas.getContext('webgl', {
             preserveDrawingBuffer: true,
+            depth: true,
         });
 
         if (gl === null) {
@@ -156,6 +157,8 @@ const game: GameState = {
         }
 
         this.gl = gl;
+
+        gl.getExtension('OES_standard_derivatives');
 
         console.log(getVideoCardInfo(this.gl));
 
@@ -383,9 +386,10 @@ const game: GameState = {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.viewport(0, 0, this.canvas!.width, this.canvas!.height);
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
-        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         gl.enable(gl.BLEND);
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+        gl.depthFunc(gl.LEQUAL);
 
         this.renderList.length = 0;
         this.performCall('renderList');

--- a/src/classic/transforms.ts
+++ b/src/classic/transforms.ts
@@ -244,6 +244,9 @@ export class Sprite extends Drawable {
             this.game.shaders.imageSheet.unif.tileSetSize,
             this.tileSetSize as number[],
         );
+        this.gl.uniform1f(this.game.shaders.imageSheet.unif.useIsoDepth, 0.0);
+        this.gl.uniform1f(this.game.shaders.imageSheet.unif.isoDepth, 0.0);
+        this.gl.uniform1f(this.game.shaders.imageSheet.unif.ghostAlpha, 0.0);
 
         this.gl.drawElements(
             this.gl.TRIANGLES,

--- a/src/classic/types.ts
+++ b/src/classic/types.ts
@@ -218,6 +218,8 @@ export interface ITilemap extends IDrawable {
     sizeX: number;
     sizeY: number;
     tileScale: vec3 | number[];
+    heightData: number[];
+    heightScale: number;
     cartesianToIsoTile(pos: vec3 | number[]): vec3;
     isoTileToCartesian(pos: vec3 | number[]): vec3;
 }

--- a/src/demo/init.ts
+++ b/src/demo/init.ts
@@ -6,9 +6,14 @@ import {
     initTilemap,
     initTilemapEditorLogic,
     initNavMeshEditorLogic,
+    initHeightEditorLogic,
     initAgent,
+    generateDemoSlopes,
 } from './prefabs.js';
 import { initUI } from './uiPrefabs.js';
+
+import { isoToCartesian4 } from '/classic/utils.js';
+import { mat4, vec3 } from 'gl-matrix';
 
 async function initContext(): Promise<void> {
     window.game = game;
@@ -23,11 +28,19 @@ async function initContext(): Promise<void> {
     initTilemap();
     initTilemapEditorLogic();
     initNavMeshEditorLogic();
+    initHeightEditorLogic();
     initAgent();
+    generateDemoSlopes();
 
     initUI();
 
-    game.camera.position[0] += 800;
+    // Centre camera on demo slope area around tile (90, 85)
+    const isoToWorld = mat4.clone(isoToCartesian4);
+    mat4.scale(isoToWorld, isoToWorld, [45, 45, 1]);
+    const centre = vec3.fromValues(90, 85, 0);
+    vec3.transformMat4(centre, centre, isoToWorld);
+    game.camera.position[0] = centre[0];
+    game.camera.position[1] = centre[1];
 
     game.launch();
 }

--- a/src/demo/prefabs.ts
+++ b/src/demo/prefabs.ts
@@ -10,6 +10,11 @@ declare module '/classic/types.js' {
         editorTarget?: string;
         editorTile?: number;
         editorNavTile?: number;
+        editorHeight?: number;
+        heightScaleMultiplier?: number;
+        heightEditMode?: string;
+        agentEnabled?: boolean;
+        agentSelected?: boolean;
     }
 }
 
@@ -130,6 +135,92 @@ export function initNavMeshEditorLogic(): void {
     });
 }
 
+/**
+ * Registers the height-fill-on-selection handler.
+ * The height value widget (UISprite +/- buttons + label) lives in
+ * uiPrefabs.ts `initHeightWidget`.
+ */
+export function initHeightEditorLogic(): void {
+    const tilemap = game.getEntity('tilemap')!;
+    const compTilemap = tilemap.getComponent(Tilemap)!;
+    const compTilemapCollider = tilemap.getComponent(Collider)!;
+
+    compTilemapCollider.addHandler('selection', function () {
+        if (game.editorTarget !== 'height') return;
+        const [begin, end] = compTilemap.getSelection();
+
+        vec2.max(begin, begin, [0, 0]);
+        vec2.min(end, end, compTilemap.mapSize as vec2);
+
+        const val = game.editorHeight ?? 0;
+        const isSet = game.heightEditMode === 'set';
+
+        console.log(
+            '[height]',
+            isSet ? 'set' : 'blend',
+            [begin[0], begin[1]],
+            'to',
+            [end[0], end[1]],
+            'value',
+            val,
+        );
+
+        for (let y = begin[1]; y < end[1]; y++) {
+            for (let x = begin[0]; x < end[0]; x++) {
+                if (isSet) {
+                    compTilemap.setHeight(x, y, Math.max(0, val));
+                } else {
+                    const idx = x + compTilemap.sizeX * y;
+                    const cur = compTilemap.heightData[idx] ?? 0;
+                    compTilemap.setHeight(x, y, Math.max(0, cur + val));
+                }
+            }
+        }
+
+        game.getEntity('tilemapNavigation')?.getComponent(IsometricNavMesh)?.syncHeights();
+    });
+}
+
+/** Generates demo slope patterns in the centre of the tilemap to showcase height features. */
+export function generateDemoSlopes(): void {
+    const tm = game.getEntity('tilemap')?.getComponent(Tilemap);
+    if (!tm) return;
+
+    const cx = 80;
+    const cy = 80;
+
+    // Flat platform (height 3)
+    for (let y = cy; y < cy + 10; y++) for (let x = cx; x < cx + 10; x++) tm.setHeight(x, y, 3);
+
+    // Pyramid steps (1→5→1)
+    for (let y = cy - 5; y < cy + 15; y++) {
+        for (let x = cx + 12; x < cx + 22; x++) {
+            const dx = x - (cx + 17);
+            const dy = y - (cy + 5);
+            const dist = Math.max(Math.abs(dx), Math.abs(dy));
+            tm.setHeight(x, y, Math.max(0, 4 - dist));
+        }
+    }
+
+    // Ramp going SE
+    for (let i = 0; i < 12; i++) tm.setHeight(cx + 24 + i, cy + i, Math.floor(i / 3) + 1);
+
+    // Ramp going SW
+    for (let i = 0; i < 12; i++) tm.setHeight(cx + 24 + i, cy + 14 - i, Math.floor(i / 3) + 1);
+
+    // Valley (height 0 depression surrounded by height 2)
+    for (let y = cy + 20; y < cy + 30; y++)
+        for (let x = cx; x < cx + 10; x++) tm.setHeight(x, y, y === cy + 25 ? 0 : 3);
+
+    // Alternating plateau
+    for (let y = cy + 20; y < cy + 30; y++)
+        for (let x = cx + 12; x < cx + 22; x++) tm.setHeight(x, y, (x + y) % 2 === 0 ? 5 : 1);
+
+    console.log('[demo] slope terrain generated');
+
+    game.getEntity('tilemapNavigation')?.getComponent(IsometricNavMesh)?.syncHeights();
+}
+
 /** Click-to-pathfind IsoAgent: attaches collider + click handler on the tilemap. */
 export function initAgent(): void {
     const tilemap = game.getEntity('tilemap')!.getComponent(Tilemap)!;
@@ -172,14 +263,48 @@ export function initAgent(): void {
 
     const compTilemapCollider = tilemap.entity.getComponent(Collider)!;
 
+    game.agentEnabled = true;
+    game.agentSelected = false;
+
+    // Init agent height to terrain surface
+    const aTx = Math.floor(agent.position[0]);
+    const aTy = Math.floor(agent.position[1]);
+    const aIdx =
+        Math.min(aTx, tilemap.sizeX - 1) + Math.min(aTy, tilemap.sizeY - 1) * tilemap.sizeX;
+    agent.position[2] = (tilemap.heightData[aIdx] ?? 0) * tilemap.heightScale;
+
     compTilemapCollider.addHandler('click', function () {
-        const start: [number, number] = [agent.position[0], agent.position[1]];
-        const end: [number, number] = [tilemap.mouseIsoPos[0], tilemap.mouseIsoPos[1]];
+        if (!game.agentEnabled) return;
+
+        const clickX = tilemap.mouseIsoPos[0];
+        const clickY = tilemap.mouseIsoPos[1];
+        const agentX = agent.position[0];
+        const agentY = agent.position[1];
+
+        // Click very close to agent → toggle selection
+        if (Math.hypot(clickX - agentX, clickY - agentY) < 0.8) {
+            game.agentSelected = !(game.agentSelected ?? false);
+            return true;
+        }
+
+        // Click elsewhere → move agent if selected
+        if (!game.agentSelected) return;
+
+        const start: [number, number] = [agentX, agentY];
+        const end: [number, number] = [clickX, clickY];
 
         if (vec2.dist(start, end) > 2) {
             pathfinder.findPath(start, end).then((p) => {
                 if (p != null) agent.followPath(p as [number, number][]);
             });
+        }
+    });
+
+    // Selection ring and P-key toggle
+    navAgent.registerCall('update', function () {
+        if (game.wasKeyPressed('KeyP')) {
+            game.agentEnabled = !(game.agentEnabled ?? true);
+            console.log('[agent] movement', game.agentEnabled ? 'enabled' : 'disabled');
         }
     });
 }

--- a/src/demo/uiPrefabs.ts
+++ b/src/demo/uiPrefabs.ts
@@ -9,11 +9,16 @@ declare module '/classic/types.js' {
         editorTarget?: string;
         editorTile?: number;
         editorNavTile?: number;
+        editorHeight?: number;
+        heightScaleMultiplier?: number;
+        heightEditMode?: string;
+        agentSelected?: boolean;
     }
 }
 
 let _tilePalette: UIContainer | null = null;
 let _navPalette: UIContainer | null = null;
+let _heightWidget: UIContainer | null = null;
 let _uiScale = 1;
 
 /**
@@ -28,11 +33,15 @@ export function initUI(): void {
     game.editorTarget = 'none';
     game.editorTile = 0;
     game.editorNavTile = 0;
+    game.editorHeight = 0;
+    game.heightScaleMultiplier = 1;
+    game.heightEditMode = 'blend';
 
     initTopBar(UI);
     initToolButtons(UI);
     _tilePalette = initTilePalette(UI);
     _navPalette = initNavPalette(UI);
+    _heightWidget = initHeightWidget(UI);
     initEditorModeControl(UI);
 }
 
@@ -109,6 +118,13 @@ function initToolButtons(UI: UIManager): void {
     const tile = makeBtn('editorIcons', btnPixel, btnPixel, 1, [4, 4]);
     const nav = makeBtn('editorIcons', btnPixel, btnPixel, 2, [4, 4]);
 
+    // Height button: uses a coloured container + text label instead of
+    // editorIcons sprite because frame 3 of that spritesheet is blank.
+    const heightContainer = UI.spawnContainer(btnPixel, btnPixel, [0.2, 0.4, 0.8, 1]);
+    const heightLabel = UI.spawnText('H', 0.6 * _uiScale, 100, [1, 1, 1, 1], [0, 0, 0, 0]);
+    heightContainer.addChild(heightLabel, 'mid-center', 'mid-center');
+    const heightCollider = UI.addColliderToElem(heightContainer);
+
     let sineCounter = 0;
     let timeSinceClick = 10;
     let isOpen = false;
@@ -130,6 +146,23 @@ function initToolButtons(UI: UIManager): void {
         return true;
     });
 
+    heightCollider.addHandler('click', () => {
+        game.editorTarget = 'height';
+        return true;
+    });
+
+    // Agent selection indicator: small [A] button, always visible
+    const agentInd = Math.round(48 * _uiScale);
+    const agentBox = UI.spawnContainer(agentInd, agentInd, [0.1, 0.6, 0.1, 0.8]);
+    const agentTxt = UI.spawnText('A', 0.55 * _uiScale, 100, [1, 1, 1, 1], [0, 0, 0, 0]);
+    agentBox.addChild(agentTxt, 'mid-center', 'mid-center');
+    const agentCol = UI.addColliderToElem(agentBox);
+
+    agentCol.addHandler('click', () => {
+        game.agentSelected = !(game.agentSelected ?? true);
+        return true;
+    });
+
     UI.root.entity.registerCall('update', () => {
         const ch = game.canvas!.height;
         const wiggle = Math.sin(Math.PI * sineCounter) / wiggleFactor;
@@ -141,6 +174,7 @@ function initToolButtons(UI: UIManager): void {
         const closedX = btnPixel - slideDist - half;
         const tileY = ch - btnPixel * 3 - half;
         const navY = ch - btnPixel * 4 - half;
+        const heightY = ch - btnPixel * 5 - half;
 
         dev.container.setPosition(btnPixel - half, ch - btnPixel - half);
 
@@ -149,26 +183,39 @@ function initToolButtons(UI: UIManager): void {
 
         const tileCur = tile.container.position[0];
         const navCur = nav.container.position[0];
+        const heightCur = heightContainer.position[0];
         if (timeSinceClick <= 1) {
             tile.container.setPosition(tileCur + (targetX - tileCur) * t, tileY);
             nav.container.setPosition(navCur + (targetX - navCur) * t, navY);
+            heightContainer.setPosition(heightCur + (targetX - heightCur) * t, heightY);
         } else {
             tile.container.setPosition(targetX, tileY);
             nav.container.setPosition(targetX, navY);
+            heightContainer.setPosition(targetX, heightY);
         }
 
-        const applyHover = (sprite: UISprite, collider: Collider) => {
+        const applyHover = (sprite: UISprite | null, collider: Collider) => {
             if (game.physics!.gjk(collider, game.physics!.mouse)) {
-                const s = btnPixel + (wiggle + clickPulse) * btnPixel;
-                sprite.setSize(s, s);
+                if (sprite != null) {
+                    const s = btnPixel + (wiggle + clickPulse) * btnPixel;
+                    sprite.setSize(s, s);
+                }
             } else {
-                sprite.setSize(btnPixel, btnPixel);
+                if (sprite != null) {
+                    sprite.setSize(btnPixel, btnPixel);
+                }
             }
         };
 
         applyHover(dev.sprite, dev.collider);
         applyHover(tile.sprite, tile.collider);
         applyHover(nav.sprite, nav.collider);
+        applyHover(null, heightCollider);
+
+        // Agent indicator: bottom-left, below dev button
+        const selected = game.agentSelected ?? true;
+        agentBox.color = selected ? [0.1, 0.7, 0.1, 0.8] : [0.3, 0.3, 0.3, 0.6];
+        agentBox.setPosition(agentInd / 2, ch - btnPixel * 2 - agentInd / 2);
 
         sineCounter = (sineCounter + game.deltaTime) % 1;
         timeSinceClick += game.deltaTime * 3;
@@ -290,13 +337,130 @@ function initNavPalette(UI: UIManager): UIContainer {
     return container;
 }
 
-/** Toggles palette/nav-mesh visibility each frame based on game.editorTarget. */
+/** Height editing tool widget: value row + scale row + set/blend toggle. */
+function initHeightWidget(UI: UIManager): UIContainer {
+    const btnSize = Math.round(32 * _uiScale);
+    const labelW = Math.round(50 * _uiScale);
+    const gap = Math.round(4 * _uiScale);
+    const widgetW = btnSize * 2 + labelW + Math.round(12 * _uiScale);
+    const rowH = btnSize;
+    const widgetH = rowH * 3 + gap * 4;
+    const uiBorder = Math.round(10 * _uiScale);
+
+    function updateHeightScale(): void {
+        const tm = game.getEntity('tilemap')?.getComponent(Tilemap);
+        if (tm) {
+            tm.heightScale = tm.tilePixelSize[0] * (game.heightScaleMultiplier ?? 1);
+            tm._meshDirty = true;
+        }
+    }
+
+    const container = UI.spawnContainer(widgetW, widgetH, [0, 0, 0, 0.4]);
+
+    // Row 1: height delta value
+    const hMinus = UI.spawnContainer(btnSize, btnSize, [0.6, 0.1, 0.1, 1]);
+    const hMinusTxt = UI.spawnText('-', 0.6 * _uiScale, 100, [1, 1, 1, 1], [0, 0, 0, 0]);
+    hMinus.addChild(hMinusTxt, 'mid-center', 'mid-center');
+    container.addChild(hMinus, 'top-left', 'top-left');
+
+    const hLabel = UI.spawnText('0', 0.5 * _uiScale, 60, [1, 1, 1, 1], [0, 0, 0, 0]);
+    container.addChild(hLabel, 'top-left', 'top-left');
+
+    const hPlus = UI.spawnContainer(btnSize, btnSize, [0.1, 0.6, 0.1, 1]);
+    const hPlusTxt = UI.spawnText('+', 0.6 * _uiScale, 100, [1, 1, 1, 1], [0, 0, 0, 0]);
+    hPlus.addChild(hPlusTxt, 'mid-center', 'mid-center');
+    container.addChild(hPlus, 'top-left', 'top-left');
+
+    // Row 2: height scale multiplier
+    const sMinus = UI.spawnContainer(btnSize, btnSize, [0.1, 0.1, 0.6, 1]);
+    const sMinusTxt = UI.spawnText('s-', 0.45 * _uiScale, 100, [1, 1, 1, 1], [0, 0, 0, 0]);
+    sMinus.addChild(sMinusTxt, 'mid-center', 'mid-center');
+    container.addChild(sMinus, 'top-left', 'top-left');
+
+    const sLabel = UI.spawnText('x1', 0.45 * _uiScale, 60, [1, 1, 1, 1], [0, 0, 0, 0]);
+    container.addChild(sLabel, 'top-left', 'top-left');
+
+    const sPlus = UI.spawnContainer(btnSize, btnSize, [0.1, 0.1, 0.6, 1]);
+    const sPlusTxt = UI.spawnText('s+', 0.45 * _uiScale, 100, [1, 1, 1, 1], [0, 0, 0, 0]);
+    sPlus.addChild(sPlusTxt, 'mid-center', 'mid-center');
+    container.addChild(sPlus, 'top-left', 'top-left');
+
+    // Row 3: set / blend mode toggle
+    const modeBtn = UI.spawnContainer(widgetW, rowH, [0.2, 0.2, 0.2, 1]);
+    const modeTxt = UI.spawnText('blend', 0.4 * _uiScale, 100, [1, 1, 1, 1], [0, 0, 0, 0]);
+    modeBtn.addChild(modeTxt, 'mid-center', 'mid-center');
+    container.addChild(modeBtn, 'top-left', 'top-left');
+
+    // Colliders
+    const hMinusCol = UI.addColliderToElem(hMinus);
+    const hPlusCol = UI.addColliderToElem(hPlus);
+    const sMinusCol = UI.addColliderToElem(sMinus);
+    const sPlusCol = UI.addColliderToElem(sPlus);
+    const modeCol = UI.addColliderToElem(modeBtn);
+
+    hMinusCol.addHandler('click', () => {
+        game.editorHeight = (game.editorHeight ?? 0) - 1;
+        return true;
+    });
+    hPlusCol.addHandler('click', () => {
+        game.editorHeight = (game.editorHeight ?? 0) + 1;
+        return true;
+    });
+    sMinusCol.addHandler('click', () => {
+        game.heightScaleMultiplier = Math.max(1, (game.heightScaleMultiplier ?? 1) - 1);
+        updateHeightScale();
+        return true;
+    });
+    sPlusCol.addHandler('click', () => {
+        game.heightScaleMultiplier = (game.heightScaleMultiplier ?? 1) + 1;
+        updateHeightScale();
+        return true;
+    });
+    modeCol.addHandler('click', () => {
+        game.heightEditMode = game.heightEditMode === 'set' ? 'blend' : 'set';
+        return true;
+    });
+
+    // Manual positioning each frame
+    UI.root.entity.registerCall('update', () => {
+        const cw = game.canvas!.width;
+        const ch = game.canvas!.height;
+        const x0 = cw - uiBorder - widgetW;
+        const y0 = ch - uiBorder - widgetH;
+        const cx = gap;
+        const cy1 = gap;
+        const cy2 = rowH + gap * 2;
+        const cy3 = rowH * 2 + gap * 3;
+
+        container.setPosition(x0 + widgetW / 2, y0 + widgetH / 2);
+
+        hMinus.setPosition(x0 + cx, y0 + cy1);
+        hLabel.setPosition(x0 + cx + btnSize + gap, y0 + cy1);
+        hPlus.setPosition(x0 + cx + btnSize + gap + labelW, y0 + cy1);
+
+        sMinus.setPosition(x0 + cx, y0 + cy2);
+        sLabel.setPosition(x0 + cx + btnSize + gap, y0 + cy2);
+        sPlus.setPosition(x0 + cx + btnSize + gap + labelW, y0 + cy2);
+
+        modeBtn.setPosition(x0 + cx, y0 + cy3);
+
+        hLabel.setText((game.editorHeight ?? 0).toString());
+        sLabel.setText('x' + (game.heightScaleMultiplier ?? 1).toString());
+        modeTxt.setText(game.heightEditMode ?? 'blend');
+    });
+
+    container.setEnabled(false);
+    return container;
+}
+
+/** Toggles palette/nav-mesh/height-widget visibility each frame based on game.editorTarget. */
 function initEditorModeControl(UI: UIManager): void {
     const navMeshEntity = game.getEntity('tilemapNavigation')!;
 
     UI.root.entity.registerCall('update', () => {
         if (_tilePalette) _tilePalette.setEnabled(game.editorTarget === 'tilemap');
         if (_navPalette) _navPalette.setEnabled(game.editorTarget === 'navMesh');
+        if (_heightWidget) _heightWidget.setEnabled(game.editorTarget === 'height');
         navMeshEntity.enabled = game.editorTarget === 'navMesh';
     });
 }

--- a/src/shaders/direct_tex.vert
+++ b/src/shaders/direct_tex.vert
@@ -4,10 +4,15 @@ attribute vec2 texCoord;
 uniform mat4 modelMatrix;
 uniform mat4 cameraMatrix;
 uniform mat4 projectionMatrix;
+uniform float useIsoDepth;
+uniform float isoDepth;
 
 varying mediump vec2 vTexCoord;
 
 void main(void ) {
     gl_Position = projectionMatrix * cameraMatrix * modelMatrix * vertexPos;
+    if (useIsoDepth > 0.5) {
+        gl_Position.z = clamp(isoDepth, 0.0, 1.0);
+    }
     vTexCoord = texCoord;
 }

--- a/src/shaders/iso_tilemap.frag
+++ b/src/shaders/iso_tilemap.frag
@@ -1,6 +1,8 @@
 precision mediump float;
 
 varying mediump vec2 vMapCoord;
+varying mediump float vTileId;
+varying mediump float vIsoDepth;
 
 uniform sampler2D mapData;
 uniform vec2 mapSize;
@@ -13,6 +15,8 @@ uniform vec2 selectedTile;
 uniform vec2 selectionBegin;
 uniform vec4 selectionColor;
 uniform int selectionMode;
+uniform vec4 wallColor;
+uniform float slopeDarken;
 
 float getMapData(vec2 pos) {
     vec4 rawData = texture2D(mapData, pos);
@@ -57,10 +61,19 @@ vec4 getTilePixel(float tileIdFlat, vec2 mapCoord) {
 }
 
 void main(void ) {
-    vec2 mapCoord = vec2(vMapCoord.x, vMapCoord.y);
+    vec4 color;
 
-    gl_FragColor = getTilePixel(getMapData(mapCoord), mapCoord);
+    if (vTileId > 0.5) {
+        color = wallColor;
+    } else {
+        vec2 mapCoord = vec2(vMapCoord.x, vMapCoord.y);
+        color = getTilePixel(getMapData(mapCoord), mapCoord);
 
-    // gl_FragColor = vec4(1.0 / float(tileId), 0.0, 0.0, 1.0);
+        if (vTileId < -0.01) {
+            color.rgb *= 1.0 + vTileId * slopeDarken;
+        }
+    }
 
+    if (color.a < 0.01) discard;
+    gl_FragColor = color;
 }

--- a/src/shaders/iso_tilemap.vert
+++ b/src/shaders/iso_tilemap.vert
@@ -1,7 +1,8 @@
 precision mediump float;
 
-attribute vec4 vertexPos;
+attribute vec3 vertexPos;
 attribute vec2 mapCoord;
+attribute float tileId;
 
 uniform mat4 isoMatrix;
 uniform mat4 modelMatrix;
@@ -9,13 +10,22 @@ uniform mat4 cameraMatrix;
 uniform mat4 projectionMatrix;
 
 uniform vec2 mapSize;
-
 uniform vec2 tilePixelSize;
 
 varying mediump vec2 vMapCoord;
+varying mediump float vTileId;
 
 void main(void ) {
-    gl_Position = projectionMatrix * cameraMatrix * modelMatrix * isoMatrix * vertexPos;
-
+    vec4 worldPos = modelMatrix * isoMatrix * vec4(vertexPos, 1.0);
+    worldPos.y -= vertexPos.z;
+    vec4 clipPos = projectionMatrix * cameraMatrix * worldPos;
+    float isoDepth = clamp(
+        (vertexPos.x - vertexPos.y) / 400.0 + 0.5 - vertexPos.z / 14500.0,
+        0.0,
+        1.0
+    );
+    clipPos.z = isoDepth;
+    gl_Position = clipPos;
     vMapCoord = mapCoord;
+    vTileId = tileId;
 }

--- a/src/shaders/sheet.frag
+++ b/src/shaders/sheet.frag
@@ -6,6 +6,7 @@ uniform sampler2D texSampler;
 
 uniform vec2 tileSetSize;
 uniform float tileIdFlat;
+uniform float ghostAlpha;
 
 vec4 getTilePixel(float tileIdFlat, vec2 texCoord) {
     vec2 tileId = vec2(floor(mod(tileIdFlat, tileSetSize.x)), floor(tileIdFlat / tileSetSize.x));
@@ -19,5 +20,10 @@ vec4 getTilePixel(float tileIdFlat, vec2 texCoord) {
 }
 
 void main(void ) {
-    gl_FragColor = getTilePixel(tileIdFlat, vec2(vTexCoord.x, vTexCoord.y));
+    vec4 color = getTilePixel(tileIdFlat, vec2(vTexCoord.x, vTexCoord.y));
+    if (color.a < 0.01) discard;
+    if (ghostAlpha > 0.0) {
+        color.a = ghostAlpha;
+    }
+    gl_FragColor = color;
 }


### PR DESCRIPTION
<!-- pr-msg-meta
branch: height-engine
base: master
submitted:
  github: ___
-->

## Add height-based 3d terrain rendering engine

### Motivation

The current engine renders flat isometric tilemaps from a single GPU-driven
quad. There is no elevation, no slopes, no depth ordering between terrain and
sprites — everything uses a painter's-algorithm sort that cannot handle
height transitions. Adding 3d terrain requires a complete overhaul of mesh
generation, depth ordering, sprite occlusion, and coordinate transforms.

### Summary of changes

- Height-capable 3d mesh generation (`buildMesh()`) with continuous-surface
  corner interpolation (slopes), proportional slope darkening via fragment
  shader, and boundary wall faces. Performance: pre-sized `Float32Array`,
  `bufferSubData` + `DYNAMIC_DRAW`, pre-computed coordinate tables, dirty-flag
  rebuild.
- Iso-coordinate depth formula `(tx−ty)/400 + 0.5 − z/14500` governs occlusion
  across tilemap vertices and isometric sprites. `tx−ty` is the correct depth
  axis (SW=closest, NE=farthest); `tx+ty` was explored and discarded. Screen-Y
  mapping, polygon offset, and Z-bias approaches were also explored and
  discarded.
- Vertex shader Y-offset (`worldPos.y −= vertexPos.z`) for visual elevation,
  with `updateMousePos()` compensation using bilinear 3-pass fixed-point height
  read for accurate tile selection on slopes.
- Dual-pass ghost rendering for all isometric sprites: ghost pass (ALWAYS depth
  test, 40% alpha, no depth writes) renders a silhouette through occluding
  terrain; normal pass (LEQUAL depth test, full alpha) overdraws where the
  sprite should be visible. `sheet.frag` `ghostAlpha` uniform.
- Agent: bilinear height tracking in `update()`, smooth height lerp, speed
  penalty via bilinear surface gradient on slopes, `position[2]` initialized to
  terrain surface.
- `IsometricNavMesh.syncHeights()` marks tiles with > 2‑unit height difference
  as non-walkable; automatically called after height edits and demo terrain
  generation.
- Pathfinder: `reconstructPath` fix — the goal tile was never included in the
  returned path; agent always stopped 1 tile short.
- Depth buffer enabled per-drawable (not globally), `discard` on alpha < 0.01
  in `sheet.frag` to prevent transparent sprite backgrounds from polluting the
  depth buffer.

### Scopes changed

- `src/classic/isometric.ts`
  * `Tilemap`: `heightData[]`, `heightScale`, `setHeight()`, `buildMesh()`,
    `rawDraw()`, `modelMatrix()`, `updateMousePos()` height compensation,
    `order()` simplifications
  * `IsometricNavMesh`: `syncHeights()` height-based nav integration
  * `IsometricDrawable`: bilinear height in `modelMatrix()`, `order()` refactor
  * `IsoSprite`: dual-pass ghost rendering in `rawDraw()`
  * `IsoAgent`: bilinear height, smooth lerp, slope speed penalty
- `src/shaders/iso_tilemap.vert` — vec3 vertexPos, tileId attr, isoDepth formula
- `src/shaders/iso_tilemap.frag` — wall colour, slope darkening, agent transparency removed
- `src/shaders/direct_tex.vert` — useIsoDepth / isoDepth uniforms
- `src/shaders/sheet.frag` — alpha discard, ghostAlpha
- `src/classic/state.ts` — depth buffer (`depth: true`), per-drawable depth test
- `src/classic/types.ts` — height fields on ITilemap
- `src/classic/transforms.ts` — Sprite useIsoDepth=0
- `src/classic/pathfinder.ts` — reconstructPath goal tile fix
- `src/demo/init.ts` — camera centre fix, demo generation
- `src/demo/prefabs.ts` — height editor logic, agent controls, demo slopes
- `src/demo/uiPrefabs.ts` — height widget (3 rows), agent indicator, height dev button
- `public/manifest.json` — new shader attrs/uniforms
- `public/state.json` — agent starting position + anchor fix

### Future follow up

- [ ] Replace hardcoded `400` / `14500` depth denominators with map-size-derived
  uniforms for non‑200×200 maps.
- [ ] Wall texturing — fragment shader path exists (wall vertices carry tileId
  ≥ 1 ), needs UV lookup from sprite sheet for the wall face.
- [ ] Height-data persistence (`dump()` / `load()` serialization) — currently
  height edits are lost on page reload.

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
