### PR TITLE
Add loading screen with load progress and debug log

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </head>
 
     <body>
-        <h1 id="loader">LOADING...</h1>
+        <div id="loader" class="loader-overlay loader-visual-mode">LOADING...</div>
         <script type="module" src="/src/main.ts"></script>
         <canvas id="glCanvas">
             Unable to initialize WebGL. Your browser or machine may not support it.

--- a/src/classic/consoleLog.ts
+++ b/src/classic/consoleLog.ts
@@ -1,0 +1,238 @@
+import { APP_NAME, APP_VERSION_DISPLAY } from '../version.js';
+
+/**
+ * Console message capture for the loading screen (src/classic/loader.ts).
+ *
+ * Wraps the browser console so every message logged while the loader is on
+ * screen (engine init, shader/asset fetches, errors, unhandled rejections)
+ * is recorded in an in-memory ring buffer. The loader renders the captured
+ * lines and offers a "copy log" button that pastes a formatted debug report
+ * for sending to developers.
+ */
+
+export type ConsoleLevel = 'log' | 'info' | 'warn' | 'error' | 'debug' | 'trace';
+
+export interface ConsoleEntry {
+    time: number;
+    level: ConsoleLevel;
+    text: string;
+}
+
+const MAX_ENTRIES = 500;
+
+const CAPTURED_LEVELS: ConsoleLevel[] = ['log', 'info', 'warn', 'error', 'debug', 'trace'];
+
+let capturing = false;
+let entries: ConsoleEntry[] = [];
+const listeners = new Set<(entry: ConsoleEntry) => void>();
+const originals: Partial<Record<ConsoleLevel, (...args: unknown[]) => void>> = {};
+
+function push(level: ConsoleLevel, args: unknown[]): void {
+    const entry = { time: Date.now(), level, text: formatConsoleArgs(args) };
+    entries.push(entry);
+    if (entries.length > MAX_ENTRIES) {
+        entries.shift();
+    }
+    for (const listener of listeners) {
+        listener(entry);
+    }
+}
+
+// ============================================================================
+// Capture
+// ============================================================================
+
+export function startConsoleCapture(): void {
+    if (capturing) {
+        return;
+    }
+    capturing = true;
+
+    for (const level of CAPTURED_LEVELS) {
+        const original = console[level].bind(console);
+        originals[level] = original;
+        const wrapped: (...args: unknown[]) => void = (...args) => {
+            original(...args);
+            push(level, args);
+        };
+        console[level] = wrapped;
+    }
+
+    const originalAssert = console.assert.bind(console);
+    const wrappedAssert: (condition?: boolean, ...data: unknown[]) => void = (
+        condition,
+        ...data
+    ) => {
+        originalAssert(condition, ...data);
+        if (!condition) {
+            push('error', data.length ? data : ['Assertion failed']);
+        }
+    };
+    console.assert = wrappedAssert;
+
+    window.addEventListener('error', onUncaughtError);
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+}
+
+function onUncaughtError(event: ErrorEvent): void {
+    push('error', [
+        `Uncaught ${event.message} at ${event.filename}:${event.lineno}:${event.colno}`,
+    ]);
+}
+
+function onUnhandledRejection(event: PromiseRejectionEvent): void {
+    push('error', ['Unhandled promise rejection:', event.reason]);
+}
+
+/**
+ * Records an entry (and forwards it to the real console) without relying on
+ * the wrapped console methods. Used by the loader for messages it generates
+ * itself, so they always end up in the copyable log.
+ */
+export function appendConsoleEntry(level: ConsoleLevel, args: unknown[]): void {
+    const original = originals[level];
+    if (original) {
+        original(...args);
+    } else if (!capturing) {
+        console[level](...args);
+    }
+    push(level, args);
+}
+
+export function subscribeConsole(listener: (entry: ConsoleEntry) => void): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export function clearConsoleLog(): void {
+    entries = [];
+}
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+function jsonStringify(value: unknown): string | undefined {
+    const seen = new Set<unknown>();
+    try {
+        return JSON.stringify(value, (_key, v) => {
+            if (typeof v === 'object' && v !== null) {
+                if (seen.has(v)) {
+                    return '[Circular]';
+                }
+                seen.add(v);
+            }
+            return v;
+        });
+    } catch {
+        return undefined;
+    }
+}
+
+export function formatConsoleArg(arg: unknown): string {
+    if (arg === null) {
+        return 'null';
+    }
+    if (arg === undefined) {
+        return 'undefined';
+    }
+    if (typeof arg === 'string') {
+        return arg;
+    }
+    if (typeof arg === 'number' || typeof arg === 'boolean' || typeof arg === 'bigint') {
+        return String(arg);
+    }
+    if (arg instanceof Error) {
+        return arg.stack ?? `${arg.name}: ${arg.message}`;
+    }
+    if (typeof (arg as { tagName?: unknown }).tagName === 'string') {
+        return String(arg);
+    }
+    const json = jsonStringify(arg);
+    return json ?? String(arg);
+}
+
+export function formatConsoleArgs(args: unknown[]): string {
+    return args.map(formatConsoleArg).join(' ');
+}
+
+function pad(value: number, width = 2): string {
+    return String(value).padStart(width, '0');
+}
+
+function formatTime(time: number): string {
+    const d = new Date(time);
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(
+        d.getMilliseconds(),
+        3,
+    )}`;
+}
+
+export function formatConsoleEntry(entry: ConsoleEntry): string {
+    return `[${formatTime(entry.time)}] [${entry.level}] ${entry.text}`;
+}
+
+// ============================================================================
+// Reading / copying
+// ============================================================================
+
+export function getConsoleLog(): string {
+    return entries.map(formatConsoleEntry).join('\n');
+}
+
+/** Formatted error/warn lines, most recent last, for the visual error panel. */
+export function getConsoleErrors(max = 8): string[] {
+    const errors = entries.filter((e) => e.level === 'error' || e.level === 'warn');
+    return errors.slice(-max).map(formatConsoleEntry);
+}
+
+export interface DebugReportMeta {
+    status: string;
+    step: string;
+    progress: number;
+    elapsedMs: number;
+}
+
+export function buildDebugReport(meta?: DebugReportMeta): string {
+    const lines: string[] = [];
+    lines.push(`${APP_NAME} ${APP_VERSION_DISPLAY}`);
+    lines.push(`Captured at: ${new Date().toISOString()}`);
+    if (meta) {
+        lines.push(`Load status: ${meta.status}`);
+        lines.push(`Current step: ${meta.step}`);
+        lines.push(`Progress: ${Math.round(meta.progress * 100)}%`);
+        lines.push(`Elapsed: ${(meta.elapsedMs / 1000).toFixed(1)}s`);
+    }
+    lines.push('');
+    lines.push('--- console log ---');
+    lines.push(getConsoleLog() || '(no console output captured)');
+    return lines.join('\n');
+}
+
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+    if (navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+            return true;
+        } catch {
+            // fall through to the legacy path below
+        }
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    let ok = false;
+    try {
+        ok = document.execCommand('copy');
+    } catch {
+        ok = false;
+    }
+    textarea.remove();
+    return ok;
+}

--- a/src/classic/loader.ts
+++ b/src/classic/loader.ts
@@ -1,0 +1,440 @@
+import { setLoaderSink } from './utils.js';
+import {
+    startConsoleCapture,
+    subscribeConsole,
+    appendConsoleEntry,
+    buildDebugReport,
+    copyTextToClipboard,
+    formatConsoleEntry,
+    getConsoleErrors,
+} from './consoleLog.js';
+import type { ConsoleEntry } from './consoleLog.js';
+import { APP_NAME, APP_VERSION_DISPLAY } from '../version.js';
+import { LOADER_STYLE, LOADER_STYLE_ID } from './loaderStyles.js';
+
+/**
+ * Loading screen overlay for the classic-wgl demo, packaged as a small
+ * code-defined API so other pages can drop it in with one call:
+ *
+ *     const loader = createLoader({ exit: 'instant' });
+ *     loader.setProgress('Loading assets', 0.25);
+ *     // ...
+ *     loader.finish();
+ *
+ * Styles are injected into the document at runtime (see loaderStyles.ts) and
+ * the loader's own DOM is cleaned up on finish(), so consumers don't need to
+ * wire up a stylesheet or mount element.
+ *
+ * Features:
+ *   - Two render modes, switchable with a corner button (visual: dark gray,
+ *     logo + weighted progress bar; terminal: black, green log lines). The
+ *     mode toggle persists to localStorage only when `persistMode` is set.
+ *   - Browser console messages are captured (see consoleLog.ts) and streamed
+ *     into the terminal log; errors/warnings surface in visual mode as a red
+ *     panel, with a "copy log" button that pastes a formatted debug report.
+ *   - A stall watchdog appends a warning when no progress arrives for
+ *     `stallTimeoutMs`.
+ *   - On finish() the overlay either fades out (`exit: 'fade'`) or is removed
+ *     immediately (`exit: 'instant'`).
+ *
+ * The engine is decoupled from this overlay through the loader sink in
+ * src/classic/utils.ts (setLoaderSink/deleteLoaderLabel), which routes shader
+ * error messages and launch cleanup here when a loader is active.
+ */
+
+export type LoaderMode = 'visual' | 'terminal';
+
+export type LoaderExit = 'fade' | 'instant';
+
+export interface LoaderOptions {
+    /** Initial render mode. Defaults to 'visual'. */
+    mode?: LoaderMode;
+    /** How the overlay goes away on finish(). Defaults to 'fade'. */
+    exit?: LoaderExit;
+    /** Mount point for the overlay. Defaults to #loader, else a new div. */
+    target?: HTMLElement;
+    /** Heading text (visual mode). Defaults to `${APP_NAME} ${APP_VERSION_DISPLAY}`. */
+    title?: string;
+    /** Logo image URL (visual mode). Omitted (no logo) when not provided. */
+    logoUrl?: string;
+    /** Stall watchdog threshold in ms. Defaults to STALL_TIMEOUT_MS. */
+    stallTimeoutMs?: number;
+    /** Show the "copy log" button. Defaults to true. */
+    copyLog?: boolean;
+    /** Persist the mode toggle to localStorage. Defaults to false. */
+    persistMode?: boolean;
+}
+
+export const LOADER_STORAGE_KEY = 'classic-wgl:loader-mode';
+
+/** No load progress for this long (ms) triggers a stall warning entry. */
+export const STALL_TIMEOUT_MS = 20000;
+
+export function isLoaderMode(value: string | null | undefined): value is LoaderMode {
+    return value === 'visual' || value === 'terminal';
+}
+
+function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
+    try {
+        return window.localStorage;
+    } catch {
+        return null;
+    }
+}
+
+export function readLoaderMode(): LoaderMode {
+    try {
+        const value = getStorage()?.getItem(LOADER_STORAGE_KEY);
+        return isLoaderMode(value) ? value : 'visual';
+    } catch {
+        return 'visual';
+    }
+}
+
+export function writeLoaderMode(mode: LoaderMode): void {
+    try {
+        getStorage()?.setItem(LOADER_STORAGE_KEY, mode);
+    } catch {
+        // storage unavailable (private mode etc.) - ignore
+    }
+}
+
+export interface LoaderController {
+    setProgress(label: string, fraction: number): void;
+    log(line: string): void;
+    error(message: string): void;
+    fail(message: string): void;
+    note(message: string): void;
+    finish(): void;
+}
+
+function clamp01(value: number): number {
+    return Math.min(1, Math.max(0, value));
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    className?: string,
+): HTMLElementTagNameMap[K] {
+    const node = document.createElement(tag);
+    if (className) {
+        node.className = className;
+    }
+    return node;
+}
+
+function injectLoaderStyle(): HTMLStyleElement {
+    const existing = document.getElementById(LOADER_STYLE_ID);
+    if (existing) {
+        return existing as HTMLStyleElement;
+    }
+    const style = document.createElement('style');
+    style.id = LOADER_STYLE_ID;
+    style.textContent = LOADER_STYLE;
+    document.head.appendChild(style);
+    return style;
+}
+
+class Loader implements LoaderController {
+    private _mode: LoaderMode;
+    private _exit: LoaderExit;
+    private _persistMode: boolean;
+    private _stallTimeoutMs: number;
+    private _style: HTMLStyleElement;
+    private _root: HTMLElement;
+    private _copy!: HTMLButtonElement;
+    private _toggle: HTMLButtonElement;
+    private _barFill: HTMLElement;
+    private _pct: HTMLElement;
+    private _label: HTMLElement;
+    private _note: HTMLElement;
+    private _log: HTMLElement;
+    private _progress: HTMLElement;
+    private _errors: HTMLElement;
+    private _errorsList: HTMLElement;
+    private _fraction = 0;
+    private _lastLoggedLabel = '';
+    private _finished = false;
+    private _status: 'loading' | 'failed' = 'loading';
+    private _startedAt = Date.now();
+    private _lastProgressAt = Date.now();
+    private _stallReportedAt = Date.now();
+    private _stallTimer: number | null = null;
+    private _unsubscribeConsole: (() => void) | null = null;
+
+    constructor(options: LoaderOptions = {}) {
+        this._persistMode = options.persistMode ?? false;
+        this._exit = options.exit ?? 'fade';
+        this._stallTimeoutMs = options.stallTimeoutMs ?? STALL_TIMEOUT_MS;
+        this._mode = this._resolveInitialMode(options);
+
+        this._style = injectLoaderStyle();
+
+        this._root =
+            options.target ??
+            document.getElementById('loader') ??
+            (() => {
+                const div = el('div');
+                div.id = 'loader';
+                document.body.appendChild(div);
+                return div;
+            })();
+
+        this._root.className = 'loader-overlay';
+        this._root.innerHTML = '';
+
+        const actions = el('div', 'loader-actions');
+
+        const copyLog = options.copyLog ?? true;
+        if (copyLog) {
+            this._copy = el('button', 'loader-copy');
+            this._copy.type = 'button';
+            this._copy.textContent = 'copy log';
+            this._copy.addEventListener('click', this._copyLog.bind(this));
+            actions.appendChild(this._copy);
+        }
+
+        this._toggle = el('button', 'loader-toggle');
+        this._toggle.type = 'button';
+        this._toggle.addEventListener('click', this._toggleMode.bind(this));
+
+        actions.appendChild(this._toggle);
+
+        const visual = el('div', 'loader-visual');
+
+        if (options.logoUrl) {
+            const logo = el('img', 'loader-logo');
+            logo.src = options.logoUrl;
+            logo.alt = APP_NAME;
+            logo.addEventListener('error', () => {
+                logo.style.display = 'none';
+            });
+            visual.appendChild(logo);
+        }
+
+        const title = el('div', 'loader-title');
+        title.textContent = options.title ?? `${APP_NAME} ${APP_VERSION_DISPLAY}`;
+
+        const bar = el('div', 'loader-bar');
+        this._barFill = el('div', 'loader-bar-fill');
+        bar.appendChild(this._barFill);
+
+        const meta = el('div', 'loader-meta');
+        this._pct = el('span', 'loader-pct');
+        this._label = el('span', 'loader-label');
+        meta.append(this._pct, this._label);
+
+        const note = el('div', 'loader-note');
+        this._note = note;
+
+        const errors = el('div', 'loader-errors');
+        const errorsHead = el('div', 'loader-errors-head');
+        errorsHead.textContent = 'console errors';
+        this._errorsList = el('pre', 'loader-errors-list');
+        errors.append(errorsHead, this._errorsList);
+        this._errors = errors;
+
+        visual.append(title, bar, meta, note, errors);
+
+        const terminal = el('div', 'loader-terminal');
+        this._log = el('div', 'loader-log');
+        this._progress = el('div', 'loader-terminal-progress');
+        terminal.append(this._log, this._progress);
+
+        this._root.append(actions, visual, terminal);
+
+        this._updateMode();
+
+        startConsoleCapture();
+        this._unsubscribeConsole = subscribeConsole((entry) => this._onConsoleEntry(entry));
+        this._stallTimer = window.setInterval(() => this._checkStall(), 1000);
+
+        setLoaderSink(this);
+    }
+
+    private _resolveInitialMode(options: LoaderOptions): LoaderMode {
+        if (options.persistMode) {
+            const stored = getStorage()?.getItem(LOADER_STORAGE_KEY);
+            if (isLoaderMode(stored)) {
+                return stored;
+            }
+        }
+        return options.mode ?? 'visual';
+    }
+
+    setProgress(label: string, fraction: number): void {
+        this._lastProgressAt = Date.now();
+        this._fraction = clamp01(fraction);
+        const pct = Math.round(this._fraction * 100);
+
+        this._label.textContent = label;
+        this._label.classList.remove('loader-label-error');
+        this._pct.textContent = `${pct}%`;
+        this._barFill.style.width = `${this._fraction * 100}%`;
+
+        if (label !== this._lastLoggedLabel) {
+            this._lastLoggedLabel = label;
+            this._logLine(`> ${label}`);
+        }
+        this._renderProgress();
+    }
+
+    log(line: string): void {
+        this._logLine(line);
+    }
+
+    error(message: string): void {
+        this._lastProgressAt = Date.now();
+        this._label.textContent = message;
+        this._label.classList.add('loader-label-error');
+        this._pct.textContent = '!';
+        appendConsoleEntry('error', [message]);
+    }
+
+    note(message: string): void {
+        this._note.textContent = message;
+        this._note.hidden = message === '';
+    }
+
+    fail(message: string): void {
+        if (this._status === 'failed') {
+            return;
+        }
+        this._status = 'failed';
+        this._stopStallTimer();
+        this._lastProgressAt = Date.now();
+
+        appendConsoleEntry('error', [message]);
+
+        this._root.classList.add('loader-failed');
+        this._label.textContent = message;
+        this._label.classList.add('loader-label-error');
+        this._pct.textContent = 'FAILED';
+        this._barFill.style.width = '100%';
+        this._showErrors();
+    }
+
+    finish(): void {
+        if (this._finished) {
+            return;
+        }
+        this._finished = true;
+        this._stopStallTimer();
+        if (this._unsubscribeConsole) {
+            this._unsubscribeConsole();
+            this._unsubscribeConsole = null;
+        }
+        this.setProgress('Ready', 1);
+        setLoaderSink(null);
+        if (this._exit === 'instant') {
+            this._destroy();
+        } else {
+            this._root.classList.add('loader-hidden');
+            window.setTimeout(() => this._destroy(), 600);
+        }
+    }
+
+    private _destroy(): void {
+        this._style.remove();
+        this._root.remove();
+    }
+
+    private _toggleMode(): void {
+        this._mode = this._mode === 'visual' ? 'terminal' : 'visual';
+        if (this._persistMode) {
+            writeLoaderMode(this._mode);
+        }
+        this._updateMode();
+    }
+
+    private _updateMode(): void {
+        this._root.classList.toggle('loader-visual-mode', this._mode === 'visual');
+        this._root.classList.toggle('loader-terminal-mode', this._mode === 'terminal');
+        this._toggle.textContent = this._mode === 'visual' ? 'terminal' : 'visual';
+    }
+
+    private _logLine(text: string, cls?: string): void {
+        const line = el('div', 'loader-log-line');
+        if (cls) {
+            line.classList.add(cls);
+        }
+        line.textContent = text;
+        this._log.appendChild(line);
+        this._log.scrollTop = this._log.scrollHeight;
+    }
+
+    private _renderProgress(): void {
+        const width = 24;
+        const filled = Math.round(this._fraction * width);
+        const bar = '#'.repeat(filled) + '-'.repeat(width - filled);
+        const pct = Math.round(this._fraction * 100);
+        this._progress.textContent = `[${bar}] ${pct}% ${this._lastLoggedLabel}`;
+    }
+
+    private _onConsoleEntry(entry: ConsoleEntry): void {
+        this._logLine(formatConsoleEntry(entry));
+        if (entry.level === 'error' || entry.level === 'warn') {
+            this._showErrors();
+        } else {
+            this._renderErrors();
+        }
+    }
+
+    private _showErrors(): void {
+        this._root.classList.add('loader-show-errors');
+        this._renderErrors();
+    }
+
+    private _renderErrors(): void {
+        const lines = getConsoleErrors();
+        this._errorsList.textContent = lines.length ? lines.join('\n') : '(no errors)';
+    }
+
+    private _checkStall(): void {
+        if (this._finished || this._status === 'failed') {
+            return;
+        }
+        const idleMs = Date.now() - this._lastProgressAt;
+        if (
+            idleMs >= this._stallTimeoutMs &&
+            Date.now() - this._stallReportedAt >= this._stallTimeoutMs
+        ) {
+            this._stallReportedAt = Date.now();
+            appendConsoleEntry('warn', [
+                `Loading stalled — no progress for ${this._stallTimeoutMs / 1000}s. ` +
+                    `Current step: "${this._lastLoggedLabel || 'n/a'}", progress ${Math.round(
+                        this._fraction * 100,
+                    )}%.`,
+            ]);
+        }
+    }
+
+    private async _copyLog(): Promise<void> {
+        const report = buildDebugReport({
+            status: this._status,
+            step: this._lastLoggedLabel,
+            progress: this._fraction,
+            elapsedMs: Date.now() - this._startedAt,
+        });
+        const ok = await copyTextToClipboard(report);
+        if (ok) {
+            this._copy.classList.add('copied');
+            this._copy.textContent = 'copied!';
+            window.setTimeout(() => {
+                this._copy.classList.remove('copied');
+                this._copy.textContent = 'copy log';
+            }, 1500);
+        }
+    }
+
+    private _stopStallTimer(): void {
+        if (this._stallTimer !== null) {
+            window.clearInterval(this._stallTimer);
+            this._stallTimer = null;
+        }
+    }
+}
+
+export function createLoader(options?: LoaderOptions): LoaderController {
+    return new Loader(options);
+}

--- a/src/classic/loaderStyles.ts
+++ b/src/classic/loaderStyles.ts
@@ -1,0 +1,290 @@
+/**
+ * Loading-screen styles for createLoader().
+ *
+ * Kept as a plain CSS string and injected into a scoped <style> element at
+ * runtime (see loader.ts), so library consumers get a working loading screen
+ * by just calling createLoader() — no separate stylesheet to wire up. Every
+ * rule is scoped under `#loader` to avoid leaking onto consumer pages.
+ */
+
+export const LOADER_STYLE_ID = 'classic-wgl-loader-style';
+
+export const LOADER_STYLE = `
+#loader {
+    --loader-bg: #1a1a1a;
+    --loader-fg: #ddd;
+    --loader-accent: #4caf50;
+    --loader-panel: #0a0a0a;
+    --loader-bevel-hi: #4a4a4a;
+    --loader-bevel-lo: #000;
+}
+
+#loader.loader-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    background: var(--loader-bg);
+    color: var(--loader-fg);
+    font-family: system-ui, sans-serif;
+    transition: opacity 0.5s ease;
+}
+
+#loader.loader-hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Top-right action buttons (copy log + mode toggle) */
+
+#loader .loader-actions {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    display: flex;
+    gap: 8px;
+}
+
+#loader .loader-actions button {
+    padding: 4px 12px;
+    border: 2px solid transparent;
+    border-radius: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
+#loader .loader-copy.copied {
+    color: var(--loader-accent);
+}
+
+/* terminal: subtle translucent buttons */
+
+#loader.loader-terminal-mode .loader-actions button {
+    border-color: rgba(255, 255, 255, 0.35);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+#loader.loader-terminal-mode .loader-actions button:hover {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+/* visual: dark-mode win95 raised bevel buttons */
+
+#loader.loader-visual-mode .loader-actions button {
+    border-color: var(--loader-bevel-hi) var(--loader-bevel-lo) var(--loader-bevel-lo)
+        var(--loader-bevel-hi);
+    background: #2a2a2a;
+    color: var(--loader-fg);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+#loader.loader-visual-mode .loader-actions button:hover {
+    background: #333;
+}
+
+#loader.loader-visual-mode .loader-actions button:active {
+    border-color: var(--loader-bevel-lo) var(--loader-bevel-hi) var(--loader-bevel-hi)
+        var(--loader-bevel-lo);
+    background: #1f1f1f;
+}
+
+/* Visual mode */
+
+#loader .loader-visual {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    max-width: 420px;
+    padding: 32px;
+}
+
+#loader.loader-visual-mode .loader-visual {
+    display: flex;
+}
+
+#loader.loader-visual-mode {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+#loader .loader-logo {
+    width: clamp(120px, 25vmin, 280px);
+    max-width: 40vw;
+    height: auto;
+    image-rendering: pixelated;
+    filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.6));
+}
+
+#loader .loader-title {
+    font-size: 14px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+#loader .loader-bar {
+    width: 100%;
+    height: 22px;
+    border: 2px solid;
+    border-color: var(--loader-bevel-lo) var(--loader-bevel-hi) var(--loader-bevel-hi)
+        var(--loader-bevel-lo);
+    border-radius: 0;
+    background: var(--loader-panel);
+    box-sizing: border-box;
+    padding: 2px;
+    overflow: hidden;
+}
+
+#loader .loader-bar-fill {
+    height: 100%;
+    width: 0%;
+    border-radius: 0;
+    background-color: var(--loader-accent);
+    background-image: repeating-linear-gradient(
+        90deg,
+        rgba(0, 0, 0, 0) 0 12px,
+        rgba(0, 0, 0, 0.45) 12px 14px
+    );
+    box-shadow:
+        inset 0 2px 0 rgba(255, 255, 255, 0.35),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.55);
+    transition: width 0.15s ease;
+}
+
+#loader .loader-meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    width: 100%;
+    font-size: 12px;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+#loader .loader-pct {
+    color: var(--loader-accent);
+}
+
+#loader .loader-label-error {
+    color: #ff5555;
+    font-weight: 700;
+}
+
+/* Load-test hint (shown when ?slow / ?fail= query params are active) */
+
+#loader .loader-note {
+    max-width: 100%;
+    box-sizing: border-box;
+    font-size: 11px;
+    line-height: 1.4;
+    color: #e0a83a;
+    text-align: center;
+}
+
+/* Console error panel (visual mode) */
+
+#loader .loader-errors {
+    display: none;
+    width: 100%;
+    box-sizing: border-box;
+    border: 2px solid;
+    border-color: var(--loader-bevel-hi) var(--loader-bevel-lo) var(--loader-bevel-lo)
+        var(--loader-bevel-hi);
+    background: rgba(255, 85, 85, 0.08);
+    color: #ff8888;
+    text-align: left;
+}
+
+#loader.loader-show-errors .loader-errors,
+#loader.loader-failed .loader-errors {
+    display: block;
+}
+
+#loader .loader-errors-head {
+    padding: 4px 8px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #ff5555;
+}
+
+#loader .loader-errors-list {
+    margin: 0;
+    padding: 0 8px 8px;
+    max-height: 160px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    line-height: 1.5;
+}
+
+/* Failed load state: red accent, FAILED readout, keep overlay visible */
+
+#loader.loader-failed {
+    --loader-accent: #e53935;
+}
+
+#loader.loader-failed .loader-bar-fill {
+    background-color: #e53935;
+}
+
+/* Terminal mode */
+
+#loader .loader-terminal {
+    display: none;
+    flex: 1 1 auto;
+    align-self: stretch;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    box-sizing: border-box;
+    flex-direction: column;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+#loader.loader-terminal-mode .loader-terminal {
+    display: flex;
+}
+
+#loader.loader-terminal-mode {
+    --loader-bg: #000;
+    --loader-fg: #33ff33;
+    --loader-accent: #33ff33;
+    align-items: stretch;
+    justify-content: flex-start;
+    padding: 24px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+#loader .loader-log {
+    flex: 1;
+    overflow-y: auto;
+    font-size: 13px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+#loader .loader-log-error {
+    color: #ff5555;
+}
+
+#loader .loader-terminal-progress {
+    margin-top: 12px;
+    font-size: 13px;
+    white-space: pre;
+}
+`;

--- a/src/classic/state.ts
+++ b/src/classic/state.ts
@@ -14,6 +14,14 @@ import {
     initBuffers,
     initTextures,
     initAnimations,
+    estimateManifestWeight,
+    slowSleep,
+    MANIFEST_WEIGHT,
+    SHADER_FETCH_WEIGHT,
+    SHADER_COMPILE_WEIGHT,
+    BUFFERS_WEIGHT,
+    TEXTURE_WEIGHT,
+    ANIMATIONS_WEIGHT,
 } from '/classic/utils.js';
 
 import type {
@@ -32,6 +40,7 @@ import type {
     CallName,
     CallFunction,
     StateData,
+    ProgressCallback,
 } from './types.js';
 
 // Type for the game state object
@@ -39,7 +48,7 @@ interface GameState extends IGameState {
     init(): void;
     getTexture(name: string): ITexture;
     download(url: string): void;
-    load(url: string): Promise<void>;
+    load(url: string, onProgress?: ProgressCallback): Promise<void>;
     registerCall(callName: CallName, entity: IEntity, fn: CallFunction): void;
     unregisterCall(callName: CallName, entity: IEntity, fn: CallFunction): void;
     performCall(callName: CallName): void;
@@ -49,7 +58,7 @@ interface GameState extends IGameState {
     destroyEntity(entity: IEntity): void;
     getGameObject(cmd: string | IComponent): IEntity | IComponent;
     resizeCanvas(): void;
-    loadResources(): Promise<void>;
+    loadResources(onProgress?: ProgressCallback): Promise<void>;
     launch(): void;
     draw(now: number): void;
     isMouseButtonDown(button: number): boolean;
@@ -207,13 +216,21 @@ const game: GameState = {
         URL.revokeObjectURL(link.href);
     },
 
-    async load(url: string) {
+    async load(url: string, onProgress?: ProgressCallback) {
+        const report = onProgress ?? (() => {});
+
+        report(`Fetching ${url}`, 0);
         const state = await fetchObject<StateData>(url);
         if (!state) {
             throw new Error(`Failed to load state from ${url}`);
         }
+        await slowSleep();
 
-        for (const entityName in state.entities) {
+        const entityNames = Object.keys(state.entities);
+        for (let i = 0; i < entityNames.length; i++) {
+            const entityName = entityNames[i];
+            report(`Spawning entity: ${entityName}`, (i + 1) / entityNames.length);
+
             const entity = state.entities[entityName];
             const instance = this.spawnEntity(entityName);
 
@@ -345,20 +362,47 @@ const game: GameState = {
         this.performCall('canvasResize');
     },
 
-    async loadResources() {
+    async loadResources(onProgress?: ProgressCallback) {
+        const report = onProgress ?? (() => {});
+
+        report('Fetching manifest', 0);
         const manifest = await fetchObject<Manifest>('/manifest.json');
         if (!manifest) {
             throw new Error('Failed to load manifest.json');
         }
         this.manifest = manifest;
+        await slowSleep();
 
-        this.shaders = await initShaders(this.gl, this.manifest.shaders);
+        const total = estimateManifestWeight(manifest);
+        let acc = MANIFEST_WEIGHT;
+        const reportPhase = (label: string) => report(label, acc / total);
 
+        reportPhase('Initializing shaders');
+        this.shaders = await initShaders(this.gl, this.manifest.shaders, (label, frac) =>
+            report(
+                label,
+                (acc +
+                    frac *
+                        (this.manifest.shaders.length *
+                            (SHADER_FETCH_WEIGHT + SHADER_COMPILE_WEIGHT))) /
+                    total,
+            ),
+        );
+        acc += this.manifest.shaders.length * (SHADER_FETCH_WEIGHT + SHADER_COMPILE_WEIGHT);
+
+        report('Initializing buffers', acc / total);
         this.buffers = initBuffers(this.gl);
+        acc += BUFFERS_WEIGHT;
 
-        this.textures = await initTextures(this.gl, this.manifest.textures);
+        report('Loading textures', acc / total);
+        this.textures = await initTextures(this.gl, this.manifest.textures, (label, frac) =>
+            report(label, (acc + frac * (this.manifest.textures.length * TEXTURE_WEIGHT)) / total),
+        );
+        acc += this.manifest.textures.length * TEXTURE_WEIGHT;
 
+        report('Building animations', acc / total);
         this.animations = initAnimations(this.manifest.animations);
+        acc += ANIMATIONS_WEIGHT;
     },
 
     launch() {

--- a/src/classic/types.ts
+++ b/src/classic/types.ts
@@ -254,6 +254,10 @@ export interface IUIManager {
 // Resource Manifest Types
 // ============================================================================
 
+/** Reports loading progress for a bounded phase; `fraction` is always 0..1
+ * for that phase's own scope. */
+export type ProgressCallback = (label: string, fraction: number) => void;
+
 export interface TextureManifestEntry {
     name: string;
     src: string;
@@ -360,7 +364,7 @@ export interface IGameState {
     init(): void;
     getTexture(name: string): ITexture;
     download(url: string): void;
-    load(url: string): Promise<void>;
+    load(url: string, onProgress?: ProgressCallback): Promise<void>;
     registerCall(callName: CallName, entity: IEntity, fn: CallFunction): void;
     unregisterCall(callName: CallName, entity: IEntity, fn: CallFunction): void;
     performCall(callName: CallName): void;
@@ -370,7 +374,7 @@ export interface IGameState {
     destroyEntity(entity: IEntity): void;
     getGameObject(cmd: string | IComponent): IEntity | IComponent;
     resizeCanvas(): void;
-    loadResources(): Promise<void>;
+    loadResources(onProgress?: ProgressCallback): Promise<void>;
     launch(): void;
     draw(now: number): void;
 

--- a/src/classic/utils.ts
+++ b/src/classic/utils.ts
@@ -9,6 +9,8 @@ import type {
     IBuffer,
     IAnimation,
     GameBuffers,
+    Manifest,
+    ProgressCallback,
 } from './types.js';
 
 // ============================================================================
@@ -91,16 +93,94 @@ export function loadImage(src: string): Promise<HTMLImageElement> {
 
 const loadingLabel = document.getElementById('loader');
 
+/**
+ * Optional sink for the loading screen. When a loader registers one (see
+ * src/classic/loader.ts), loader messages are routed through it instead of the
+ * bare #loader element, keeping the engine decoupled from the overlay.
+ */
+export interface LoaderSink {
+    error(message: string): void;
+    finish(): void;
+}
+
+let loaderSink: LoaderSink | null = null;
+
+export function setLoaderSink(sink: LoaderSink | null): void {
+    loaderSink = sink;
+}
+
 export function setLoaderLabel(msg: string): void {
+    if (loaderSink) {
+        loaderSink.error(msg);
+        return;
+    }
     if (loadingLabel) {
         loadingLabel.innerHTML = msg;
     }
 }
 
 export function deleteLoaderLabel(): void {
+    if (loaderSink) {
+        loaderSink.finish();
+        return;
+    }
     if (loadingLabel) {
         loadingLabel.remove();
     }
+}
+
+// ============================================================================
+// Slow-load test helper
+// ============================================================================
+
+/**
+ * Optional per-step delay applied during resource loading. Disabled by default;
+ * the demo's `?slow` load test (src/demo/loadTest.ts) switches it on so the
+ * loading bar crawl is easy to watch.
+ */
+let loadSleepMs = 0;
+
+export function setLoadSleepMs(ms: number): void {
+    loadSleepMs = Math.max(0, Math.floor(ms));
+}
+
+export function getLoadSleepMs(): number {
+    return loadSleepMs;
+}
+
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Delays the configured amount when the `?slow` load test is active. */
+export function slowSleep(): Promise<void> {
+    return loadSleepMs > 0 ? sleep(loadSleepMs) : Promise.resolve();
+}
+
+// ============================================================================
+// Load progress weighting
+// ============================================================================
+
+// Estimated effort of each load phase, in arbitrary weight units. These are
+// derived from the number of real operations (network fetches, GPU compiles)
+// each phase performs, and are combined with the manifest structure in
+// estimateManifestWeight to compute the total cost of loadResources().
+
+export const MANIFEST_WEIGHT = 2; // fetching manifest.json
+export const SHADER_FETCH_WEIGHT = 2; // vertex + fragment source fetches
+export const SHADER_COMPILE_WEIGHT = 1; // compile + link
+export const BUFFERS_WEIGHT = 1;
+export const TEXTURE_WEIGHT = 1; // image download + upload
+export const ANIMATIONS_WEIGHT = 1;
+
+export function estimateManifestWeight(manifest: Manifest): number {
+    return (
+        MANIFEST_WEIGHT +
+        manifest.shaders.length * (SHADER_FETCH_WEIGHT + SHADER_COMPILE_WEIGHT) +
+        BUFFERS_WEIGHT +
+        manifest.textures.length * TEXTURE_WEIGHT +
+        ANIMATIONS_WEIGHT
+    );
 }
 
 // ============================================================================
@@ -229,8 +309,17 @@ export class Shader implements IShader {
 export async function initShaders(
     gl: WebGLRenderingContext,
     shaderManifest: ShaderInfo[],
+    onProgress?: ProgressCallback,
 ): Promise<Record<string, Shader>> {
     const shaders: Record<string, Shader> = {};
+
+    const stepTotal = shaderManifest.length * (SHADER_FETCH_WEIGHT + SHADER_COMPILE_WEIGHT);
+    let stepDone = 0;
+    const report = (label: string) => {
+        if (onProgress) {
+            onProgress(label, stepDone / stepTotal);
+        }
+    };
 
     for (const shaderInfo of shaderManifest) {
         const name = shaderInfo.name;
@@ -244,8 +333,15 @@ export async function initShaders(
             shaderInfo.unif,
         );
 
+        report(`Fetching shader: ${name}`);
+        await slowSleep();
         await shaders[name].fetchCode();
+        stepDone += SHADER_FETCH_WEIGHT;
+
+        report(`Compiling shader: ${name}`);
+        await slowSleep();
         shaders[name].compile();
+        stepDone += SHADER_COMPILE_WEIGHT;
     }
 
     return shaders;
@@ -346,7 +442,10 @@ export async function loadTexture(
     const texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
 
-    const image = await loadImage(url);
+    const image = await loadImage(url).catch((err) => {
+        console.error('Failed to load texture:', url, err);
+        throw err;
+    });
 
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
 
@@ -386,12 +485,23 @@ export class Texture implements ITexture {
 export async function initTextures(
     gl: WebGLRenderingContext,
     textureManifest: TextureManifestEntry[],
+    onProgress?: ProgressCallback,
 ): Promise<Record<string, Texture>> {
     const textures: Record<string, Texture> = {};
 
+    let stepDone = 0;
+    const report = (label: string) => {
+        if (onProgress) {
+            onProgress(label, stepDone / textureManifest.length);
+        }
+    };
+
     for (const tex of textureManifest) {
         textures[tex.name] = new Texture(gl, tex.name, tex.src);
+        report(`Loading texture: ${tex.name}`);
+        await slowSleep();
         await textures[tex.name].load();
+        stepDone += 1;
     }
 
     return textures;

--- a/src/demo/init.ts
+++ b/src/demo/init.ts
@@ -13,42 +13,91 @@ import {
 } from './prefabs.js';
 import { initUI } from './uiPrefabs.js';
 import { initLighting } from '/classic/lighting.js';
+import { createLoader } from '/classic/loader.js';
+import type { LoaderController } from '/classic/loader.js';
+import { applyLoadTestParams } from './loadTest.js';
 
 import { isoToCartesian4 } from '/classic/utils.js';
 import { mat4, vec3 } from 'gl-matrix';
 
+// Fraction of the loading bar assigned to each phase of startup.
+const SLOTS = {
+    init: [0.0, 0.03],
+    resources: [0.03, 0.85],
+    state: [0.85, 0.97],
+    scene: [0.97, 1.0],
+} as const;
+
+const loader: LoaderController = createLoader({
+    exit: 'instant',
+    persistMode: true,
+    logoUrl: '/res/cool_snek.png',
+});
+
+// Optional manual-test knobs (?slow, ?fail=...) - see src/demo/loadTest.ts.
+const testOpts = applyLoadTestParams();
+const testParts: string[] = [];
+if (testOpts.sleepMs > 0) {
+    testParts.push(`slow ${testOpts.sleepMs}ms/step`);
+}
+if (testOpts.fail) {
+    testParts.push(`fail=${testOpts.fail}`);
+}
+if (testParts.length > 0) {
+    loader.note(`load test: ${testParts.join(' / ')}`);
+}
+
+// Maps a phase-local progress fraction (0..1) onto its global slot on the bar.
+function report(slotStart: number, slotSpan: number) {
+    return (label: string, fraction: number) =>
+        loader.setProgress(label, slotStart + fraction * slotSpan);
+}
+
 async function initContext(): Promise<void> {
-    window.game = game;
+    try {
+        window.game = game;
 
-    game.init();
-    await game.loadResources();
+        loader.setProgress('Initializing WebGL', SLOTS.init[0]);
+        game.init();
+        loader.setProgress('Initializing WebGL', SLOTS.init[1]);
 
-    await game.load('/state.json');
+        const [resStart, resEnd] = SLOTS.resources;
+        await game.loadResources(report(resStart, resEnd - resStart));
 
-    initCursor();
-    initCameraControllerWASD();
-    initTilemap();
-    initTilemapEditorLogic();
-    initNavMeshEditorLogic();
-    initHeightEditorLogic();
-    initAgent();
-    generateDemoSlopes();
-    initFootprintColliders();
+        const [stateStart, stateEnd] = SLOTS.state;
+        await game.load('/state.json', report(stateStart, stateEnd - stateStart));
 
-    initUI();
-    initLighting();
+        loader.setProgress('Building scene', SLOTS.scene[0]);
+        initCursor();
+        initCameraControllerWASD();
+        initTilemap();
+        initTilemapEditorLogic();
+        initNavMeshEditorLogic();
+        initHeightEditorLogic();
+        initAgent();
+        generateDemoSlopes();
+        initFootprintColliders();
 
-    game.showGrid = true;
+        initUI();
+        initLighting();
 
-    // Centre camera on demo slope area around tile (90, 85)
-    const isoToWorld = mat4.clone(isoToCartesian4);
-    mat4.scale(isoToWorld, isoToWorld, [45, 45, 1]);
-    const centre = vec3.fromValues(0, 0, 0);
-    vec3.transformMat4(centre, centre, isoToWorld);
-    game.camera.position[0] = centre[0];
-    game.camera.position[1] = centre[1];
+        game.showGrid = true;
 
-    game.launch();
+        // Centre camera on demo slope area around tile (90, 85)
+        const isoToWorld = mat4.clone(isoToCartesian4);
+        mat4.scale(isoToWorld, isoToWorld, [45, 45, 1]);
+        const centre = vec3.fromValues(0, 0, 0);
+        vec3.transformMat4(centre, centre, isoToWorld);
+        game.camera.position[0] = centre[0];
+        game.camera.position[1] = centre[1];
+
+        loader.setProgress('Building scene', SLOTS.scene[1]);
+
+        game.launch();
+    } catch (err) {
+        console.error('Failed to initialize classic-wgl:', err);
+        loader.fail(err instanceof Error ? (err.stack ?? err.message) : String(err));
+    }
 }
 
 window.addEventListener('load', initContext, false);

--- a/src/demo/loadTest.ts
+++ b/src/demo/loadTest.ts
@@ -1,0 +1,78 @@
+import { setLoadSleepMs } from '/classic/utils.js';
+import { appendConsoleEntry } from '/classic/consoleLog.js';
+
+/**
+ * Optional query-param test knobs for manually exercising the loading screen:
+ *
+ *   ?slow          slow each resource-loading step by DEFAULT_TEST_SLEEP_MS
+ *   ?slow=250      ... with a custom per-step delay (ms)
+ *   ?fail=shader   404 every /shaders/* fetch (real compile failure)
+ *   ?fail=manifest 404 /manifest.json
+ *   ?fail=state    404 /state.json
+ *
+ * `applyLoadTestParams()` is called from src/demo/init.ts before loading
+ * starts. What gets applied is recorded as console entries so it shows up in
+ * the terminal log and the copyable debug report.
+ */
+
+export const DEFAULT_TEST_SLEEP_MS = 400;
+
+export type LoadTestFailure = 'shader' | 'manifest' | 'state';
+
+export interface LoadTestOptions {
+    /** Per-step delay in ms; 0 disables the slow-down. */
+    sleepMs: number;
+    fail: LoadTestFailure | null;
+}
+
+const FAIL_URL_MAP: Record<LoadTestFailure, string> = {
+    shader: '/shaders/',
+    manifest: '/manifest.json',
+    state: '/state.json',
+};
+
+export function parseLoadTestParams(search: string): LoadTestOptions {
+    const params = new URLSearchParams(search);
+
+    let sleepMs = 0;
+    if (params.has('slow')) {
+        const raw = params.get('slow');
+        sleepMs =
+            raw !== null && raw !== ''
+                ? Math.max(0, Math.round(Number(raw)) || 0)
+                : DEFAULT_TEST_SLEEP_MS;
+    }
+
+    const failParam = params.get('fail');
+    const fail: LoadTestFailure | null =
+        failParam === 'shader' || failParam === 'manifest' || failParam === 'state'
+            ? failParam
+            : null;
+
+    return { sleepMs, fail };
+}
+
+export function applyLoadTestParams(search?: string): LoadTestOptions {
+    const opts = parseLoadTestParams(search ?? window.location.search);
+
+    if (opts.sleepMs > 0) {
+        setLoadSleepMs(opts.sleepMs);
+        appendConsoleEntry('info', [`Load test: slowing load to ${opts.sleepMs}ms per step`]);
+    }
+
+    if (opts.fail) {
+        const pattern = FAIL_URL_MAP[opts.fail];
+        const originalFetch = window.fetch.bind(window);
+        window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+            const url =
+                typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+            if (url.includes(pattern)) {
+                return Promise.resolve(new Response('', { status: 404, statusText: 'Not Found' }));
+            }
+            return originalFetch(input, init);
+        }) as typeof fetch;
+        appendConsoleEntry('info', [`Load test: requests matching "${pattern}" will fail (404)`]);
+    }
+
+    return opts;
+}

--- a/tests/classic/consoleLog.test.ts
+++ b/tests/classic/consoleLog.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    startConsoleCapture,
+    clearConsoleLog,
+    getConsoleLog,
+    getConsoleErrors,
+    appendConsoleEntry,
+    subscribeConsole,
+    formatConsoleArg,
+    buildDebugReport,
+    copyTextToClipboard,
+} from '/classic/consoleLog.js';
+import type { ConsoleEntry } from '/classic/consoleLog.js';
+
+startConsoleCapture();
+
+const originalNavigator = window.navigator;
+
+function stubNavigator(overrides: Record<string, unknown>): void {
+    const stub = { ...originalNavigator, ...overrides } as unknown as Navigator;
+    Object.defineProperty(globalThis, 'navigator', { value: stub, configurable: true });
+}
+
+function restoreNavigator(): void {
+    Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        configurable: true,
+    });
+}
+
+afterEach(() => {
+    restoreNavigator();
+    vi.restoreAllMocks();
+});
+
+describe('startConsoleCapture', () => {
+    beforeEach(() => {
+        clearConsoleLog();
+    });
+
+    it('records console messages with their level', () => {
+        console.error('boom');
+        console.log('hi');
+        const log = getConsoleLog();
+        expect(log).toContain('[error] boom');
+        expect(log).toContain('[log] hi');
+    });
+
+    it('is idempotent - a single call records a single entry', () => {
+        startConsoleCapture();
+        startConsoleCapture();
+        console.log('once');
+        const matches = getConsoleLog().match(/once/g);
+        expect(matches).toHaveLength(1);
+    });
+});
+
+describe('formatConsoleArg', () => {
+    it('renders primitives', () => {
+        expect(formatConsoleArg(null)).toBe('null');
+        expect(formatConsoleArg(undefined)).toBe('undefined');
+        expect(formatConsoleArg(42)).toBe('42');
+        expect(formatConsoleArg('str')).toBe('str');
+        expect(formatConsoleArg(true)).toBe('true');
+    });
+
+    it('stringifies objects without crashing on circular refs', () => {
+        const obj: Record<string, unknown> = { name: 'circle' };
+        obj.self = obj;
+        const out = formatConsoleArg(obj);
+        expect(out).toContain('circle');
+        expect(out).toContain('[Circular]');
+    });
+
+    it('uses the error stack when available', () => {
+        const err = new Error('nope');
+        const out = formatConsoleArg(err);
+        expect(out).toContain('nope');
+    });
+});
+
+describe('appendConsoleEntry', () => {
+    it('records an entry directly', () => {
+        clearConsoleLog();
+        appendConsoleEntry('error', ['manual message']);
+        expect(getConsoleLog()).toContain('[error] manual message');
+    });
+});
+
+describe('subscribeConsole', () => {
+    it('notifies subscribers with new entries and stops on unsubscribe', () => {
+        const received: ConsoleEntry[] = [];
+        const unsubscribe = subscribeConsole((entry) => received.push(entry));
+        clearConsoleLog();
+
+        appendConsoleEntry('warn', ['hello sub']);
+        expect(received).toHaveLength(1);
+        expect(received[0].text).toContain('hello sub');
+
+        unsubscribe();
+        appendConsoleEntry('error', ['after unsubscribe']);
+        expect(received).toHaveLength(1);
+    });
+});
+
+describe('getConsoleErrors', () => {
+    it('filters to error and warn entries', () => {
+        clearConsoleLog();
+        appendConsoleEntry('log', ['ignored log line']);
+        appendConsoleEntry('error', ['b']);
+        appendConsoleEntry('warn', ['c']);
+        const errors = getConsoleErrors().join('\n');
+        expect(errors).toContain('b');
+        expect(errors).toContain('c');
+        expect(errors).not.toContain('ignored log line');
+    });
+});
+
+describe('buildDebugReport', () => {
+    it('includes the header, load meta and console log', () => {
+        clearConsoleLog();
+        appendConsoleEntry('log', ['line1']);
+
+        const report = buildDebugReport({
+            status: 'failed',
+            step: 'Loading textures',
+            progress: 0.4,
+            elapsedMs: 5000,
+        });
+
+        expect(report).toContain('classic-wgl');
+        expect(report).toContain('Load status: failed');
+        expect(report).toContain('Current step: Loading textures');
+        expect(report).toContain('40%');
+        expect(report).toContain('5.0s');
+        expect(report).toContain('line1');
+    });
+});
+
+describe('copyTextToClipboard', () => {
+    it('uses the async clipboard API when available', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        stubNavigator({ clipboard: { writeText } });
+
+        await expect(copyTextToClipboard('payload')).resolves.toBe(true);
+        expect(writeText).toHaveBeenCalledWith('payload');
+    });
+
+    it('falls back to execCommand when the clipboard API is unavailable', async () => {
+        stubNavigator({});
+        Object.defineProperty(document, 'execCommand', {
+            value: () => true,
+            configurable: true,
+        });
+        const execCommand = vi.spyOn(document, 'execCommand').mockReturnValue(true);
+
+        await expect(copyTextToClipboard('payload')).resolves.toBe(true);
+        expect(execCommand).toHaveBeenCalled();
+    });
+});

--- a/tests/classic/loader.test.ts
+++ b/tests/classic/loader.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    isLoaderMode,
+    readLoaderMode,
+    writeLoaderMode,
+    createLoader,
+    LOADER_STORAGE_KEY,
+    STALL_TIMEOUT_MS,
+} from '/classic/loader.js';
+import { clearConsoleLog, getConsoleLog } from '/classic/consoleLog.js';
+
+describe('isLoaderMode', () => {
+    it('accepts the two known modes', () => {
+        expect(isLoaderMode('visual')).toBe(true);
+        expect(isLoaderMode('terminal')).toBe(true);
+    });
+
+    it('rejects unknown values', () => {
+        expect(isLoaderMode('dev')).toBe(false);
+        expect(isLoaderMode(null)).toBe(false);
+        expect(isLoaderMode(undefined)).toBe(false);
+    });
+});
+
+describe('readLoaderMode / writeLoaderMode', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    it('defaults to visual when nothing is stored', () => {
+        expect(readLoaderMode()).toBe('visual');
+    });
+
+    it('round-trips a stored mode', () => {
+        writeLoaderMode('terminal');
+        expect(readLoaderMode()).toBe('terminal');
+
+        writeLoaderMode('visual');
+        expect(readLoaderMode()).toBe('visual');
+    });
+
+    it('falls back to visual for invalid stored values', () => {
+        window.localStorage.setItem(LOADER_STORAGE_KEY, 'dev');
+        expect(readLoaderMode()).toBe('visual');
+    });
+});
+
+describe('createLoader', () => {
+    let root: HTMLElement;
+
+    beforeEach(() => {
+        document.getElementById('loader')?.remove();
+        root = document.createElement('div');
+        root.id = 'loader';
+        document.body.appendChild(root);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it('builds the overlay around the #loader element', () => {
+        const loader = createLoader();
+        expect(root.classList.contains('loader-overlay')).toBe(true);
+        expect(root.querySelector('.loader-toggle')).not.toBeNull();
+        expect(root.querySelector('.loader-copy')).not.toBeNull();
+        expect(root.querySelector('.loader-bar-fill')).not.toBeNull();
+        expect(root.querySelector('.loader-log')).not.toBeNull();
+        expect(root.querySelector('.loader-errors')).not.toBeNull();
+        loader.finish();
+    });
+
+    it('reflects progress in the bar fill', () => {
+        const loader = createLoader();
+        const fill = root.querySelector('.loader-bar-fill') as HTMLElement;
+        loader.setProgress('Loading texture: t', 0.5);
+        expect(fill.style.width).toBe('50%');
+        loader.finish();
+    });
+
+    it('surfaces errors in the label', () => {
+        const loader = createLoader();
+        const label = root.querySelector('.loader-label') as HTMLElement;
+        loader.error('Failed to create shader');
+        expect(label.classList.contains('loader-label-error')).toBe(true);
+        expect(label.textContent).toBe('Failed to create shader');
+        loader.finish();
+    });
+
+    it('fail() shows the failed state, records the message and keeps the overlay', () => {
+        const loader = createLoader();
+        clearConsoleLog();
+        loader.fail('Failed to load manifest.json');
+
+        expect(root.classList.contains('loader-failed')).toBe(true);
+        expect(root.classList.contains('loader-hidden')).toBe(false);
+        expect(root.classList.contains('loader-show-errors')).toBe(true);
+
+        const label = root.querySelector('.loader-label') as HTMLElement;
+        expect(label.textContent).toBe('Failed to load manifest.json');
+        expect(getConsoleLog()).toContain('Failed to load manifest.json');
+
+        const pct = root.querySelector('.loader-pct') as HTMLElement;
+        expect(pct.textContent).toBe('FAILED');
+        loader.finish();
+    });
+
+    it('emits a stall warning after the timeout without progress', () => {
+        vi.useFakeTimers();
+        const loader = createLoader();
+        clearConsoleLog();
+        loader.setProgress('Fetching manifest', 0);
+
+        vi.advanceTimersByTime(STALL_TIMEOUT_MS + 1000);
+
+        expect(getConsoleLog()).toContain('stalled');
+        expect(getConsoleLog()).toContain('Fetching manifest');
+        loader.finish();
+    });
+
+    it('finish() with exit: "instant" removes the overlay immediately', () => {
+        const loader = createLoader({ exit: 'instant' });
+        expect(root.isConnected).toBe(true);
+        loader.finish();
+        expect(root.isConnected).toBe(false);
+    });
+
+    it('finish() with the default fade exit hides the overlay but keeps it until the transition ends', () => {
+        const loader = createLoader();
+        loader.finish();
+        expect(root.isConnected).toBe(true);
+        expect(root.classList.contains('loader-hidden')).toBe(true);
+    });
+
+    it('renders a load-test note', () => {
+        const loader = createLoader();
+        const note = root.querySelector('.loader-note') as HTMLElement;
+        expect(note).not.toBeNull();
+        loader.note('load test: slow 400ms/step / fail=shader');
+        expect(note.textContent).toBe('load test: slow 400ms/step / fail=shader');
+        expect(note.hidden).toBe(false);
+        loader.note('');
+        expect(note.hidden).toBe(true);
+        loader.finish();
+    });
+
+    it('copy button copies the debug report to the clipboard', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(globalThis, 'navigator', {
+            value: { ...navigator, clipboard: { writeText } },
+            configurable: true,
+        });
+
+        const loader = createLoader();
+        clearConsoleLog();
+        loader.setProgress('Loading textures', 0.5);
+
+        const copyBtn = root.querySelector('.loader-copy') as HTMLButtonElement;
+        expect(copyBtn).not.toBeNull();
+        copyBtn.click();
+
+        await vi.waitFor(() => expect(writeText).toHaveBeenCalled());
+        const text = writeText.mock.calls[0][0] as string;
+        expect(text).toContain('classic-wgl');
+        expect(text).toContain('console log');
+        expect(text).toContain('Loading textures');
+        loader.finish();
+    });
+});

--- a/tests/classic/utils.test.ts
+++ b/tests/classic/utils.test.ts
@@ -9,7 +9,9 @@ import {
     getNoiseRange,
     degreeToRadian,
     radianToDegree,
+    estimateManifestWeight,
 } from '/classic/utils.js';
+import type { Manifest } from '/classic/types.js';
 
 describe('getObjectValues', () => {
     it('returns the values of a plain object', () => {
@@ -102,5 +104,35 @@ describe('getNoiseRange', () => {
                 expect(v).toBeLessThanOrEqual(to);
             }
         }
+    });
+});
+
+describe('estimateManifestWeight', () => {
+    const shader = {
+        name: 'solid',
+        vertex: '/shaders/a.vert',
+        fragment: '/shaders/a.frag',
+        attr: [],
+        unif: [],
+    };
+    const texture = { name: 't', src: '/res/t.png' };
+
+    it('counts each shader as fetch (2) plus compile (1)', () => {
+        const manifest = { shaders: [shader, shader], textures: [], animations: [] } as Manifest;
+        expect(estimateManifestWeight(manifest)).toBe(2 + 2 * 3 + 1 + 0 + 1);
+    });
+
+    it('counts each texture as one unit', () => {
+        const manifest = {
+            shaders: [],
+            textures: [texture, texture, texture],
+            animations: [],
+        } as Manifest;
+        expect(estimateManifestWeight(manifest)).toBe(2 + 0 + 1 + 3 * 1 + 1);
+    });
+
+    it('accounts for manifest, buffers and animations overhead', () => {
+        const manifest = { shaders: [], textures: [], animations: [] } as Manifest;
+        expect(estimateManifestWeight(manifest)).toBe(2 + 0 + 1 + 0 + 1);
     });
 });

--- a/tests/demo/loadTest.test.ts
+++ b/tests/demo/loadTest.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { parseLoadTestParams, applyLoadTestParams, DEFAULT_TEST_SLEEP_MS } from '/demo/loadTest.js';
+import { startConsoleCapture, clearConsoleLog, getConsoleLog } from '/classic/consoleLog.js';
+import { getLoadSleepMs, setLoadSleepMs } from '/classic/utils.js';
+
+startConsoleCapture();
+
+describe('parseLoadTestParams', () => {
+    it('returns disabled options for an empty query', () => {
+        expect(parseLoadTestParams('')).toEqual({ sleepMs: 0, fail: null });
+    });
+
+    it('enables the default slow-down with ?slow', () => {
+        expect(parseLoadTestParams('?slow')).toEqual({
+            sleepMs: DEFAULT_TEST_SLEEP_MS,
+            fail: null,
+        });
+    });
+
+    it('honours a custom delay with ?slow=<ms>', () => {
+        expect(parseLoadTestParams('?slow=250')).toEqual({ sleepMs: 250, fail: null });
+        expect(parseLoadTestParams('?slow=0')).toEqual({ sleepMs: 0, fail: null });
+        expect(parseLoadTestParams('?slow=abc')).toEqual({ sleepMs: 0, fail: null });
+    });
+
+    it('parses the fail mode', () => {
+        expect(parseLoadTestParams('?fail=shader')).toEqual({ sleepMs: 0, fail: 'shader' });
+        expect(parseLoadTestParams('?fail=manifest')).toEqual({ sleepMs: 0, fail: 'manifest' });
+        expect(parseLoadTestParams('?fail=state')).toEqual({ sleepMs: 0, fail: 'state' });
+        expect(parseLoadTestParams('?fail=bogus')).toEqual({ sleepMs: 0, fail: null });
+    });
+
+    it('combines slow and fail', () => {
+        expect(parseLoadTestParams('?slow=150&fail=state')).toEqual({
+            sleepMs: 150,
+            fail: 'state',
+        });
+    });
+});
+
+describe('applyLoadTestParams', () => {
+    let realFetch: typeof fetch | undefined;
+
+    beforeEach(() => {
+        clearConsoleLog();
+        setLoadSleepMs(0);
+        realFetch = window.fetch;
+        vi.unstubAllGlobals();
+    });
+
+    afterEach(() => {
+        window.fetch = realFetch as typeof fetch;
+        vi.unstubAllGlobals();
+    });
+
+    it('turns on the slow-down and logs what it applied', () => {
+        const opts = applyLoadTestParams('?slow=200');
+        expect(opts).toEqual({ sleepMs: 200, fail: null });
+        expect(getLoadSleepMs()).toBe(200);
+        expect(getConsoleLog()).toContain('Load test: slowing load to 200ms per step');
+    });
+
+    it('patches fetch to 404 matching URLs when ?fail= is present', async () => {
+        const original = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+        vi.stubGlobal('fetch', original);
+
+        const opts = applyLoadTestParams('?fail=shader');
+        expect(opts.fail).toBe('shader');
+
+        const failed = await window.fetch('/shaders/solid.vert');
+        expect(failed.status).toBe(404);
+        expect(original).not.toHaveBeenCalled();
+
+        const passed = await window.fetch('/manifest.json');
+        expect(passed.status).toBe(200);
+        expect(original).toHaveBeenCalledWith('/manifest.json', undefined);
+        expect(getConsoleLog()).toContain('requests matching "/shaders/"');
+    });
+
+    it('leaves unrelated requests untouched', async () => {
+        const original = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+        vi.stubGlobal('fetch', original);
+
+        applyLoadTestParams('?fail=manifest');
+
+        const res = await window.fetch('/res/cool_snek.png');
+        expect(res.status).toBe(200);
+        expect(original).toHaveBeenCalledTimes(1);
+    });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,8 @@ export default defineConfig({
                 'src/classic/collision.ts',
                 'src/classic/utils.ts',
                 'src/classic/registry.ts',
+                'src/classic/loader.ts',
+                'src/classic/consoleLog.ts',
             ],
         },
     },


### PR DESCRIPTION
<!-- pr-msg-meta
branch: loader-screen
base: master
submitted:
  github: ___
-->

## Add loading screen with load progress and debug log

### Motivation

The demo page used to show a bare `LOADING...` label until the
engine was ready, and the engine reported no progress along the
way. This change wires weighted load progress through the engine
and turns the loading screen into a small code-defined library
API so other pages can drop it in with one call.

### Summary of changes

- Add weighted progress reporting to `load()` / `loadResources()`
  and route loader messages through an optional `LoaderSink`,
  keeping the engine decoupled from any overlay.
- Add a code-defined `createLoader()` to the library with
  visual/terminal modes, fade or instant exit, a stall watchdog
  and a copyable debug report of captured console output.
- Inject loader styles at runtime so consumers don't need to wire
  up a stylesheet; the demo keeps its localStorage mode toggle.
- Add `?slow` / `?fail=` load-test knobs for exercising the
  loading screen manually in `npm run dev`.

### Scopes changed

- `classic.loader` — moved from `demo.loader`; now a library API
  with options, exit modes and injected styles.
- `classic.consoleLog` — moved from `demo.consoleLog`; console
  capture and debug-report helpers.
- `classic.loaderStyles` — new; runtime-injected CSS string.
- `classic.{types,state,utils}` — `ProgressCallback`, phase
  weights, `LoaderSink`, default-off `slowSleep()`.
- `demo.{init,loadTest}` — demo wiring and load-test knobs.
- `tests.{classic,demo}` — moved and new loader tests.

### Future follow up

- [ ] Add npm packaging (exports map + library build) so external
  pages can install `classic-wgl` and use `createLoader()` from
  `node_modules`; `package.json` `main` is a placeholder `index.js`
  today.

---

(this pr content was generated in some part by `opencode` using `deepseek-v4-flash-free` (`opencode`))
