### PR TITLE
Add tile-boundary grid overlay on mouse hover

### DIFF
--- a/.claude/skills/isometric-tilemap/SKILL.md
+++ b/.claude/skills/isometric-tilemap/SKILL.md
@@ -847,3 +847,65 @@ separate darkening uniform or math is needed.
 
 Lighting runs after selection so the selection overlay (an editor tool)
 retains its visual intensity regardless of light settings.
+
+---
+
+## 17. MOUSE-HOVER GRID OVERLAY
+
+### Overview
+
+The fragment shader draws black grid lines at tile boundaries within a
+configurable Chebyshev radius of the mouse cursor.  Toggled via G key;
+suppressed during editor selection and never drawn on wall faces.
+Enabled by default (`game.showGrid = true`).
+
+### Uniforms
+
+| Uniform      | Type   | Purpose                                   |
+| ------------ | ------ | ----------------------------------------- |
+| `showGrid`   | int    | Toggle (0 = off, 1 = on)                  |
+| `gridRadius` | float  | Tile-radius around mouse (default 3.0)   |
+| `gridColor`  | vec3   | Line colour (default black [0,0,0])      |
+
+Declared in `iso_tilemap.frag`, added to `manifest.json` under
+`isoTilemap.unif`, set each frame in `Tilemap.rawDraw()`.
+
+### Fragment shader logic
+
+1. Gate: `showGrid > 0 && selectionMode == -1 && vTileId <= 0.5`
+   (off during selection overlay; walls excluded)
+2. Recover tile-space coords from the varying:
+   `tileCoord = vMapCoord * mapSize`
+3. Identify the current tile: `ct = floor(tileCoord.x)`,
+   `rt = floor(tileCoord.y)`
+4. Identify the mouse tile: `mt = floor(selectedTile.x)`,
+   `nt = floor(selectedTile.y)`
+5. Chebyshev distance: `dist = max(abs(ct - mt), abs(nt - rt))`
+6. If `dist <= gridRadius`, compute edge-proximity:
+   ```glsl
+   float dx = min(localUV.x, 1.0 - localUV.x);
+   float dy = min(localUV.y, 1.0 - localUV.y);
+   float edgeDist = min(dx, dy);
+   float border = 1.0 - smoothstep(0.0, edge, edgeDist);
+   ```
+7. Distance fade: `fade = 1.0 - dist / max(gridRadius, 0.01)`
+8. Blend: `color.rgb = mix(color.rgb, gridColor, border * fade * 0.85)`
+
+Runs after lighting so grid lines are always visible regardless of
+light settings.
+
+### Toggle state
+
+`game.showGrid` (boolean) added via module augmentation in
+`prefabs.ts` / `uiPrefabs.ts`.  The G-key handler lives in
+`initTilemap()`'s `'update'` callback via
+`game.wasKeyPressed('KeyG')`.  Defaults to `true` set in
+`init.ts`.
+
+### Pitfall: max vs min for edge distance
+
+Using `max()` to combine edge-distances (e.g. `max(smoothstep(0, e,
+localUV.x), smoothstep(0, e, 1.0 - localUV.x))`) always produces ~1
+because any point is far from at *least* one edge.  The correct
+operation is `min(localUV, 1.0 - localUV)` — distance to the
+**nearest** edge — so `border = 1` only at boundaries.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -60,6 +60,9 @@
                 "selectionMode",
                 "selectionColor",
                 "wallColor",
+                "gridRadius",
+                "showGrid",
+                "gridColor",
                 "ambientColor",
                 "lightDirection",
                 "lightColor"

--- a/src/classic/isometric.ts
+++ b/src/classic/isometric.ts
@@ -499,6 +499,10 @@ export class Tilemap extends Drawable {
 
         this.gl.uniform4fv(shader.unif.wallColor, [0.3, 0.2, 0.15, 1.0]);
 
+        this.gl.uniform1f(shader.unif.gridRadius, 3.0);
+        this.gl.uniform1i(shader.unif.showGrid, (game.showGrid ?? false) ? 1 : 0);
+        this.gl.uniform3fv(shader.unif.gridColor, [0, 0, 0]);
+
         this.gl.uniformMatrix3fv(shader.unif.normalMatrix, false, this._normalMatrix);
         this.gl.uniform3fv(shader.unif.ambientColor, game.lightAmbient ?? [0.2, 0.2, 0.25]);
         this.gl.uniform3fv(shader.unif.lightDirection, game.lightDir ?? [0.45, -0.35, 0.82]);

--- a/src/demo/init.ts
+++ b/src/demo/init.ts
@@ -36,6 +36,8 @@ async function initContext(): Promise<void> {
     initUI();
     initLighting();
 
+    game.showGrid = true;
+
     // Centre camera on demo slope area around tile (90, 85)
     const isoToWorld = mat4.clone(isoToCartesian4);
     mat4.scale(isoToWorld, isoToWorld, [45, 45, 1]);

--- a/src/demo/prefabs.ts
+++ b/src/demo/prefabs.ts
@@ -21,6 +21,7 @@ declare module '/classic/types.js' {
         lightColor?: [number, number, number];
         lightAzimuth?: number;
         lightElevation?: number;
+        showGrid?: boolean;
         uiConsumedClick?: boolean;
         panelMenuOpen?: boolean;
     }
@@ -75,6 +76,10 @@ export function initTilemap(): void {
     ) as Collider;
 
     tilemap.registerCall('update', function () {
+        if (game.wasKeyPressed('KeyG')) {
+            game.showGrid = !(game.showGrid ?? false);
+        }
+
         const camDelta = game.camera.getFix();
         vec3.negate(camDelta, camDelta);
         vec3.copy(compTilemapCollider.position, camDelta);

--- a/src/demo/uiPrefabs.ts
+++ b/src/demo/uiPrefabs.ts
@@ -23,6 +23,7 @@ declare module '/classic/types.js' {
         lightAmbient?: [number, number, number];
         lightDir?: [number, number, number];
         lightColor?: [number, number, number];
+        showGrid?: boolean;
         lightAzimuth?: number;
         lightElevation?: number;
     }

--- a/src/shaders/iso_tilemap.frag
+++ b/src/shaders/iso_tilemap.frag
@@ -17,6 +17,10 @@ uniform vec4 selectionColor;
 uniform int selectionMode;
 uniform vec4 wallColor;
 
+uniform float gridRadius;
+uniform int showGrid;
+uniform vec3 gridColor;
+
 uniform vec3 ambientColor;
 uniform vec3 lightDirection;
 uniform vec3 lightColor;
@@ -77,6 +81,25 @@ void main(void ) {
 
     float diff = max(dot(normalize(vNormal), lightDirection), 0.0);
     color.rgb *= ambientColor + diff * lightColor;
+
+    if (showGrid > 0 && selectionMode == -1 && vTileId <= 0.5) {
+        vec2 tileCoord = vMapCoord * mapSize;
+        vec2 localUV = fract(tileCoord);
+        float mt = floor(selectedTile.x);
+        float nt = floor(selectedTile.y);
+        float ct = floor(tileCoord.x);
+        float rt = floor(tileCoord.y);
+        float dist = max(abs(ct - mt), abs(nt - rt));
+        if (dist <= gridRadius) {
+            float edge = 0.04;
+            float dx = min(localUV.x, 1.0 - localUV.x);
+            float dy = min(localUV.y, 1.0 - localUV.y);
+            float edgeDist = min(dx, dy);
+            float border = 1.0 - smoothstep(0.0, edge, edgeDist);
+            float fade = 1.0 - dist / max(gridRadius, 0.01);
+            color.rgb = mix(color.rgb, gridColor, border * fade * 0.85);
+        }
+    }
 
     gl_FragColor = color;
 }


### PR DESCRIPTION
<!-- pr-msg-meta
branch: mouse-grid
base: dev-ui-refresh
submitted:
  github: ___
-->

## Add tile-boundary grid overlay on mouse hover

### Motivation

The isometric tilemap renders as a continuous surface with no
visual indication of individual tile boundaries. This makes it
hard to judge tile positions when authoring terrain or diagnosing
selection accuracy — you can't see where one tile ends and the
next begins without invoking the editor selection rectangle.

### Summary of changes

- Add fragment-shader grid overlay drawing black tile-boundary
  lines within a Chebyshev radius around the mouse cursor
  (`showGrid` / `gridRadius` / `gridColor` uniforms, gated on
  `selectionMode == -1` and `vTileId <= 0.5`).

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
