### PR TITLE
Add tilemap directional lighting system

### DIFF
--- a/.claude/skills/isometric-tilemap/SKILL.md
+++ b/.claude/skills/isometric-tilemap/SKILL.md
@@ -14,7 +14,7 @@ compatibility: Requires WebGL context with depth buffer. Relies on gl-matrix,
     custom Vite shader plugin, and the ECS call-registry pattern.
 metadata:
     author: classic-wgl
-    version: '0.4'
+    version: '0.5'
 allowed-tools: Read, Grep, Glob, Bash(git *), Edit, Write
 ---
 
@@ -275,6 +275,19 @@ per‑pixel occlusion correctly.
 `slopeDarken` uniform defaults to `0.4` — a 1-height-unit cliff darkens by
 40%, a gentle 0.2-unit ramp by ~8%.
 
+**Lighting uniforms:** `ambientColor` (vec3), `lightDirection` (vec3, world‑space
+surface→light), `lightColor` (vec3). After colour sampling, the shader applies
+Lambert diffuse lighting:
+
+```glsl
+float diff = max(dot(normalize(vNormal), lightDirection), 0.0);
+color.rgb *= ambientColor + diff * lightColor;
+```
+
+This runs after wall/tile colour, slope darkening, and selection overlay — so
+all three rendering paths are lit. The `vNormal` varying comes from the vertex
+shader via the `normal` attribute and `normalMatrix` transform (see §16).
+
 ### direct_tex.vert — sprite vertex shader
 
 **Uniforms:** `useIsoDepth`, `isoDepth`
@@ -290,10 +303,10 @@ Shared by IsoSprite and Sprite. Does sprite-sheet frame lookup + alpha discard.
 
 ## 6. MESH GENERATION — buildMesh()
 
-### Vertex format (6 floats, interleaved)
+### Vertex format (9 floats, interleaved)
 
 ```
-[x, y, z, mx, my, tileId]
+[x, y, z, mx, my, tileId, nx, ny, nz]
 ```
 
 | Offset | Count | Content                              | Attribute   |
@@ -301,6 +314,7 @@ Shared by IsoSprite and Sprite. Does sprite-sheet frame lookup + alpha discard.
 | 0      | 3     | Map-space position (tx, ty, z)       | `vertexPos` |
 | 12     | 2     | Normalised map coords (tx/sX, ty/sY) | `mapCoord`  |
 | 20     | 1     | -steepness (top faces), ≥1 (walls)   | `tileId`    |
+| 24     | 3     | Face normal in map space             | `normal`    |
 
 ### Top face (floor/slope)
 
@@ -681,3 +695,155 @@ visible areas.
 - Same VAO, same texture, same uniforms — only `ghostAlpha` and
   `depthFunc`/`depthMask` change
 - No FBOs, no additional texture lookups, no terrain shader changes
+
+---
+
+## 16. LIGHTING SYSTEM
+
+### Overview
+
+The tilemap uses ambient + directional diffuse (Lambert) lighting.
+Per‑face flat‑shaded normals are computed during mesh construction and
+transformed through a `normalMatrix` uniform to account for the non‑uniform
+isometric scale. Light parameters are driven by selectable presets with
+adjustable azimuth/elevation.
+
+### Key files
+
+| File                           | Role                                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `src/classic/lighting.ts`      | Presets dict, `applyLightPreset()`, `updateLightDirection()`, `initLighting()`                                |
+| `src/shaders/iso_tilemap.vert` | `normal` attribute, `normalMatrix` uniform, `vNormal` varying                                                 |
+| `src/shaders/iso_tilemap.frag` | `ambientColor` / `lightDirection` / `lightColor` uniforms, diffuse calc                                       |
+| `src/classic/isometric.ts`     | Per‑face normal computation in `buildMesh()`, `normalMatrix` in `setScale()`, uniform plumbing in `rawDraw()` |
+| `public/manifest.json`         | `normal` attr + `normalMatrix`/`ambientColor`/`lightDirection`/`lightColor` unifs                             |
+| `src/demo/uiPrefabs.ts`        | Light config widget (preset cycle + azimuth/elevation ± buttons)                                              |
+
+### Normal computation in `buildMesh()`
+
+Normals are computed **per triangle** and stored in map space (same coordinate
+frame as vertex positions, pre‑isoMatrix). All three vertices of a triangle
+share the same normal (flat shading).
+
+**Top face, triangle 1 (NW → NE → SW):**
+
+```
+edge1 = (1, 0, zNE − zNW)
+edge2 = (0, 1, zSW − zNW)
+n = normalize(cross(edge1, edge2)) = normalize((zNW−zNE, zNW−zSW, 1))
+```
+
+**Top face, triangle 2 (NE → SE → SW):**
+
+```
+edge1 = (0, 1, zSE − zNE)
+edge2 = (−1, 1, zSW − zNE)
+n = normalize(cross(edge1, edge2)) = normalize((zSW−zSE, zNE−zSE, 1))
+```
+
+**Wall normals** are axis‑aligned unit vectors in map space:
+
+| Wall boundary | Condition   | Map‑space normal |
+| ------------- | ----------- | ---------------- |
+| East          | `tx+1 ≥ sX` | `(−1, 0, 0)`     |
+| South         | `ty+1 ≥ sY` | `(0, 1, 0)`      |
+| West          | `tx = 0`    | `(1, 0, 0)`      |
+| North         | `ty = 0`    | `(0, −1, 0)`     |
+
+The `pushVert()` helper writes the same `(nx, ny, nz)` for all three
+vertices of each triangle. `writeTriNormal()` computes the normal from
+two edge vectors using the standard cross‑product formula.
+
+### `normalMatrix` uniform
+
+The `isoMatrix` applies a non‑uniform scale (from `isoToCartesian4`:
+`scale(1, 0.5, 1)` in XY). Normals must be transformed by the
+**inverse‑transpose** of the model‑view matrix's upper‑left 3×3:
+
+```typescript
+// In setScale():
+const iso3 = mat3.create();
+mat3.fromMat4(iso3, this._isoToCartesian);
+const invIso3 = mat3.create();
+mat3.invert(invIso3, iso3);
+mat3.transpose(this._normalMatrix, invIso3);
+```
+
+In the vertex shader:
+
+```glsl
+vNormal = normalize(normalMatrix * normal);
+```
+
+The normal matrix is static — it only changes when the tilemap scale changes
+(via `setScale()`), which dirties the mesh and triggers a rebuild.
+
+### `rawDraw()` uniform plumbing
+
+```typescript
+// New attribute pointer (normal at byte offset 24, 3 floats):
+this.gl.vertexAttribPointer(shader.attr.normal, 3, this.gl.FLOAT, false, stride, 24);
+this.gl.enableVertexAttribArray(shader.attr.normal);
+
+// New uniforms:
+this.gl.uniformMatrix3fv(shader.unif.normalMatrix, false, this._normalMatrix);
+this.gl.uniform3fv(shader.unif.ambientColor, game.lightAmbient ?? [0.2, 0.2, 0.25]);
+this.gl.uniform3fv(shader.unif.lightDirection, game.lightDir ?? [0.45, -0.35, 0.82]);
+this.gl.uniform3fv(shader.unif.lightColor, game.lightColor ?? [0.8, 0.75, 0.65]);
+```
+
+### Light presets
+
+Defined in `src/classic/lighting.ts`:
+
+```
+LIGHT_PRESETS = {
+    sunny:  ambient:[0.15,0.15,0.20] direction:norm([0.453,0.211,0.866]) color:[1.0,0.95,0.85]
+    cloudy: ambient:[0.35,0.35,0.40] direction:norm([0.0,-0.2,1.0]) color:[0.70,0.72,0.78]
+    dawn:   ambient:[0.20,0.15,0.25] direction:norm([0.5, 0.2,0.3]) color:[1.0,0.40,0.20]
+    night:  ambient:[0.10,0.12,0.25] direction:norm([-0.2,-0.5,0.8]) color:[0.30,0.40,0.70]
+}
+```
+
+`applyLightPreset(key)` copies a preset into `game.lightAmbient`,
+`game.lightDir`, and `game.lightColor`, and derives `game.lightAzimuth`
+and `game.lightElevation` from the direction vector.
+
+### Direction ↔ azimuth/elevation
+
+The light direction is stored as a world‑space unit vector (`surface → light`).
+It's convertible to/from azimuth/elevation for UI display:
+
+```
+azimuth   = atan2(d[0], −d[1]) × 180/π   (0° = South of iso map)
+elevation = asin(d[2]) × 180/π           (0° = horizon, 90° = zenith)
+
+lightDir.x = cos(el) × sin(az)
+lightDir.y = −cos(el) × cos(az)   (negated because world Y goes down)
+lightDir.z = sin(el)
+```
+
+When the user tweaks azimuth or elevation via the light config widget,
+`updateLightDirection()` recomputes the direction vector and stores it
+in `game.lightDir`. The preset changes to `'custom'` to indicate deviation
+from a named preset.
+
+### Slope darkening removed
+
+The manual slope‑darkening pass (`color.rgb *= 1.0 + vTileId * slopeDarken`)
+was removed from the fragment shader. The lighting system now provides the
+sole slope contrast: steeper faces have angled normals that reduce the
+`dot(N, L)` term, naturally darkening them relative to flat terrain. No
+separate darkening uniform or math is needed.
+
+### Shader apply order
+
+```
+1. Sample tile colour (getTilePixel)
+2. Apply selection overlay (if active)
+3. Alpha discard (if near‑zero)
+4. Apply lighting: color.rgb *= ambientColor + dot(N, L) * lightColor
+```
+
+Lighting runs after selection so the selection overlay (an editor tool)
+retains its visual intensity regardless of light settings.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -42,12 +42,13 @@
             "name": "isoTilemap",
             "vertex": "/shaders/iso_tilemap.vert",
             "fragment": "/shaders/iso_tilemap.frag",
-            "attr": ["vertexPos", "mapCoord", "tileId"],
+            "attr": ["vertexPos", "mapCoord", "tileId", "normal"],
             "unif": [
                 "isoMatrix",
                 "modelMatrix",
                 "cameraMatrix",
                 "projectionMatrix",
+                "normalMatrix",
                 "mapData",
                 "mapSize",
                 "mapTileSize",
@@ -59,7 +60,9 @@
                 "selectionMode",
                 "selectionColor",
                 "wallColor",
-                "slopeDarken"
+                "ambientColor",
+                "lightDirection",
+                "lightColor"
             ]
         }
     ],

--- a/src/classic/isometric.ts
+++ b/src/classic/isometric.ts
@@ -7,7 +7,7 @@ import { Animator } from '/classic/animator.js';
 import { registerComponent } from '/classic/registry.js';
 import type { IEntity, ITexture, ComponentData, IAnimation } from './types.js';
 
-import { mat4, vec2, vec3 } from 'gl-matrix';
+import { mat4, mat3, vec2, vec3 } from 'gl-matrix';
 
 type Vec3Like = vec3 | [number, number, number] | number[];
 type Vec2Like = vec2 | [number, number] | number[];
@@ -36,6 +36,7 @@ export class Tilemap extends Drawable {
     _meshVertCount: number = 0;
     _meshDirty: boolean = true;
     _needsBufferResize: boolean = true;
+    _normalMatrix = mat3.create();
 
     constructor(
         entity: IEntity,
@@ -197,6 +198,12 @@ export class Tilemap extends Drawable {
 
         this._cartesianToIso = mat4.clone(cartesianToIso4);
         mat4.scale(this._cartesianToIso, this._cartesianToIso, this.invScale);
+
+        const iso3 = mat3.create();
+        mat3.fromMat4(iso3, this._isoToCartesian);
+        const invIso3 = mat3.create();
+        mat3.invert(invIso3, iso3);
+        mat3.transpose(this._normalMatrix, invIso3);
     }
 
     cartesianToIso(v: vec3): void {
@@ -285,7 +292,8 @@ export class Tilemap extends Drawable {
         const sY = this.sizeY;
         const hs = this.heightScale;
 
-        const maxVerts = sX * sY * 180; // worst case: face + 4 walls = 30 vertices = 180 floats
+        const VERT_FLOATS = 9;
+        const maxVerts = sX * sY * 270; // worst case: face + 4 walls = 30 vertices × 9 floats
         const verts = new Float32Array(maxVerts);
         let vi = 0;
 
@@ -293,6 +301,43 @@ export class Tilemap extends Drawable {
         const my = new Float32Array(sY + 1);
         for (let i = 0; i <= sX; i++) mx[i] = i / sX;
         for (let i = 0; i <= sY; i++) my[i] = i / sY;
+
+        function pushVert(
+            x: number,
+            y: number,
+            z: number,
+            mxv: number,
+            myv: number,
+            tid: number,
+            nx: number,
+            ny: number,
+            nz: number,
+        ): void {
+            verts[vi++] = x;
+            verts[vi++] = y;
+            verts[vi++] = z;
+            verts[vi++] = mxv;
+            verts[vi++] = myv;
+            verts[vi++] = tid;
+            verts[vi++] = nx;
+            verts[vi++] = ny;
+            verts[vi++] = nz;
+        }
+
+        function writeTriNormal(
+            dx1: number,
+            dy1: number,
+            dz1: number,
+            dx2: number,
+            dy2: number,
+            dz2: number,
+        ): [number, number, number] {
+            const nx = dy1 * dz2 - dz1 * dy2;
+            const ny = dz1 * dx2 - dx1 * dz2;
+            const nz = dx1 * dy2 - dy1 * dx2;
+            const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+            return [nx / len, ny / len, nz / len];
+        }
 
         for (let ty = 0; ty < sY; ty++) {
             for (let tx = 0; tx < sX; tx++) {
@@ -328,209 +373,64 @@ export class Tilemap extends Drawable {
                 const mxSE = mx[tx + 1];
                 const mySE = my[ty + 1];
 
-                verts[vi++] = tx;
-                verts[vi++] = ty;
-                verts[vi++] = zNW;
-                verts[vi++] = mxNW;
-                verts[vi++] = myNW;
-                verts[vi++] = faceTileId;
-                verts[vi++] = tx + 1;
-                verts[vi++] = ty;
-                verts[vi++] = zNE;
-                verts[vi++] = mxNE;
-                verts[vi++] = myNE;
-                verts[vi++] = faceTileId;
-                verts[vi++] = tx;
-                verts[vi++] = ty + 1;
-                verts[vi++] = zSW;
-                verts[vi++] = mxSW;
-                verts[vi++] = mySW;
-                verts[vi++] = faceTileId;
-                verts[vi++] = tx + 1;
-                verts[vi++] = ty;
-                verts[vi++] = zNE;
-                verts[vi++] = mxNE;
-                verts[vi++] = myNE;
-                verts[vi++] = faceTileId;
-                verts[vi++] = tx + 1;
-                verts[vi++] = ty + 1;
-                verts[vi++] = zSE;
-                verts[vi++] = mxSE;
-                verts[vi++] = mySE;
-                verts[vi++] = faceTileId;
-                verts[vi++] = tx;
-                verts[vi++] = ty + 1;
-                verts[vi++] = zSW;
-                verts[vi++] = mxSW;
-                verts[vi++] = mySW;
-                verts[vi++] = faceTileId;
+                // Top face triangle 1: NW -> NE -> SW
+                let tn = writeTriNormal(1, 0, zNE - zNW, 0, 1, zSW - zNW);
+                pushVert(tx, ty, zNW, mxNW, myNW, faceTileId, tn[0], tn[1], tn[2]);
+                pushVert(tx + 1, ty, zNE, mxNE, myNE, faceTileId, tn[0], tn[1], tn[2]);
+                pushVert(tx, ty + 1, zSW, mxSW, mySW, faceTileId, tn[0], tn[1], tn[2]);
+
+                // Top face triangle 2: NE -> SE -> SW
+                tn = writeTriNormal(0, 1, zSE - zNE, -1, 1, zSW - zNE);
+                pushVert(tx + 1, ty, zNE, mxNE, myNE, faceTileId, tn[0], tn[1], tn[2]);
+                pushVert(tx + 1, ty + 1, zSE, mxSE, mySE, faceTileId, tn[0], tn[1], tn[2]);
+                pushVert(tx, ty + 1, zSW, mxSW, mySW, faceTileId, tn[0], tn[1], tn[2]);
 
                 const wallTileId = tid || 1;
 
                 if (tx + 1 >= sX && hThis > 0) {
                     const zTop = hThis * hs;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxNE;
-                    verts[vi++] = myNE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxNE;
-                    verts[vi++] = myNE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxSE;
-                    verts[vi++] = mySE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxNE;
-                    verts[vi++] = myNE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxSE;
-                    verts[vi++] = mySE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxSE;
-                    verts[vi++] = mySE;
-                    verts[vi++] = wallTileId;
+                    pushVert(tx + 1, ty, 0, mxNE, myNE, wallTileId, -1, 0, 0);
+                    pushVert(tx + 1, ty, zTop, mxNE, myNE, wallTileId, -1, 0, 0);
+                    pushVert(tx + 1, ty + 1, 0, mxSE, mySE, wallTileId, -1, 0, 0);
+                    pushVert(tx + 1, ty, zTop, mxNE, myNE, wallTileId, -1, 0, 0);
+                    pushVert(tx + 1, ty + 1, zTop, mxSE, mySE, wallTileId, -1, 0, 0);
+                    pushVert(tx + 1, ty + 1, 0, mxSE, mySE, wallTileId, -1, 0, 0);
                 }
 
                 if (ty + 1 >= sY && hThis > 0) {
                     const zTop = hThis * hs;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxSW;
-                    verts[vi++] = mySW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxSW;
-                    verts[vi++] = mySW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxSE;
-                    verts[vi++] = mySE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxSW;
-                    verts[vi++] = mySW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxSE;
-                    verts[vi++] = mySE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxSE;
-                    verts[vi++] = mySE;
-                    verts[vi++] = wallTileId;
+                    pushVert(tx, ty + 1, 0, mxSW, mySW, wallTileId, 0, 1, 0);
+                    pushVert(tx, ty + 1, zTop, mxSW, mySW, wallTileId, 0, 1, 0);
+                    pushVert(tx + 1, ty + 1, 0, mxSE, mySE, wallTileId, 0, 1, 0);
+                    pushVert(tx, ty + 1, zTop, mxSW, mySW, wallTileId, 0, 1, 0);
+                    pushVert(tx + 1, ty + 1, zTop, mxSE, mySE, wallTileId, 0, 1, 0);
+                    pushVert(tx + 1, ty + 1, 0, mxSE, mySE, wallTileId, 0, 1, 0);
                 }
 
                 if (tx === 0 && hThis > 0) {
                     const zTop = hThis * hs;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxSW;
-                    verts[vi++] = mySW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxSW;
-                    verts[vi++] = mySW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxNW;
-                    verts[vi++] = myNW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty + 1;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxSW;
-                    verts[vi++] = mySW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxNW;
-                    verts[vi++] = myNW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxNW;
-                    verts[vi++] = myNW;
-                    verts[vi++] = wallTileId;
+                    pushVert(tx, ty + 1, 0, mxSW, mySW, wallTileId, 1, 0, 0);
+                    pushVert(tx, ty + 1, zTop, mxSW, mySW, wallTileId, 1, 0, 0);
+                    pushVert(tx, ty, 0, mxNW, myNW, wallTileId, 1, 0, 0);
+                    pushVert(tx, ty + 1, zTop, mxSW, mySW, wallTileId, 1, 0, 0);
+                    pushVert(tx, ty, zTop, mxNW, myNW, wallTileId, 1, 0, 0);
+                    pushVert(tx, ty, 0, mxNW, myNW, wallTileId, 1, 0, 0);
                 }
 
                 if (ty === 0 && hThis > 0) {
                     const zTop = hThis * hs;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxNE;
-                    verts[vi++] = myNE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxNE;
-                    verts[vi++] = myNE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxNW;
-                    verts[vi++] = myNW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx + 1;
-                    verts[vi++] = ty;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxNE;
-                    verts[vi++] = myNE;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty;
-                    verts[vi++] = zTop;
-                    verts[vi++] = mxNW;
-                    verts[vi++] = myNW;
-                    verts[vi++] = wallTileId;
-                    verts[vi++] = tx;
-                    verts[vi++] = ty;
-                    verts[vi++] = 0;
-                    verts[vi++] = mxNW;
-                    verts[vi++] = myNW;
-                    verts[vi++] = wallTileId;
+                    pushVert(tx + 1, ty, 0, mxNE, myNE, wallTileId, 0, -1, 0);
+                    pushVert(tx + 1, ty, zTop, mxNE, myNE, wallTileId, 0, -1, 0);
+                    pushVert(tx, ty, 0, mxNW, myNW, wallTileId, 0, -1, 0);
+                    pushVert(tx + 1, ty, zTop, mxNE, myNE, wallTileId, 0, -1, 0);
+                    pushVert(tx, ty, zTop, mxNW, myNW, wallTileId, 0, -1, 0);
+                    pushVert(tx, ty, 0, mxNW, myNW, wallTileId, 0, -1, 0);
                 }
             }
         }
 
         const floatCount = vi;
-        this._meshVertCount = floatCount / 6;
+        this._meshVertCount = floatCount / VERT_FLOATS;
 
         if (this._meshVertBuffer == null || this._needsBufferResize) {
             if (this._meshVertBuffer != null) this.gl.deleteBuffer(this._meshVertBuffer);
@@ -555,7 +455,7 @@ export class Tilemap extends Drawable {
         if (this.mapDataTexture == null) return;
 
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this._meshVertBuffer);
-        const stride = 6 * 4;
+        const stride = 9 * 4;
         const shader = this.game.shaders.isoTilemap;
 
         this.gl.vertexAttribPointer(shader.attr.vertexPos, 3, this.gl.FLOAT, false, stride, 0);
@@ -566,6 +466,9 @@ export class Tilemap extends Drawable {
 
         this.gl.vertexAttribPointer(shader.attr.tileId, 1, this.gl.FLOAT, false, stride, 20);
         this.gl.enableVertexAttribArray(shader.attr.tileId);
+
+        this.gl.vertexAttribPointer(shader.attr.normal, 3, this.gl.FLOAT, false, stride, 24);
+        this.gl.enableVertexAttribArray(shader.attr.normal);
 
         shader.bind();
 
@@ -595,7 +498,11 @@ export class Tilemap extends Drawable {
         this.gl.uniform4fv(shader.unif.selectionColor, this.game.selectionColor);
 
         this.gl.uniform4fv(shader.unif.wallColor, [0.3, 0.2, 0.15, 1.0]);
-        this.gl.uniform1f(shader.unif.slopeDarken, 0.4);
+
+        this.gl.uniformMatrix3fv(shader.unif.normalMatrix, false, this._normalMatrix);
+        this.gl.uniform3fv(shader.unif.ambientColor, game.lightAmbient ?? [0.2, 0.2, 0.25]);
+        this.gl.uniform3fv(shader.unif.lightDirection, game.lightDir ?? [0.45, -0.35, 0.82]);
+        this.gl.uniform3fv(shader.unif.lightColor, game.lightColor ?? [0.8, 0.75, 0.65]);
 
         this.gl.enable(this.gl.DEPTH_TEST);
         this.gl.drawArrays(this.gl.TRIANGLES, 0, this._meshVertCount);
@@ -609,6 +516,7 @@ export class IsometricNavMesh extends Tilemap {
     _resolves: Record<number, (value: unknown) => void>;
     _rejects: Record<number, (reason?: unknown) => void>;
     _worker: Worker;
+    _navReady: boolean = false;
 
     constructor(
         entity: IEntity,
@@ -656,6 +564,8 @@ export class IsometricNavMesh extends Tilemap {
                     data: this.data,
                 }).then((ret) => {
                     console.assert(ret === 'ok', 'Isometric Nav Mesh initialization error');
+                    this._navReady = true;
+                    this.syncHeights();
                 });
             });
     }
@@ -705,7 +615,9 @@ export class IsometricNavMesh extends Tilemap {
         }
         if (changed) {
             this.uploadToGPU();
-            this.updateMap([0, 0], [sX, sY], this.data);
+            if (this._navReady) {
+                this.updateMap([0, 0], [sX, sY], this.data);
+            }
         }
     }
 

--- a/src/classic/lighting.ts
+++ b/src/classic/lighting.ts
@@ -1,0 +1,76 @@
+import game from '/classic/state.js';
+import { vec3 } from 'gl-matrix';
+
+interface ILightPreset {
+    name: string;
+    ambient: [number, number, number];
+    direction: [number, number, number];
+    color: [number, number, number];
+}
+
+function norm(x: number, y: number, z: number): [number, number, number] {
+    const v = vec3.fromValues(x, y, z);
+    vec3.normalize(v, v);
+    return [v[0], v[1], v[2]];
+}
+
+const LIGHT_PRESETS: Record<string, ILightPreset> = {
+    sunny: {
+        name: 'Sunny Day',
+        ambient: [0.15, 0.15, 0.2],
+        direction: norm(0.453, 0.211, 0.866),
+        color: [1.0, 0.95, 0.85],
+    },
+    cloudy: {
+        name: 'Cloudy',
+        ambient: [0.35, 0.35, 0.4],
+        direction: norm(0.0, -0.2, 1.0),
+        color: [0.7, 0.72, 0.78],
+    },
+    dawn: {
+        name: 'Dawn / Dusk',
+        ambient: [0.2, 0.15, 0.25],
+        direction: norm(0.5, 0.2, 0.3),
+        color: [1.0, 0.4, 0.2],
+    },
+    night: {
+        name: 'Night',
+        ambient: [0.1, 0.12, 0.25],
+        direction: norm(-0.2, -0.5, 0.8),
+        color: [0.3, 0.4, 0.7],
+    },
+};
+
+export const PRESET_ORDER: string[] = ['sunny', 'cloudy', 'dawn', 'night'];
+
+export function applyLightPreset(key: string): void {
+    const preset = LIGHT_PRESETS[key];
+    if (!preset) return;
+
+    game.lightPreset = key;
+    game.lightAmbient = [...preset.ambient] as [number, number, number];
+    game.lightDir = [...preset.direction] as [number, number, number];
+    game.lightColor = [...preset.color] as [number, number, number];
+
+    const d = game.lightDir;
+    game.lightAzimuth = (Math.atan2(d[0], -d[1]) * 180) / Math.PI;
+    game.lightElevation = (Math.asin(d[2]) * 180) / Math.PI;
+}
+
+export function updateLightDirection(): void {
+    const az = ((game.lightAzimuth ?? 0) * Math.PI) / 180;
+    const el = ((game.lightElevation ?? 45) * Math.PI) / 180;
+    const v = vec3.fromValues(
+        Math.cos(el) * Math.sin(az),
+        -Math.cos(el) * Math.cos(az),
+        Math.sin(el),
+    );
+    vec3.normalize(v, v);
+    game.lightDir = [v[0], v[1], v[2]];
+}
+
+export function initLighting(): void {
+    applyLightPreset('sunny');
+}
+
+export { LIGHT_PRESETS };

--- a/src/demo/init.ts
+++ b/src/demo/init.ts
@@ -11,6 +11,7 @@ import {
     generateDemoSlopes,
 } from './prefabs.js';
 import { initUI } from './uiPrefabs.js';
+import { initLighting } from '/classic/lighting.js';
 
 import { isoToCartesian4 } from '/classic/utils.js';
 import { mat4, vec3 } from 'gl-matrix';
@@ -33,6 +34,7 @@ async function initContext(): Promise<void> {
     generateDemoSlopes();
 
     initUI();
+    initLighting();
 
     // Centre camera on demo slope area around tile (90, 85)
     const isoToWorld = mat4.clone(isoToCartesian4);

--- a/src/demo/prefabs.ts
+++ b/src/demo/prefabs.ts
@@ -15,6 +15,12 @@ declare module '/classic/types.js' {
         heightEditMode?: string;
         agentEnabled?: boolean;
         agentSelected?: boolean;
+        lightPreset?: string;
+        lightAmbient?: [number, number, number];
+        lightDir?: [number, number, number];
+        lightColor?: [number, number, number];
+        lightAzimuth?: number;
+        lightElevation?: number;
     }
 }
 

--- a/src/shaders/iso_tilemap.frag
+++ b/src/shaders/iso_tilemap.frag
@@ -2,7 +2,7 @@ precision mediump float;
 
 varying mediump vec2 vMapCoord;
 varying mediump float vTileId;
-varying mediump float vIsoDepth;
+varying mediump vec3 vNormal;
 
 uniform sampler2D mapData;
 uniform vec2 mapSize;
@@ -16,7 +16,10 @@ uniform vec2 selectionBegin;
 uniform vec4 selectionColor;
 uniform int selectionMode;
 uniform vec4 wallColor;
-uniform float slopeDarken;
+
+uniform vec3 ambientColor;
+uniform vec3 lightDirection;
+uniform vec3 lightColor;
 
 float getMapData(vec2 pos) {
     vec4 rawData = texture2D(mapData, pos);
@@ -68,12 +71,12 @@ void main(void ) {
     } else {
         vec2 mapCoord = vec2(vMapCoord.x, vMapCoord.y);
         color = getTilePixel(getMapData(mapCoord), mapCoord);
-
-        if (vTileId < -0.01) {
-            color.rgb *= 1.0 + vTileId * slopeDarken;
-        }
     }
 
     if (color.a < 0.01) discard;
+
+    float diff = max(dot(normalize(vNormal), lightDirection), 0.0);
+    color.rgb *= ambientColor + diff * lightColor;
+
     gl_FragColor = color;
 }

--- a/src/shaders/iso_tilemap.vert
+++ b/src/shaders/iso_tilemap.vert
@@ -3,17 +3,20 @@ precision mediump float;
 attribute vec3 vertexPos;
 attribute vec2 mapCoord;
 attribute float tileId;
+attribute vec3 normal;
 
 uniform mat4 isoMatrix;
 uniform mat4 modelMatrix;
 uniform mat4 cameraMatrix;
 uniform mat4 projectionMatrix;
+uniform mat3 normalMatrix;
 
 uniform vec2 mapSize;
 uniform vec2 tilePixelSize;
 
 varying mediump vec2 vMapCoord;
 varying mediump float vTileId;
+varying mediump vec3 vNormal;
 
 void main(void ) {
     vec4 worldPos = modelMatrix * isoMatrix * vec4(vertexPos, 1.0);
@@ -28,4 +31,5 @@ void main(void ) {
     gl_Position = clipPos;
     vMapCoord = mapCoord;
     vTileId = tileId;
+    vNormal = normalize(normalMatrix * normal);
 }


### PR DESCRIPTION
<!-- pr-msg-meta
branch: tilemap-lighting
base: master
submitted:
  github: ___
-->

## Add tilemap directional lighting system

### Motivation

The tilemap rendered flat — terrain and walls had no light/shadow
variation.  Slope contrast was provided by a hardcoded
`slopeDarken` multiplier in the fragment shader that gave no
directional information and looked flat.

This adds a proper ambient + directional diffuse (Lambert)
lighting pipeline with selectable presets.

### Summary of changes

- Compute per-face flat-shaded normals in `buildMesh()` for
  top faces (cross product of triangle edges) and wall faces
  (axis-aligned unit vectors).  Vertex stride extended 6→9
  floats to carry the `normal` attribute.

- Add `normalMatrix` uniform (inverse‑transpose of `isoMatrix`)
  to correctly transform normals under the non‑uniform
  isometric scale.  Computed once in `setScale()`.

- Add `ambientColor`, `lightDirection`, `lightColor` uniforms
  to `iso_tilemap.frag`.  Lambert diffuse applied after
  colour sampling, before selection overlay.

- Drop `slopeDarken` uniform and the manual slope‑darkening
  block — surface orientation against the light direction now
  provides the sole slope contrast.

- Add `src/classic/lighting.ts` with four presets: Sunny Day
  (az 115°, el 60°), Cloudy, Dawn/Dusk, Night.  Direction
  stored as azimuth/elevation with `updateLightDirection()`
  converting to world‑space vector.

- Fix a nav‑mesh startup race: guard `updateMap` in
  `syncHeights()` with a `_navReady` flag set when the
  `initmap` worker message completes.

### Scopes changed

- `src/shaders/iso_tilemap.{vert,frag}` — normal attr,
  normalMatrix, lighting uniforms, slopeDarken removed
- `src/classic/isometric.ts` — buildMesh normals, rawDraw
  uniforms, _navReady guard
- `src/classic/lighting.ts` — new: presets engine
- `src/demo/{init,prefabs}.ts` — wiring + state augmentation
- `public/manifest.json` — normal attr + light unifs

### Links

- [isometric-tilemap skill §16](https://github.com/guilledk/classic-wgl/blob/tilemap-lighting/.claude/skills/isometric-tilemap/SKILL.md#16-lighting-system)

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
