### PR TITLE
Add `SdfText` renderer with build-time atlas and word-wrap UI

### DIFF
--- a/.claude/skills/classic-gl-state/SKILL.md
+++ b/.claude/skills/classic-gl-state/SKILL.md
@@ -166,6 +166,69 @@ by a normal pass (LEQUAL, depthMask=false — sprites don't write depth so
 sprite-sprite ordering is by renderList sort). The depth state is reset at
 frame start, so per-sprite state changes don't accumulate across frames.
 
+### `bindAttribLocation` before `linkProgram` (AMD driver workaround)
+
+AMD drivers (especially Radeon R9 200 series) may drop attribute locations
+at link time if the linker determines they're unused — even when the
+attribute is read by a varying that the fragment shader consumes. This
+returns `getAttribLocation` as `-1` and causes `vTexCoord` to be `(0,0)`
+in every fragment.
+
+**Fix:** call `gl.bindAttribLocation(program, index, name)` for every
+attribute in the manifest BEFORE `gl.linkProgram()`:
+
+```typescript
+for (let i = 0; i < attributes.length; i++) {
+    gl.bindAttribLocation(shaderProgram, i, attributes[i]);
+}
+gl.linkProgram(shaderProgram);
+```
+
+This is applied in `initShaderProgram()` in `src/classic/utils.ts`.
+
+### Sampler uniform ↔ texture unit binding order
+
+When binding a sampler uniform:
+
+```typescript
+gl.activeTexture(gl.TEXTURE0);
+gl.bindTexture(gl.TEXTURE_2D, texture);   // texture FIRST
+gl.uniform1i(samplerLoc, 0);              // sampler SECOND
+```
+
+Some drivers silently ignore a sampler assignment if the texture isn't
+already on the target unit when `uniform1i` is called. The `SdfText.rawDraw()`
+method uses this order.
+
+### SDF texture filtering override
+
+The engine's `loadTexture()` sets `gl.NEAREST` min/mag filters on all
+textures. SDF font atlases MUST use `gl.LINEAR` for `smoothstep` to produce
+anti-aliased edges. The `SdfText` constructor overrides the filter after
+retrieving the texture:
+
+```typescript
+this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture.texture);
+this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
+this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
+```
+
+### Interleaved vertex buffer for text
+
+`SdfText` uses an interleaved buffer: `[posX, posY, uvX, uvY]` per vertex,
+6 vertices per quad, stride = 16 bytes. The attribute pointers for the
+`Sdf` shader (which expects `vertexPos` at location 0 and `texCoord` at
+location 1) are:
+
+```typescript
+gl.vertexAttribPointer(shader.attr.vertexPos, 2, gl.FLOAT, false, 16, 0);
+gl.vertexAttribPointer(shader.attr.texCoord, 2, gl.FLOAT, false, 16, 8);
+```
+
+When binding this buffer to the `solid` shader (which only has `vertexPos`
+at location 0), use the same stride and offset — the solid shader ignores
+the UV data that follows each position pair.
+
 ---
 
 ## 5. DEBUGGING STATE LEAKS

--- a/.claude/skills/classic-sdf-text/SKILL.md
+++ b/.claude/skills/classic-sdf-text/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: classic-sdf-text
+description: >
+    Signed Distance Field (SDF) font rendering system for classic-wgl.
+    Covers `SdfText` (base direct-GL renderer) and `UISdfText` (word-wrap,
+    justification, outline, shadow, multi-line). Includes the build-time
+    atlas generator, coordinate system conventions, GL requirements,
+    manifest integration, and common pitfalls. Trigger phrases: "SDF
+    text", "SdfText", "UISdfText", "font rendering", "sdf.frag", "sdfText",
+    "atlas generator", "make-font-atlas", "setOutline", "setShadow",
+    "setJustify", "spawnSdfText", "dejavusans", "wrapTextAtPixelWidth",
+    "glyph metrics".
+---
+
+# classic-wgl SDF Font Rendering
+
+## 1. ARCHITECTURE
+
+```
+Drawable (transforms.ts)
+  └─ SdfText (sdfText.ts)              direct vertex-buffer rendering; no FBO
+       └─ UISdfText (ui.ts)            word-wrap, justification, multi-line
+```
+
+`SdfText` renders each glyph as a textured quad from a pre-generated SDF atlas.
+It builds an interleaved `Float32Array` vertex buffer (position + UV per vertex,
+6 vertices per glyph) and issues one `drawArrays(gl.TRIANGLES)` call per text
+string per frame (plus an optional second pass for drop-shadow).
+
+`UISdfText` extends `SdfText` with word-wrapping (pixel-width driven, not
+character-count), explicit `\n` line breaks, and per-line justification
+(`left` / `center` / `right`).
+
+All data (metrics + atlas texture) is loaded synchronously during
+`loadResources()` — no runtime `fetch`.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `scripts/make-font-atlas.mjs` | Build-time SDF atlas + metrics JSON generator |
+| `src/classic/sdfText.ts` | `SdfText` class: glyph layout, vertex buffer, rawDraw |
+| `src/classic/ui.ts` (UISdfText) | `UISdfText` class: word-wrap, justify, multi-line |
+| `src/shaders/sdf.vert` | Vertex shader: `texCoord` varying passthrough |
+| `src/shaders/sdf.frag` | Fragment shader: `smoothstep` + outline + shadow |
+| `src/classic/utils.ts` | `initSdfFonts()` — loads metrics JSON at startup |
+| `src/classic/state.ts` | `game.sdfFonts`, `game.getSdfFont()` |
+| `public/manifest.json` | `"sdfFonts": [{ "name": "...", "metrics": "..." }]` |
+
+---
+
+## 2. BUILD-TIME ATLAS GENERATOR
+
+`scripts/make-font-atlas.mjs` uses `@napi-rs/canvas` (devDependency only) to
+rasterise a `.ttf`/`.otf` file and produce a grayscale SDF texture atlas.
+
+### Key constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `GLYPH_SIZE` | 64 | Target cell size in output pixels |
+| `RENDER_SCALE` | 16 | High-res render multiplier |
+| `SOURCE_W` | `HIGH_RES + padding*2` = 3072 | Source canvas pixel dimensions |
+| `CELL_SCALE` | `SOURCE_W / GLYPH_SIZE` = 48 | Source pixels per output cell pixel |
+| `ORIGIN_CELL` | `padding / CELL_SCALE` ≈ 21.33 | Font baseline in cell-pixel coordinates |
+| `maxDist` | `GLYPH_SIZE` = 64 | SDF distance-field spread (in source pixels) |
+
+### Algorithm
+
+1. Render each glyph at `fontSize * RENDER_SCALE` px, `textBaseline='alphabetic'`, `textAlign='left'`
+2. Compute SDF: detect edges (inside→outside transitions), brute-force Manhattan distances, normalize to `[0..255]` with `maxDist` spread
+3. Crop to bounding box of non-background pixels (`byte ≠ 1`)
+4. Shelf-pack cropped glyphs into power-of-two atlas (typically 256×256)
+5. Output `public/res/<font>-sdf.png` + `public/res/<font>-sdf.json`
+
+### Metrics JSON format
+
+```json
+{
+  "name": "dejavusans",
+  "family": "DejaVuSans",
+  "atlasSize": [256, 256],
+  "glyphSize": 64,
+  "baseline": 19.968,
+  "lineHeight": 33.28,
+  "glyphs": {
+    "A": { "x": 232, "y": 0, "w": 20, "h": 22, "xOffset": -1.33, "yOffset": -20.33, "xAdvance": 17.51 }
+  }
+}
+```
+
+All numeric quantities are in **cell pixels** — the universal unit for SDF
+text metrics. One cell pixel = one pixel in the original 64×64 SDF output grid.
+
+---
+
+## 3. COORDINATE SYSTEM
+
+Everything is in **cell pixels**, multiplied by `_scale` to get screen pixels.
+
+| Quantity | Computation |
+|---|---|
+| Glyph top in local coords | `gy = baseline * scale + yOffset * scale` |
+| Glyph bottom | `gy + h * scale` |
+| Line offset (multi-line) | `gy += lineIndex * lineHeight * scale` |
+| Text block extent | `min(gy)` to `max(gy + h*scale)` across all glyphs |
+| `textHeight` | `glyphExtentMax - glyphExtentMin` (not `lineHeight * scale`!) |
+| `textWidth` | Max line advance from `xAdvance * scale` sums |
+
+**Critical:** `textHeight` must reflect the glyph *extent*, not the line box.
+The extent is recomputed immediately after the perLine collection loop
+(before the vertex buffer build) so that both the vertex local coordinates
+and `modelMatrix()` use the same value. If `textHeight` is changed *after*
+the vertex loop, the coordinates mismatch and glyphs appear squashed.
+
+Local → screen transform via `modelMatrix()`:
+```typescript
+translate(position) * scale(textWidth, textHeight, 1)
+```
+
+Positioned by the UI anchor system (e.g., `mid-center`) just like any `UIDrawable`.
+
+### UV mapping
+
+```typescript
+ux0 = g.x / atlasW;          // left edge of glyph in atlas
+ux1 = (g.x + g.w) / atlasW;  // right edge
+uy0 = g.y / atlasH;          // top edge — NO "1 -" inversion
+uy1 = (g.y + g.h) / atlasH;
+```
+
+**Do NOT use `1 - g.y/atlasH`.** This engine does not set
+`UNPACK_FLIP_Y_WEBGL`; `texImage2D` puts image row 0 at texture t=0.
+The engine's own `sheet.frag` shader follows the same convention.
+
+---
+
+## 4. SHADERS
+
+### Vertex (`sdf.vert`)
+
+```glsl
+attribute vec4 vertexPos;     // location 0 (bound before linkProgram!)
+attribute vec2 texCoord;      // location 1
+varying mediump vec2 vTexCoord;
+// standard model * camera * projection transform
+```
+
+### Fragment (`sdf.frag`)
+
+```glsl
+float distance = texture2D(texSampler, vTexCoord).r;
+float edge = 0.5;
+float alpha = smoothstep(edge - softEdge, edge + softEdge, distance);
+// Outline: smoothstep in band [edge - outlineWidth, edge]
+// Shadow: second drawPass with offset model matrix + blurred outline
+```
+
+`softEdge = 0.08` is a good fixed value for the 64-px `GLYPH_SIZE`.
+
+---
+
+## 5. GL REQUIREMENTS
+
+### `bindAttribLocation` before `linkProgram`
+
+In `initShaderProgram()` (`src/classic/utils.ts`), call
+`gl.bindAttribLocation(program, i, attributes[i])` **before**
+`gl.linkProgram()`. AMD drivers (notably Radeon R9 200) may drop attribute
+locations that appear unused to the linker, returning `getAttribLocation`
+as `-1`. This causes `vTexCoord` to be `(0,0)`, making `texture2D` sample
+the origin of the atlas (usually black).
+
+### Sampler binding order
+
+```typescript
+gl.activeTexture(gl.TEXTURE0);
+gl.bindTexture(gl.TEXTURE_2D, atlasTexture.texture);
+gl.uniform1i(shader.unif.texSampler, 0);  // AFTER texture is bound
+```
+
+Some drivers silently ignore a sampler if the texture isn't on the unit
+when `uniform1i` is called.
+
+### LINEAR filtering on SDF atlas texture
+
+The atlas texture must use `gl.LINEAR` (min + mag) for `smoothstep` to
+produce anti-aliased edges. The engine's default `initTextures()` sets
+`gl.NEAREST`, so `SdfText`'s constructor overrides this:
+
+```typescript
+this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture.texture);
+this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
+this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
+```
+
+### Interleaved vertex buffer
+
+Format: `[posX, posY, uvX, uvY]` per vertex, 6 vertices per glyph,
+stride = 16 (4 floats × 4 bytes). Attribute pointers:
+
+```typescript
+gl.vertexAttribPointer(attr.vertexPos, 2, gl.FLOAT, false, 16, 0);
+gl.vertexAttribPointer(attr.texCoord, 2, gl.FLOAT, false, 16, 8);
+```
+
+---
+
+## 6. MANIFEST INTEGRATION
+
+Font metrics are loaded synchronously during `loadResources()`, matching
+the engine pattern for shaders/textures/animations.
+
+```json
+// public/manifest.json
+{
+  "sdfFonts": [
+    { "name": "dejavusans", "metrics": "/res/dejavusans-sdf.json" }
+  ],
+  "textures": [
+    { "name": "dejavusans-sdf", "src": "/res/dejavusans-sdf.png" }
+  ]
+}
+```
+
+```typescript
+// Loaded in state.ts loadResources():
+this.sdfFonts = await initSdfFonts(this.manifest.sdfFonts || [], ...);
+
+// Accessed synchronously in SdfText constructor:
+this.metrics = this.game.getSdfFont(atlasName);
+```
+
+No runtime `fetch`, no `metricsPromise`, no `async` code path. If the JSON
+fails to load, `loadResources()` throws before the game starts.
+
+---
+
+## 7. UISdfText FEATURES
+
+### Word wrapping
+
+`UISdfText.wrapTextAtPixelWidth()`:
+
+- Splits on `\n` first (hard line breaks)
+- Within each segment, word-wraps on spaces
+- Measures each word's pixel width via `measureWord()` (sums per-glyph `xAdvance * scale`)
+- Pushes words to successive lines when `linePx + gap + wordPx > maxPx`
+
+The `maxWidth` argument to `spawnSdfText()` is in **screen pixels** (not
+character count — unlike the legacy `UIText`).
+
+### Multi-line support
+
+`_buildGlyphBuffer` tracks a `lineIndex` counter. Each glyph's `y` field
+in `perLine` stores its line index. The Y offset is computed as:
+
+```typescript
+gy = baseline * scale + yOffset * scale + lineIndex * lineHeight * scale;
+```
+
+`textHeight` accounts for the line count: `textHeight = maxExtent * lineCount`.
+
+### Justification
+
+```typescript
+infoText.setJustify('center');  // 'left' (default) | 'center' | 'right'
+```
+
+Per-line: computes `lineWidth = sum(advances)` for each line, then shifts
+glyph `x` positions by `(maxWidth - lineWidth) / 2` (center) or
+`(maxWidth - lineWidth)` (right).
+
+### Scale conversion from legacy UIText
+
+`UIText` uses a 32px glyph grid. `UISdfText` uses cell-pixel metrics (~18–25
+cell px per character). To get equivalent visual size, multiply the legacy
+scale by approximately **2.5**:
+
+```typescript
+// UIText at scale 0.5 ≈ UISdfText at scale 1.25
+// UIText at scale 0.4 ≈ UISdfText at scale 1.0
+```
+
+### `spawnButton` with SDF text
+
+```typescript
+UI.spawnButton(w, h, color, onClick, {
+    sdfText: true,
+    text: 'Label',
+    textScale: 0.4 * _uiScale,  // legacy scale — auto-converted ×2.5
+});
+```
+
+The `sdfText` option causes `spawnButton` to create a `UISdfText` child
+instead of `UIText`, with internal scale multiplication.
+
+### Outline and shadow
+
+```typescript
+title.setOutline(0.12, [0.1, 0.05, 0, 1]);   // width in SDF units, RGBA color
+title.setShadow(2, 3, [0, 0, 0, 0.5], 1);      // offsetX, offsetY, color, blur
+```
+
+Outline renders as a band around the edge in the fragment shader. Shadow
+is a second `drawPass` with an offset model matrix and wider outline blur.
+
+---
+
+## 8. COMMON PITFALLS
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| **No text visible, magenta rect appears** | SDF pipeline broken; green quads with solid shader confirm vertex pipeline | Proceed to shader/texture diagnostics |
+| **No text, green solid quads visible** | Fragment shader outputs transparent; check texCoord attribute location | `bindAttribLocation` before `linkProgram`; check `shader.attr.texCoord >= 0` |
+| **All black quads** | `texture2D` returns 0 | Atlas UVs sample empty background: verify UV range maps to glyph data region; check for `1 - g.y/atlasH` inversion bug |
+| **VertexCount = 0 after construction** | Metrics not loaded | Ensure `game.getSdfFont(name)` is available synchronously; `initSdfFonts` runs in `loadResources()` |
+| **Text squashed vertically** | `textHeight` changed after vertex loop | Compute glyph extent *before* building vertex data, not after |
+| **Glyphs rendered upside-down** | UV Y-axis inverted | Use `g.y/atlasH` (no `1 -`); this engine uses `texImage2D` without `UNPACK_FLIP_Y` |
+| **Glyphs on one pixel row** | `lineIndex` not applied | `gy += lineIndex * lineHeight * scale` in `_buildGlyphBuffer` |
+| **Text rendered ~3× too small** | Unit mismatch: old font-size units vs new cell-pixel units | Multiply scale by ~2.5 when migrating from `UIText` |
+| **Lines overlap (no vertical offset)** | `pg.y` stored but ignored | `gy` must include `pg.y * lineHeight * scale` |
+| **Justification has no effect** | Justify block runs before perLine is fully collected | Place justify block after the `\n`/char loop, before `textWidth` assignment |
+| **Atlas has all values = 1** | `maxDist` too large relative to glyph size | Use `maxDist = GLYPH_SIZE` (64), not canvas half-diagonal |
+| **Atlas has no glyph data** | BBox detection threshold wrong | Check `findBbox` — look for `byte ≠ 1` (not `byte > 128`) |
+| **Title clipped at top of screen** | `textHeight` too large, `gy` negative | Compute `textHeight` from glyph extent, not `lineHeight`; fix anchor to `mid-center` |
+
+---
+
+## 9. DEBUGGING PIPELINE
+
+Systematically isolate each stage:
+
+1. **Check `vertexCount`**: `console.log` in `rawDraw` — if 0, text was never built
+2. **Check attribute locations**: `shader.attr.texCoord` should be ≥ 0 (not -1)
+3. **Swap to solid shader with glyph buffer**: green quads → vertex pipeline works
+4. **Swap to solid shader with full-bounds quad**: confirms `modelMatrix()` is correct
+5. **Hardcode fragment output to solid color**: confirms fragment shader executes
+6. **Output `vTexCoord` as color**: confirms varying interpolation (red/green gradient per glyph)
+7. **Sample atlas at fixed `vec2(0.5, 0.5)`**: confirms texture binding works globally
+8. **Output `texture2D(texSampler, vTexCoord).r` as grayscale**: glyph shapes should appear bright if UVs map correctly
+9. **Check `gl.getError()`** around `drawArrays`: `0x0501` = INVALID_VALUE, `0x0502` = INVALID_OPERATION
+10. **Check `CURRENT_PROGRAM`**: `gl.getParameter(gl.CURRENT_PROGRAM) === shader.program`

--- a/.claude/skills/classic-sdf-text/SKILL.md
+++ b/.claude/skills/classic-sdf-text/SKILL.md
@@ -25,7 +25,7 @@ Drawable (transforms.ts)
 `SdfText` renders each glyph as a textured quad from a pre-generated SDF atlas.
 It builds an interleaved `Float32Array` vertex buffer (position + UV per vertex,
 6 vertices per glyph) and issues one `drawArrays(gl.TRIANGLES)` call per text
-string per frame (plus an optional second pass for drop-shadow).
+string per frame (plus optional passes for shadow and glow).
 
 `UISdfText` extends `SdfText` with word-wrapping (pixel-width driven, not
 character-count), explicit `\n` line breaks, and per-line justification
@@ -39,13 +39,13 @@ All data (metrics + atlas texture) is loaded synchronously during
 | File | Role |
 |------|------|
 | `scripts/make-font-atlas.mjs` | Build-time SDF atlas + metrics JSON generator |
-| `src/classic/sdfText.ts` | `SdfText` class: glyph layout, vertex buffer, rawDraw |
-| `src/classic/ui.ts` (UISdfText) | `UISdfText` class: word-wrap, justify, multi-line |
+| `src/classic/sdfText.ts` | `SdfText` class: glyph layout, vertex buffer, `rawDraw` |
+| `src/classic/ui.ts` (UISdfText) | `UISdfText` class: word-wrap, justify, height/layout |
 | `src/shaders/sdf.vert` | Vertex shader: `texCoord` varying passthrough |
-| `src/shaders/sdf.frag` | Fragment shader: `smoothstep` + outline + shadow |
-| `src/classic/utils.ts` | `initSdfFonts()` — loads metrics JSON at startup |
-| `src/classic/state.ts` | `game.sdfFonts`, `game.getSdfFont()` |
-| `public/manifest.json` | `"sdfFonts": [{ "name": "...", "metrics": "..." }]` |
+| `src/shaders/sdf.frag` | Fragment shader: derivative AA, weight, gamma, outline, alpha comp |
+| `src/classic/utils.ts` | `initSdfFonts()` — loads metrics JSON at startup, warns if `spread` missing |
+| `src/classic/state.ts` | `game.sdfFonts`, `game.getSdfFont()`, scissor-test disable |
+| `public/manifest.json` | `"sdfFonts": [{ "name": "...", "metrics": "..." }]` + shader uniforms |
 
 ---
 
@@ -58,20 +58,64 @@ rasterise a `.ttf`/`.otf` file and produce a grayscale SDF texture atlas.
 
 | Constant | Value | Meaning |
 |---|---|---|
-| `GLYPH_SIZE` | 64 | Target cell size in output pixels |
-| `RENDER_SCALE` | 16 | High-res render multiplier |
-| `SOURCE_W` | `HIGH_RES + padding*2` = 3072 | Source canvas pixel dimensions |
-| `CELL_SCALE` | `SOURCE_W / GLYPH_SIZE` = 48 | Source pixels per output cell pixel |
-| `ORIGIN_CELL` | `padding / CELL_SCALE` ≈ 21.33 | Font baseline in cell-pixel coordinates |
-| `maxDist` | `GLYPH_SIZE` = 64 | SDF distance-field spread (in source pixels) |
+| `FONT_CELL_SIZE` | `GLYPH_SIZE * 0.4` = 25.6 | Font size in cell pixels (engine unit) |
+| `PAD` | 2 | Texel gutter between glyphs (prevents LINEAR filter bleed) |
+| `SS` (supersampling factor) | 12 | High-res render multiplier per cell px |
+| `spread` (default) | 4 | SDF distance-field spread in cell pixels |
+| `GLYPH_SIZE` | 64 | Preserved for metric compatibility |
 
 ### Algorithm
 
-1. Render each glyph at `fontSize * RENDER_SCALE` px, `textBaseline='alphabetic'`, `textAlign='left'`
-2. Compute SDF: detect edges (inside→outside transitions), brute-force Manhattan distances, normalize to `[0..255]` with `maxDist` spread
-3. Crop to bounding box of non-background pixels (`byte ≠ 1`)
-4. Shelf-pack cropped glyphs into power-of-two atlas (typically 256×256)
-5. Output `public/res/<font>-sdf.png` + `public/res/<font>-sdf.json`
+**Per-glyph:**
+1. Size the raster: `cellW = ceil(inkW) + 2·(spread + pad)`, `source = cellW · SS`
+2. Render at `renderSize = FONT_CELL_SIZE · SS` px, `textBaseline='alphabetic'`, `textAlign='left'`
+3. Build inside/outside binary masks from alpha channel
+4. Compute squared-distance transform: separable Felzenszwalb EDT (`dt1d` / `edt2d`) — O(n)
+5. Point-sample at cell centres, normalize to `[0..255]` with `maxDist = spread · SS`
+6. Detect `.notdef`/blank via bitmap hash comparison against known-absent code points
+
+**Atlas:**
+- Shelf-pack cropped glyph cells into power-of-two atlas (typically 512² or 1024²)
+- `PAD=2` gutter between glyphs; background is `#000` (far-outside)
+- Packer retries with `size *= 2` on overflow; hard-fails at `--max-size` (default 4096)
+
+**Caching:**
+- Key = `sha256(font bytes + charset + SS + spread + glyphSize + PAD)`
+- Stored next to outputs as `<name>-sdf.sig`; cache hit skips regeneration
+- Cache invalidates itself if `.png` or `.json` output files are missing
+
+**CLI:**
+```
+node scripts/make-font-atlas.mjs <font.ttf> [--family name] [--ss 12] [--spread 4]
+    [--max-size 4096] [--charset groups] [--no-cache]
+```
+
+### Charset groups
+
+Charset is specified via `--charset` (default: `all`). Named groups can be combined with `+` and excluded with `-`:
+
+| Group | Glyphs | Contents |
+|---|---|---|
+| `ascii` | 95 | `0020-007E` |
+| `latin1` | 96 | `00A0-00FF` accented names, `¡¿«»°±×÷£¥¢§©®µ¶·` |
+| `punct` | 26 | curly quotes, en/em dash, ellipsis, bullet, prime, dagger |
+| `supsub` | 28 | `⁰¹²³⁻ⁿ ₀₁₂` formulas |
+| `fractions` | 16 | `½ ⅓ ¼ ⅔ ⅛` health/stack fractions |
+| `currency` | 25 | `€ ₽ ₹ ₩ ¤ ƒ` shops/economy |
+| `roman` | 32 | `Ⅰ Ⅱ Ⅲ Ⅳ` tiers |
+| `arrows` | 112 | `← ↑ → ↓ ↔ ⇧ ⇥ ↵` movement, tooltips |
+| `math` | 36 | `≈ ≠ ≤ ≥ ∞ √ ∑ ∆ ⊕` stat displays |
+| `box` | 128 | `┌─┬─┐ │ ├─┼─┤ └─┴─┘` frames, panels |
+| `blocks` | 29 | `█ ▌ ▄ ▀` progress bars (excludes ░▒▓ dither) |
+| `geometric` | 96 | `■ ▲ ● ◆ ◇` markers, minimap icons |
+| `symbols` | 84 | `☠ ☢ ⚠ ⚡ ♔♕ ♠♥♦♣ ⚀-⚅ ♪♫` game icons |
+| `dingbats` | 44 | `✓ ✔ ✗ ✘ ❤ ➔` toggles, rarity, lives |
+| `enclosed` | 30 | `① ➀ ❶` numbered lists |
+| `keys` | 13 | `⌘ ⌥ ⌃ ⏎ ⌫ ⌦ ␣` key prompts |
+| `greek` | 50 | `α β γ Δ Σ Ω π μ` stats/formulas |
+
+Default `all` produces ~935 glyphs on a 2048² atlas. Characters not covered by the
+font are silently dropped (detected via `.notdef` bitmap hash matching).
 
 ### Metrics JSON format
 
@@ -79,18 +123,21 @@ rasterise a `.ttf`/`.otf` file and produce a grayscale SDF texture atlas.
 {
   "name": "dejavusans",
   "family": "DejaVuSans",
-  "atlasSize": [256, 256],
+  "atlasSize": [2048, 2048],
   "glyphSize": 64,
+  "spread": 4,
   "baseline": 19.968,
   "lineHeight": 33.28,
   "glyphs": {
-    "A": { "x": 232, "y": 0, "w": 20, "h": 22, "xOffset": -1.33, "yOffset": -20.33, "xAdvance": 17.51 }
+    "A": { "x": 108, "y": 77, "w": 30, "h": 31, "xOffset": -6, "yOffset": -25.968, "xAdvance": 17.512 }
   }
 }
 ```
 
 All numeric quantities are in **cell pixels** — the universal unit for SDF
-text metrics. One cell pixel = one pixel in the original 64×64 SDF output grid.
+text metrics (`FONT_CELL_SIZE = 25.6`). Floats are rounded to 3 decimal places.
+
+`spread` is required — `initSdfFonts()` warns if absent (stale atlas).
 
 ---
 
@@ -103,22 +150,41 @@ Everything is in **cell pixels**, multiplied by `_scale` to get screen pixels.
 | Glyph top in local coords | `gy = baseline * scale + yOffset * scale` |
 | Glyph bottom | `gy + h * scale` |
 | Line offset (multi-line) | `gy += lineIndex * lineHeight * scale` |
-| Text block extent | `min(gy)` to `max(gy + h*scale)` across all glyphs |
-| `textHeight` | `glyphExtentMax - glyphExtentMin` (not `lineHeight * scale`!) |
-| `textWidth` | Max line advance from `xAdvance * scale` sums |
 
-**Critical:** `textHeight` must reflect the glyph *extent*, not the line box.
-The extent is recomputed immediately after the perLine collection loop
-(before the vertex buffer build) so that both the vertex local coordinates
-and `modelMatrix()` use the same value. If `textHeight` is changed *after*
-the vertex loop, the coordinates mismatch and glyphs appear squashed.
+### `textHeight` vs `_layoutHeight`
 
-Local → screen transform via `modelMatrix()`:
+The SDF cell includes `spread + PAD` margins around the visible ink:
+
+- `textHeight` = full cell height including spread margins (used for vertex
+  coordinate normalization and `modelMatrix()` scale).
+- `_layoutHeight` = `textHeight - 2·(spread + PAD)·scale` → visible ink
+  height. Returned by `UISdfText.get height()` so the UI anchor system
+  (`setChildrenPos`) uses visible ink bounds, not padded cell bounds.
+
+### `textWidth` vs `_layoutWidth`
+
+- `textWidth` = maximum rendered line width (used normally).
+- `_layoutWidth` = column width for justification. Set to `maxWidth` only
+  when `justify !== 'left'`. When set, `textWidth` is replaced with the
+  column width so the text block spans the full intended column — center
+  and right alignment then shift glyphs into the correct position.
+
+### `advanceFor(ch)`
+
+Shared by `_buildGlyphBuffer`, word-wrap measurement, and layout. Returns:
+- Known glyph → `g.xAdvance`
+- Space → space advance (or fallback)
+- Tab (`\t`) → 4 × space advance
+- Unknown → `glyphSize * 0.5`
+
+Local → screen transform via `modelMatrix(offset?)`:
 ```typescript
-translate(position) * scale(textWidth, textHeight, 1)
+translate(position + offset) * scale(textWidth, textHeight, z)
 ```
 
-Positioned by the UI anchor system (e.g., `mid-center`) just like any `UIDrawable`.
+The optional `offset` parameter is folded into the translation **before** the
+scale, ensuring shadow/glow offsets are in screen pixels, not scaled by
+`textWidth/textHeight`.
 
 ### UV mapping
 
@@ -131,7 +197,6 @@ uy1 = (g.y + g.h) / atlasH;
 
 **Do NOT use `1 - g.y/atlasH`.** This engine does not set
 `UNPACK_FLIP_Y_WEBGL`; `texImage2D` puts image row 0 at texture t=0.
-The engine's own `sheet.frag` shader follows the same convention.
 
 ---
 
@@ -143,20 +208,57 @@ The engine's own `sheet.frag` shader follows the same convention.
 attribute vec4 vertexPos;     // location 0 (bound before linkProgram!)
 attribute vec2 texCoord;      // location 1
 varying mediump vec2 vTexCoord;
-// standard model * camera * projection transform
 ```
 
 ### Fragment (`sdf.frag`)
 
+#### Uniforms
+
+| Uniform | Type | Meaning |
+|---|---|---|
+| `texSampler` | `sampler2D` | SDF atlas texture |
+| `color` | `vec4` | Fill color (a = opacity) |
+| `outlineColor` | `vec4` | Outline color (a = opacity) |
+| `outlineWidth` | `float` | Outline width in **cell pixels** |
+| `softEdge` | `float` | Manual AA fallback when derivatives unavailable |
+| `spread` | `float` | SDF spread from metrics JSON |
+| `atlasSize` | `vec2` | Atlas dimensions for UV→px conversion |
+| `weight` | `float` | Faux bold/light: `edge = 0.5 - weight` |
+| `gamma` | `float` | Perceptual gamma on final alpha |
+
+#### Derivative AA
+
 ```glsl
-float distance = texture2D(texSampler, vTexCoord).r;
-float edge = 0.5;
-float alpha = smoothstep(edge - softEdge, edge + softEdge, distance);
-// Outline: smoothstep in band [edge - outlineWidth, edge]
-// Shadow: second drawPass with offset model matrix + blurred outline
+#ifdef GL_OES_standard_derivatives
+    vec2 uvPx = fwidth(vTexCoord) * atlasSize;
+    float pxRange = (2.0 * spread) / max(length(uvPx), 1e-5);
+    w = clamp(0.5 / pxRange, 0.0001, 0.5);
+#else
+    w = softEdge;
+#endif
 ```
 
-`softEdge = 0.08` is a good fixed value for the 64-px `GLYPH_SIZE`.
+`OES_standard_derivatives` is already requested at `state.ts:177`. The
+`softEdge` uniform is a fallback only.
+
+#### Alpha compositing
+
+```glsl
+float fillAlpha = alpha * color.a;
+float outAlpha = outlineAlpha * outlineColor.a;
+result.a = outAlpha + fillAlpha * (1.0 - outAlpha);
+```
+
+Both `color.a` and `outlineColor.a` are respected. Outline width in cell
+pixels is converted to SDF units internally as `outlineWidth / (2.0 * spread)`.
+
+#### Draw passes
+
+Shadow: second `drawPass` with offset model matrix and `shadowBlur` as outline width.
+Glow: zero-offset pass with `glowRadius` as outline width.
+Main: primary fill with `outlineWidth` as outline width.
+
+All passes go through `SdfText.rawDraw()` → `drawPass()`.
 
 ---
 
@@ -168,8 +270,7 @@ In `initShaderProgram()` (`src/classic/utils.ts`), call
 `gl.bindAttribLocation(program, i, attributes[i])` **before**
 `gl.linkProgram()`. AMD drivers (notably Radeon R9 200) may drop attribute
 locations that appear unused to the linker, returning `getAttribLocation`
-as `-1`. This causes `vTexCoord` to be `(0,0)`, making `texture2D` sample
-the origin of the atlas (usually black).
+as `-1`.
 
 ### Sampler binding order
 
@@ -179,14 +280,10 @@ gl.bindTexture(gl.TEXTURE_2D, atlasTexture.texture);
 gl.uniform1i(shader.unif.texSampler, 0);  // AFTER texture is bound
 ```
 
-Some drivers silently ignore a sampler if the texture isn't on the unit
-when `uniform1i` is called.
-
 ### LINEAR filtering on SDF atlas texture
 
-The atlas texture must use `gl.LINEAR` (min + mag) for `smoothstep` to
-produce anti-aliased edges. The engine's default `initTextures()` sets
-`gl.NEAREST`, so `SdfText`'s constructor overrides this:
+The atlas texture must use `gl.LINEAR` (min + mag) — `SdfText`'s constructor
+overrides this after the engine default `gl.NEAREST`:
 
 ```typescript
 this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture.texture);
@@ -204,15 +301,29 @@ gl.vertexAttribPointer(attr.vertexPos, 2, gl.FLOAT, false, 16, 0);
 gl.vertexAttribPointer(attr.texCoord, 2, gl.FLOAT, false, 16, 8);
 ```
 
+### `_bufferDirty` flag
+
+`bufferData` is only called when the glyph buffer changed (after `setText`),
+not on every frame. Re-rendering unchanged text skips the GPU upload.
+
+### Scissor-test clipping
+
+Used by `UIContainer.clipChildren` to clip overflowing children (scroll,
+word-wrap overflow):
+
+- `state.ts` disables `SCISSOR_TEST` at frame start
+- `UIContainer.setChildrenPos()` writes `_uiClipRect` on all children when `clipChildren` is set
+- `SdfText.rawDraw()` checks `_uiClipRect`: enables scissor with flipped-Y
+  rect, draws, disables scissor — all within the single draw call
+- No state leak to other drawables
+
 ---
 
 ## 6. MANIFEST INTEGRATION
 
-Font metrics are loaded synchronously during `loadResources()`, matching
-the engine pattern for shaders/textures/animations.
+### Font metrics
 
 ```json
-// public/manifest.json
 {
   "sdfFonts": [
     { "name": "dejavusans", "metrics": "/res/dejavusans-sdf.json" }
@@ -223,16 +334,33 @@ the engine pattern for shaders/textures/animations.
 }
 ```
 
+Loaded synchronously during `loadResources()`:
 ```typescript
-// Loaded in state.ts loadResources():
 this.sdfFonts = await initSdfFonts(this.manifest.sdfFonts || [], ...);
-
-// Accessed synchronously in SdfText constructor:
-this.metrics = this.game.getSdfFont(atlasName);
+this.metrics = this.game.getSdfFont(atlasName);  // in SdfText constructor
 ```
 
-No runtime `fetch`, no `metricsPromise`, no `async` code path. If the JSON
-fails to load, `loadResources()` throws before the game starts.
+`initSdfFonts` warns if any loaded metrics are missing the `spread` field.
+
+### Shader uniforms
+
+```json
+{
+  "name": "sdf",
+  "vertex": "/shaders/sdf.vert",
+  "fragment": "/shaders/sdf.frag",
+  "attr": ["vertexPos", "texCoord"],
+  "unif": [
+    "modelMatrix", "cameraMatrix", "projectionMatrix",
+    "texSampler", "color", "outlineColor", "outlineWidth",
+    "softEdge", "spread", "atlasSize", "weight", "gamma"
+  ]
+}
+```
+
+Adding a new uniform requires updating **both** the manifest AND the shader
+source — `shader.unif.X` is derived from `getUniformLocation`, which returns
+`null` for undeclared names in the manifest.
 
 ---
 
@@ -240,50 +368,40 @@ fails to load, `loadResources()` throws before the game starts.
 
 ### Word wrapping
 
-`UISdfText.wrapTextAtPixelWidth()`:
+`_wrapAtPixelWidth(str, maxPx)` — instance method using `this.advanceFor()`:
 
 - Splits on `\n` first (hard line breaks)
-- Within each segment, word-wraps on spaces
-- Measures each word's pixel width via `measureWord()` (sums per-glyph `xAdvance * scale`)
+- Within each segment, word-wraps on spaces (ASCII space only; NBSP U+00A0
+  does NOT break)
+- Measures each word's pixel width via `this.advanceFor() * scale`
 - Pushes words to successive lines when `linePx + gap + wordPx > maxPx`
 
-The `maxWidth` argument to `spawnSdfText()` is in **screen pixels** (not
-character count — unlike the legacy `UIText`).
-
-### Multi-line support
-
-`_buildGlyphBuffer` tracks a `lineIndex` counter. Each glyph's `y` field
-in `perLine` stores its line index. The Y offset is computed as:
-
-```typescript
-gy = baseline * scale + yOffset * scale + lineIndex * lineHeight * scale;
-```
-
-`textHeight` accounts for the line count: `textHeight = maxExtent * lineCount`.
+`maxWidth` argument to `spawnSdfText()` is in **screen pixels**.
 
 ### Justification
 
 ```typescript
-infoText.setJustify('center');  // 'left' (default) | 'center' | 'right'
+text.setJustify('center');  // 'left' (default) | 'center' | 'right'
 ```
 
-Per-line: computes `lineWidth = sum(advances)` for each line, then shifts
-glyph `x` positions by `(maxWidth - lineWidth) / 2` (center) or
-`(maxWidth - lineWidth)` (right).
+Justification references the **column width** (`_layoutWidth = this.maxWidth`)
+rather than the longest rendered line. This means single-line text with
+`setJustify('center')` correctly centers within the column. Left-justify
+keeps the natural rendered width (`_layoutWidth = 0`).
+
+Per-line: computes line width, then shifts glyph positions by
+`(columnWidth - lineWidth) / 2` (center) or `(columnWidth - lineWidth)` (right).
+The `textWidth` is set to the column width, and `modelMatrix()` scales local
+coordinates so empty space to the column edge renders as transparent.
 
 ### Scale conversion from legacy UIText
-
-`UIText` uses a 32px glyph grid. `UISdfText` uses cell-pixel metrics (~18–25
-cell px per character). To get equivalent visual size, multiply the legacy
-scale by approximately **2.5**:
 
 ```typescript
 // UIText at scale 0.5 ≈ UISdfText at scale 1.25
 // UIText at scale 0.4 ≈ UISdfText at scale 1.0
 ```
 
-### `spawnButton` with SDF text
-
+`spawnButton` with `sdfText: true` auto-converts:
 ```typescript
 UI.spawnButton(w, h, color, onClick, {
     sdfText: true,
@@ -292,18 +410,30 @@ UI.spawnButton(w, h, color, onClick, {
 });
 ```
 
-The `sdfText` option causes `spawnButton` to create a `UISdfText` child
-instead of `UIText`, with internal scale multiplication.
-
-### Outline and shadow
+### Outline, shadow, glow
 
 ```typescript
-title.setOutline(0.12, [0.1, 0.05, 0, 1]);   // width in SDF units, RGBA color
-title.setShadow(2, 3, [0, 0, 0, 0.5], 1);      // offsetX, offsetY, color, blur
+title.setOutline(1, [0.1, 0.05, 0, 1]);        // 1 cell px, RGBA
+title.setShadow(2, 3, [0, 0, 0, 0.5], 2);       // offsetX, offsetY, color, blur
+title.setGlow(1.5, [1, 0.8, 0, 0.3]);           // radius, color
+text.setWeight(-0.08);                            // faux bold
+text.setGamma(1.4);                               // perceptual gamma
 ```
 
-Outline renders as a band around the edge in the fragment shader. Shadow
-is a second `drawPass` with an offset model matrix and wider outline blur.
+All dimensional values (outline width, shadow offset/blur, glow radius) are in
+**screen pixels** — the shader converts to SDF units internally using `spread`.
+
+### `snapToPixel`
+
+When `snapToPixel = true` and `ignoreCam = true`, `modelMatrix()` rounds the
+translation to whole device pixels. Eliminates sub-pixel blur for UI text
+positioned through fractional `_uiScale`.
+
+### Children with `_uiFixed`
+
+`UIElement._uiFixed = true` exempts a child from `UIContainer.setChildrenPos()`
+repositioning. Used for scrollbar track/thumb — they manage their own positions
+in the per-frame update callback.
 
 ---
 
@@ -311,33 +441,21 @@ is a second `drawPass` with an offset model matrix and wider outline blur.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| **No text visible, magenta rect appears** | SDF pipeline broken; green quads with solid shader confirm vertex pipeline | Proceed to shader/texture diagnostics |
-| **No text, green solid quads visible** | Fragment shader outputs transparent; check texCoord attribute location | `bindAttribLocation` before `linkProgram`; check `shader.attr.texCoord >= 0` |
-| **All black quads** | `texture2D` returns 0 | Atlas UVs sample empty background: verify UV range maps to glyph data region; check for `1 - g.y/atlasH` inversion bug |
-| **VertexCount = 0 after construction** | Metrics not loaded | Ensure `game.getSdfFont(name)` is available synchronously; `initSdfFonts` runs in `loadResources()` |
-| **Text squashed vertically** | `textHeight` changed after vertex loop | Compute glyph extent *before* building vertex data, not after |
-| **Glyphs rendered upside-down** | UV Y-axis inverted | Use `g.y/atlasH` (no `1 -`); this engine uses `texImage2D` without `UNPACK_FLIP_Y` |
-| **Glyphs on one pixel row** | `lineIndex` not applied | `gy += lineIndex * lineHeight * scale` in `_buildGlyphBuffer` |
-| **Text rendered ~3× too small** | Unit mismatch: old font-size units vs new cell-pixel units | Multiply scale by ~2.5 when migrating from `UIText` |
-| **Lines overlap (no vertical offset)** | `pg.y` stored but ignored | `gy` must include `pg.y * lineHeight * scale` |
-| **Justification has no effect** | Justify block runs before perLine is fully collected | Place justify block after the `\n`/char loop, before `textWidth` assignment |
-| **Atlas has all values = 1** | `maxDist` too large relative to glyph size | Use `maxDist = GLYPH_SIZE` (64), not canvas half-diagonal |
-| **Atlas has no glyph data** | BBox detection threshold wrong | Check `findBbox` — look for `byte ≠ 1` (not `byte > 128`) |
-| **Title clipped at top of screen** | `textHeight` too large, `gy` negative | Compute `textHeight` from glyph extent, not `lineHeight`; fix anchor to `mid-center` |
-
----
-
-## 9. DEBUGGING PIPELINE
-
-Systematically isolate each stage:
-
-1. **Check `vertexCount`**: `console.log` in `rawDraw` — if 0, text was never built
-2. **Check attribute locations**: `shader.attr.texCoord` should be ≥ 0 (not -1)
-3. **Swap to solid shader with glyph buffer**: green quads → vertex pipeline works
-4. **Swap to solid shader with full-bounds quad**: confirms `modelMatrix()` is correct
-5. **Hardcode fragment output to solid color**: confirms fragment shader executes
-6. **Output `vTexCoord` as color**: confirms varying interpolation (red/green gradient per glyph)
-7. **Sample atlas at fixed `vec2(0.5, 0.5)`**: confirms texture binding works globally
-8. **Output `texture2D(texSampler, vTexCoord).r` as grayscale**: glyph shapes should appear bright if UVs map correctly
-9. **Check `gl.getError()`** around `drawArrays`: `0x0501` = INVALID_VALUE, `0x0502` = INVALID_OPERATION
-10. **Check `CURRENT_PROGRAM`**: `gl.getParameter(gl.CURRENT_PROGRAM) === shader.program`
+| **No text visible, vertexCount=0** | Metrics not loaded | `game.getSdfFont(name)` available synchronously |
+| **All SDF text shifted up** | `_layoutHeight` not computed; anchor uses padded cell height | Set `_layoutHeight = textHeight - 2·(spread+2)·scale` |
+| **Left-justified button text gone / title off-center** | `_layoutWidth` forced `textWidth = columnW` for all text | Guard `_layoutWidth` to `justify !== 'left'` only |
+| **Justification has no visible effect** | Uses longest rendered line width, not column width | Use `_layoutWidth = maxWidth` as column reference |
+| **Camera zooms when scrolling panel** | `game.mouseWheel` is global | Add `_scrollContainers` guard in camera controller |
+| **Scrollbar moves with content** | `setChildrenPos` applies `scrollY` to all children | Set `_uiFixed = true` on scrollbar children |
+| **Atlas LINEAR filter bleeds adjacent glyphs** | Zero gutter between glyphs | `PAD=2` in generator |
+| **Shelf packer silently overflows** | No overflow check | Retry with `size *= 2`; hard-fail at `--max-size` |
+| **Shadow offset scaled by text size** | Post-translate after `S(textWidth, textHeight)` | Fold offset into `modelMatrix(offset?)` before scale |
+| **Wrap vs layout advance mismatch** | Different fallback values in `measureWord` vs `_buildGlyphBuffer` | Use shared `advanceFor()` |
+| **Box-drawing strokes thin at spread=4** | Interior field peaks at ~152/255 | Stay above `weight > 0.09` for box chars |
+| **Dither chars (░▒▓) render as mush** | SDF can't represent high-frequency checkerboards | Excluded; gate behind `--charset +dither` |
+| **Atlas .sig cache misses pointlessly** | Cache key doesn't account for missing outputs | Cache hit also verifies `.png`/`.json` exist |
+| **Generated atlas at 2048² instead of 1024²** | Cell sizes grew with spread=4 | Normal; ~340KB PNG at 2048² is acceptable |
+| **Text squashed vertically** | `textHeight` changed after vertex loop | Compute glyph extent before building vertex data |
+| **Glyphs rendered upside-down** | UV Y-axis inverted | `g.y/atlasH` (no `1 -`); no `UNPACK_FLIP_Y` |
+| **Glyphs on one pixel row** | `lineIndex` not applied | `gy += lineIndex * lineHeight * scale` |
+| **Text rendered ~3× too small** | Unit mismatch | Multiply scale by ~2.5 when migrating from `UIText` |

--- a/.claude/skills/classic-ui/SKILL.md
+++ b/.claude/skills/classic-ui/SKILL.md
@@ -44,8 +44,10 @@ Drawable (transforms.ts)
             └─ UIArray (ui.ts)           flex‑like horizontal/vertical layout
   └─ Sprite (transforms.ts)              textured quad
        └─ UISprite (ui.ts)               sized in canvas pixels
-  └─ Text (transforms.ts)                render‑to‑texture text
-       └─ UIText (ui.ts)                 sized in canvas pixels
+  └─ Text (transforms.ts)                render‑to‑texture text (legacy)
+       └─ UIText (ui.ts)                 sized in canvas pixels (legacy)
+  └─ SdfText (sdfText.ts)                direct SDF vertex‑buffer text
+       └─ UISdfText (ui.ts)              word‑wrap, justify, outline, shadow
 ```
 
 The `UIManager` singleton is stored as `game.ui`. It owns the root container
@@ -55,7 +57,7 @@ and drives layout refresh via a dirty flag.
 
 | File                        | Role                                                                    |
 | --------------------------- | ----------------------------------------------------------------------- |
-| `src/classic/ui.ts`         | UIManager, UIContainer, UIElement, UIText, UISprite, UIArray, UIPadding |
+| `src/classic/ui.ts`         | UIManager, UIContainer, UIElement, UIText, UISdfText, UISprite, UIArray, UIPadding |
 | `src/demo/uiPrefabs.ts`     | Demo UI tree: top bar, tool buttons, palettes, height/light widgets     |
 | `src/demo/prefabs.ts`       | Editor logic handlers (tile/nav/height fill‑on‑selection)               |
 | `src/classic/transforms.ts` | Drawable, Rectangle, Sprite, Text base classes                          |
@@ -609,6 +611,86 @@ and all Unicode (arrows, degree symbols, emoji, accented chars).
 
 ---
 
+## 8b. SDF FONT TEXT (`UISdfText`)
+
+The `UISdfText` renderer uses a pre‑generated signed‑distance‑field (SDF)
+atlas and supports proportional spacing, word‑wrapping by pixel width,
+multi‑line via explicit `\n`, and per‑line justification. It replaces the
+legacy `UIText`'s monospaced sprite‑sheet approach.
+
+### Factory method
+
+```typescript
+UI.spawnSdfText(text, textScale, maxWidth, color, bgColor) → UISdfText
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | `string` | Initial text content |
+| `textScale` | `number` | Scale multiplier (cell‑pixel units; ~2.5× larger than equivalent `UIText` scale) |
+| `maxWidth` | `number` | Maximum pixel width before word‑wrapping (screen pixels, *not* char count) |
+| `color` | `Color` | Foreground text RGBA |
+| `bgColor` | `Color` | Background RGBA (unused in UISdfText; pass `[0,0,0,0]`) |
+
+### Scale conversion from `UIText`
+
+| Legacy `UIText` scale | Equivalent `UISdfText` scale | Notes |
+|---|---|---|
+| 0.4 | 1.0 | Controls hint "WASD MOVE" |
+| 0.5 | 1.25 | Menu items, height widget |
+| 0.55 | 1.375 | Agent `[A]` button |
+| 0.6 | 1.5 | Classic title |
+
+### Feature methods
+
+| Method | Description |
+|---|---|
+| `setText(str)` | Sets new text; triggers word‑wrap and layout recalculation (synchronous) |
+| `setTextColor(rgba)` | Sets foreground color |
+| `setTextScale(scale)` | Changes scale; recalculates layout |
+| `setMaxWidth(px)` | Changes pixel max‑width; recalculates wrapping |
+| `setJustify('left' \| 'center' \| 'right')` | Per‑line horizontal alignment |
+| `setOutline(width, color)` | Adds an outline band around glyph edges (SDF‑unit width, RGBA) |
+| `setShadow(ox, oy, color, blur)` | Drop‑shadow with offset and blur |
+| `setEnabled(bool)` | Toggles visibility; cascades through children |
+| `setPosition(x, y)` | Positions top‑left corner in canvas‑pixel space |
+
+### Multi‑line support
+
+Embed `\n` in the text string for hard line breaks. The `wrapTextAtPixelWidth`
+function splits on `\n` first, then applies word‑wrapping within each segment.
+`_buildGlyphBuffer` offsets each line's glyphs by `lineIndex * lineHeight * scale`.
+
+### Justification
+
+`setJustify('center')` shifts each line's glyphs by `(maxWidth - linePixelWidth) / 2`.
+`setJustify('right')` shifts by `(maxWidth - linePixelWidth)`. Per‑line widths are
+computed from actual glyph advance sums, not character counts.
+
+### `spawnButton` integration
+
+```typescript
+UI.spawnButton(w, h, color, onClick, {
+    sdfText: true,              // uses spawnSdfText instead of spawnText
+    text: 'Label',
+    textScale: 0.5 * _uiScale,  // legacy scale — auto‑converted ×2.5 internally
+});
+```
+
+### Common pitfalls specific to SDF text
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Text not visible, vertexCount=0 | Metrics not loaded synchronously | Ensure `initSdfFonts` runs in `loadResources()`; `game.getSdfFont(name)` returns data |
+| All glyphs collapse to one line | `lineIndex` not added to `gy` | `gy += pg.y * lineHeight * scale` in `_buildGlyphBuffer` |
+| Text squashed vertically | `textHeight` changed after vertex loop | Compute glyph extent *before* building vertex data |
+| Lines overlapping (multi‑line) | Same as above | Track `lineIndex` in perLine and offset `gy` |
+| Text overflow at right edge | `maxWidth` too small, or widget widths not adjusted for scale conversion | Bump `labelW`/`dirW`/`glyphPixelW` by ~1.25–2× |
+| `setJustify` has no effect on legacy `UIText` | Legacy text has no justify support | Only use on `UISdfText` instances |
+| Text ~3× smaller than expected | Scale not converted from legacy units | Multiply legacy scale by ~2.5 |
+
+---
+
 ## 9. COMMON PITFALLS
 
 | Symptom                                                               | Cause                                                                                             | Fix                                                                                                       |
@@ -658,9 +740,10 @@ col.clickPriority = 1;  // dispatch before DEV toggle button (priority 0)
 UIManager(game) → UI
 UI.spawnContainer(w, h, [r,g,b,a])       → UIContainer
 UI.spawnText(str, fontScale, maxChars, [r,g,b,a], [br,bg,bb,ba]) → UIText
+UI.spawnSdfText(str, textScale, maxWidth, [r,g,b,a], [br,bg,bb,ba]) → UISdfText
 UI.spawnSprite(texName, w, h, frame, [cols,rows]) → UISprite
-UI.spawnButton(w, h, color, onClick, opts?) → { container: UIContainer, collider: Collider, child?: UIText|UISprite }
-//  opts: { text?, textScale?, textColor?, sprite?, spriteFrame?, spriteTileSet?, priority?, hover?, clickFeedback? }
+UI.spawnButton(w, h, color, onClick, opts?) → { container: UIContainer, collider: Collider, child?: UIText|UISdfText|UISprite }
+//  opts: { text?, textScale?, textColor?, sdfText?, sprite?, spriteFrame?, spriteTileSet?, priority?, hover?, clickFeedback? }
 UI.addColliderToElem(UIElement)           → Collider
 
 container.addChild(child, selfAnchor?, childAnchor?) → this
@@ -671,6 +754,13 @@ container.setSize(w, h)                  → this
 
 text.setText(str)                         → this
 text.setTextColor([r,g,b,a])              → this
+
+sdftext.setText(str)                      → this
+sdftext.setJustify('left'|'center'|'right') → this
+sdftext.setOutline(width, [r,g,b,a])      → this
+sdftext.setShadow(ox, oy, [r,g,b,a], blur) → this
+sdftext.setTextScale(n)                   → this
+sdftext.setMaxWidth(n)                    → this
 
 sprite.setSize(w, h)                      → this
 sprite.setPosition(x, y)                  → this

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "main": "index.js",
     "scripts": {
-        "assets": "node scripts/copy-assets.mjs",
+        "assets": "node scripts/copy-assets.mjs && node scripts/make-font-atlas.mjs assets/fonts/DejaVuSans.ttf --family DejaVuSans",
         "dev": "npm run assets && vite",
         "build": "npm run assets && vite build",
         "preview": "vite preview",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -39,6 +39,22 @@
             ]
         },
         {
+            "name": "sdf",
+            "vertex": "/shaders/sdf.vert",
+            "fragment": "/shaders/sdf.frag",
+            "attr": ["vertexPos", "texCoord"],
+            "unif": [
+                "modelMatrix",
+                "cameraMatrix",
+                "projectionMatrix",
+                "texSampler",
+                "color",
+                "outlineColor",
+                "outlineWidth",
+                "softEdge"
+            ]
+        },
+        {
             "name": "isoTilemap",
             "vertex": "/shaders/iso_tilemap.vert",
             "fragment": "/shaders/iso_tilemap.frag",
@@ -95,6 +111,10 @@
             "src": "/res/font.png"
         },
         {
+            "name": "dejavusans-sdf",
+            "src": "/res/dejavusans-sdf.png"
+        },
+        {
             "name": "editorIcons",
             "src": "/res/editor_icons.png"
         },
@@ -117,6 +137,12 @@
         {
             "name": "house",
             "src": "/res/house01.png"
+        }
+    ],
+    "sdfFonts": [
+        {
+            "name": "dejavusans",
+            "metrics": "/res/dejavusans-sdf.json"
         }
     ],
     "animations": [

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -51,7 +51,11 @@
                 "color",
                 "outlineColor",
                 "outlineWidth",
-                "softEdge"
+                "softEdge",
+                "spread",
+                "atlasSize",
+                "weight",
+                "gamma"
             ]
         },
         {

--- a/scripts/make-font-atlas.mjs
+++ b/scripts/make-font-atlas.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+/**
+ * Generates a signed-distance-field (SDF) font atlas for pure-GL text rendering.
+ *
+ * Usage:  node scripts/make-font-atlas.mjs <font.ttf> [options]
+ *
+ * Options:
+ *   --family <name>   Font family name (default: font file basename)
+ *   --ss <n>          Supersampling factor (default: 12)
+ *   --spread <n>      SDF spread in cell pixels (default: 4)
+ *   --max-size <n>    Maximum atlas width/height (default: 4096)
+ *   --no-cache        Skip the content-hash cache
+ *
+ * Produces:
+ *   public/res/<basename>-sdf.png   – grayscale SDF atlas texture
+ *   public/res/<basename>-sdf.json  – glyph metrics + atlas positions
+ */
+
+import canvasModule from '@napi-rs/canvas';
+const { GlobalFonts, createCanvas, ImageData } = canvasModule;
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const resDir = path.join(root, 'public', 'res');
+
+const GLYPH_SIZE = 64;
+const PAD = 2;
+// Font cell-pixel size. Must match the "cell pixel" unit used throughout the
+// engine: cell px = (GLYPH_SIZE * 1.2 * old_RENDER_SCALE) / old_CELL_SCALE
+// old_RENDER_SCALE was 16, old_CELL_SCALE was 48.  Simplifies to GLYPH_SIZE * 0.4.
+const FONT_CELL_SIZE = GLYPH_SIZE * 0.4;
+
+const CHARS =
+    ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+
+function nearestPow2(n) {
+    let v = 1;
+    while (v < n) v *= 2;
+    return v;
+}
+
+// ---------------------------------------------------------------------------
+// Separable squared-distance transform (Felzenszwalb)
+// ---------------------------------------------------------------------------
+
+/**
+ * 1D squared-distance transform of an input function.
+ *  f[n]     - input function values per column / row
+ *  d[n]     - output distance values
+ *  v[n],z[] - scratch space
+ */
+function dt1d(f, n, d, v, z) {
+    let k = 0;
+    v[0] = 0;
+    z[0] = -1e20;
+    z[1] = 1e20;
+    for (let q = 1; q < n; q++) {
+        let s = (f[q] + q * q - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
+        while (s <= z[k]) {
+            k--;
+            s = (f[q] + q * q - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
+        }
+        k++;
+        v[k] = q;
+        z[k] = s;
+        z[k + 1] = 1e20;
+    }
+    k = 0;
+    for (let q = 0; q < n; q++) {
+        while (z[k + 1] < q) k++;
+        d[q] = (q - v[k]) * (q - v[k]) + f[v[k]];
+    }
+}
+
+/**
+ * Separable 2D squared-distance transform.
+ * bufOut receives the result; inputs mask where mask[p] is true for inside.
+ */
+function edt2d(mask, w, h, bufOut) {
+    const INF = 1e20;
+    const m = Math.max(w, h);
+    const f = new Float64Array(m);
+    const d = new Float64Array(m);
+    const v = new Int32Array(m);
+    const z = new Float64Array(m + 1);
+
+    for (let x = 0; x < w; x++) {
+        for (let y = 0; y < h; y++) f[y] = mask[y * w + x] ? 0 : INF;
+        dt1d(f, h, d, v, z);
+        for (let y = 0; y < h; y++) bufOut[y * w + x] = d[y];
+    }
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) f[x] = bufOut[y * w + x];
+        dt1d(f, w, d, v, z);
+        for (let x = 0; x < w; x++) bufOut[y * w + x] = d[x];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Atlas packing
+// ---------------------------------------------------------------------------
+
+function packAtlas(glyphs, pad, maxSize = 4096) {
+    const sorted = [...glyphs].sort((a, b) => b.bh - a.bh || b.bw - a.bw);
+    const totalArea = sorted.reduce((s, g) => s + (g.bw + pad) * (g.bh + pad), 0);
+    let size = nearestPow2(Math.ceil(Math.sqrt(totalArea) * 1.3));
+
+    while (true) {
+        let x = pad,
+            y = pad,
+            rowH = 0;
+        let ok = true;
+
+        for (const g of sorted) {
+            if (x + g.bw + pad > size) {
+                y += rowH + pad;
+                x = pad;
+                rowH = 0;
+            }
+            if (y + g.bh + pad > size) {
+                ok = false;
+                break;
+            }
+            g.atlasX = x;
+            g.atlasY = y;
+            x += g.bw + pad;
+            rowH = Math.max(rowH, g.bh);
+        }
+
+        if (ok) return size;
+        if (size >= maxSize) {
+            throw new Error(
+                `Atlas packer could not fit ${sorted.length} glyphs at max size ${maxSize}×${maxSize}. ` +
+                    'Try reducing the charset or passing --max-size with a larger value.',
+            );
+        }
+        size *= 2;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SDF generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the SDF for a single glyph using separable EDT.
+ * Renders the glyph at high resolution into a per-glyph-sized raster,
+ * runs inside/outside distance transforms, and point-samples at cell centres.
+ *
+ * @param {*} gfx - canvas 2D context (canvas will be resized per glyph)
+ * @param {string} fontFamily
+ * @param {number} fontSize - cell pixels
+ * @param {number} ss - supersampling factor
+ * @param {number} spread - SDF spread in cell pixels
+ * @param {string} char - character to render
+ * @returns glyph result object
+ */
+function renderGlyphSDF(gfx, fontFamily, fontSize, ss, spread, char) {
+    const renderSize = fontSize * ss;
+    const spreadPx = spread * ss;
+    const padPx = PAD * ss;
+
+    gfx.font = `${renderSize}px "${fontFamily}"`;
+    gfx.textBaseline = 'alphabetic';
+    gfx.textAlign = 'left';
+    const m = gfx.measureText(char);
+
+    const inkW = Math.max(1, Math.ceil((m.actualBoundingBoxLeft + m.actualBoundingBoxRight) / ss));
+    const inkH = Math.max(
+        1,
+        Math.ceil((m.actualBoundingBoxAscent + m.actualBoundingBoxDescent) / ss),
+    );
+    const cellW = inkW + spread * 2 + PAD * 2;
+    const cellH = inkH + spread * 2 + PAD * 2;
+    const srcW = cellW * ss;
+    const srcH = cellH * ss;
+
+    gfx.canvas.width = srcW;
+    gfx.canvas.height = srcH;
+
+    gfx.fillStyle = '#ffffff';
+    gfx.font = `${renderSize}px "${fontFamily}"`;
+    gfx.textBaseline = 'alphabetic';
+    gfx.textAlign = 'left';
+
+    gfx.clearRect(0, 0, srcW, srcH);
+    const drawX = padPx + spreadPx;
+    const drawY = padPx + spreadPx + renderSize * 0.78;
+    gfx.fillText(char, drawX, drawY);
+
+    const imgData = gfx.getImageData(0, 0, srcW, srcH).data;
+
+    const inside = new Uint8Array(srcW * srcH);
+    const outside = new Uint8Array(srcW * srcH);
+    for (let i = 0, p = 0; i < imgData.length; i += 4, p++) {
+        const on = imgData[i + 3] > 128;
+        inside[p] = on ? 1 : 0;
+        outside[p] = on ? 0 : 1;
+    }
+
+    const bufA = new Float64Array(srcW * srcH);
+    const bufB = new Float64Array(srcW * srcH);
+    edt2d(outside, srcW, srcH, bufA);
+    edt2d(inside, srcW, srcH, bufB);
+
+    const maxDist = spread * ss;
+    const cellBuf = new Uint8ClampedArray(cellW * cellH * 4);
+
+    for (let cy = 0; cy < cellH; cy++) {
+        for (let cx = 0; cx < cellW; cx++) {
+            const sx = cx * ss + (ss >> 1);
+            const sy = cy * ss + (ss >> 1);
+            const p = sy * srcW + sx;
+            const sd = inside[p] ? Math.sqrt(bufA[p]) : -Math.sqrt(bufB[p]);
+            const norm = Math.max(-1, Math.min(1, sd / maxDist));
+            const byte = Math.round(128 + norm * 127);
+            const di = (cy * cellW + cx) * 4;
+            cellBuf[di] = byte;
+            cellBuf[di + 1] = byte;
+            cellBuf[di + 2] = byte;
+            cellBuf[di + 3] = 255;
+        }
+    }
+
+    let anyVariant = false;
+    for (let i = 0; i < cellBuf.length; i += 4) {
+        if (cellBuf[i] !== 128) {
+            anyVariant = true;
+            break;
+        }
+    }
+
+    // Compute offsets relative to the glyph origin (left baseline point)
+    // The glyph origin within the cell in cell-pixel coordinates is at:
+    //   originX = PAD + spread   (drawX / ss)
+    //   originY = PAD + spread + baseline  (drawY / ss = PAD + spread + fontSize*0.78)
+    const baseline = fontSize * 0.78;
+    const originCX = PAD + spread;
+    const originCY = PAD + spread + baseline;
+
+    // xOffset = cell_left_edge - origin_x  (BBox left relative to origin)
+    // yOffset = cell_top_edge - origin_y   (BBox top relative to origin)
+    const xOffset = 0 - originCX;
+    const yOffset = 0 - originCY;
+
+    return {
+        imageData: new ImageData(cellBuf, cellW, cellH),
+        xAdvance: m.width / ss,
+        xOffset,
+        yOffset,
+        bw: cellW,
+        bh: cellH,
+        char,
+        anyVariant,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Content-hash cache
+// ---------------------------------------------------------------------------
+
+const CACHE_VERSION = 1;
+
+function cacheKey(fontBuf, charset, opts) {
+    const h = createHash('sha256');
+    h.update(String(CACHE_VERSION));
+    h.update(fontBuf);
+    h.update(charset);
+    h.update(String(opts.ss));
+    h.update(String(opts.spread));
+    h.update(String(GLYPH_SIZE));
+    h.update(String(PAD));
+    return h.digest('hex');
+}
+
+async function cacheHit(baseName, key) {
+    const sigPath = path.join(resDir, `${baseName}-sdf.sig`);
+    try {
+        const existing = (await readFile(sigPath, 'utf-8')).trim();
+        if (existing !== key) return false;
+        // Verify output files still exist
+        await stat(path.join(resDir, `${baseName}-sdf.png`));
+        await stat(path.join(resDir, `${baseName}-sdf.json`));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function cacheWrite(baseName, key) {
+    await writeFile(path.join(resDir, `${baseName}-sdf.sig`), key);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function parseArgs(args) {
+    if (args.length < 1) {
+        console.error('Usage: make-font-atlas.mjs <font.ttf> [options]');
+        process.exit(1);
+    }
+
+    const fontPath = path.resolve(args[0]);
+    const fontName = path.basename(fontPath, path.extname(fontPath));
+
+    const opts = {
+        family: fontName,
+        ss: 12,
+        spread: 4,
+        maxSize: 4096,
+        noCache: false,
+    };
+
+    for (let i = 1; i < args.length; i++) {
+        const a = args[i];
+        if (a === '--family' && i + 1 < args.length) opts.family = args[++i];
+        else if (a === '--ss' && i + 1 < args.length) opts.ss = parseInt(args[++i], 10);
+        else if (a === '--spread' && i + 1 < args.length) opts.spread = parseInt(args[++i], 10);
+        else if (a === '--max-size' && i + 1 < args.length) opts.maxSize = parseInt(args[++i], 10);
+        else if (a === '--no-cache') opts.noCache = true;
+    }
+
+    return { fontPath, fontName, opts };
+}
+
+async function main() {
+    const { fontPath, fontName, opts } = parseArgs(process.argv.slice(2));
+    const baseName = fontName.toLowerCase().replace(/\s+/g, '-');
+
+    // Check cache
+    if (!opts.noCache) {
+        const fontBuf = await readFile(fontPath);
+        const key = cacheKey(fontBuf, CHARS, opts);
+        if (await cacheHit(baseName, key)) {
+            console.log(`SDF atlas cache hit for ${baseName} (${CHARS.length} glyphs)`);
+            return;
+        }
+    }
+
+    console.log(`Loading font: ${fontPath}`);
+    GlobalFonts.registerFromPath(fontPath, opts.family);
+
+    const fontSize = FONT_CELL_SIZE;
+
+    // Shared 2D context, resized per glyph
+    const gfx = createCanvas(8, 8).getContext('2d');
+
+    const glyphResults = [];
+    console.log(`Generating ${CHARS.length} glyphs (ss=${opts.ss}, spread=${opts.spread})...`);
+    const t0 = Date.now();
+
+    for (const char of CHARS) {
+        const result = renderGlyphSDF(gfx, opts.family, fontSize, opts.ss, opts.spread, char);
+        glyphResults.push(result);
+    }
+
+    const genMs = Date.now() - t0;
+    console.log(
+        `  ${glyphResults.length} glyphs rendered in ${(genMs / 1000).toFixed(1)} s ` +
+            `(${(genMs / glyphResults.length).toFixed(1)} ms/glyph)`,
+    );
+
+    const atlasSize = packAtlas(glyphResults, PAD, opts.maxSize);
+
+    const atlasCanvas = createCanvas(atlasSize, atlasSize);
+    const atlasCtx = atlasCanvas.getContext('2d');
+
+    atlasCtx.fillStyle = '#000000';
+    atlasCtx.fillRect(0, 0, atlasSize, atlasSize);
+
+    const glyphMap = {};
+    let spaceAdvance = fontSize * 0.28;
+
+    for (const g of glyphResults) {
+        atlasCtx.putImageData(g.imageData, g.atlasX, g.atlasY);
+
+        const xAdvance = g.char === ' ' ? spaceAdvance : g.xAdvance;
+        if (g.char === ' ' && g.xAdvance > 0) spaceAdvance = g.xAdvance;
+
+        glyphMap[g.char] = {
+            x: g.atlasX,
+            y: g.atlasY,
+            w: g.bw,
+            h: g.bh,
+            xOffset: g.xOffset,
+            yOffset: g.yOffset,
+            xAdvance: xAdvance,
+        };
+    }
+
+    const metrics = {
+        name: baseName,
+        family: opts.family,
+        atlasSize: [atlasSize, atlasSize],
+        glyphSize: GLYPH_SIZE,
+        spread: opts.spread,
+        baseline: fontSize * 0.78,
+        lineHeight: fontSize * 1.3,
+        glyphs: glyphMap,
+    };
+
+    await mkdir(resDir, { recursive: true });
+
+    const pngBuf = await atlasCanvas.encode('png');
+    const pngPath = path.join(resDir, `${baseName}-sdf.png`);
+    const jsonPath = path.join(resDir, `${baseName}-sdf.json`);
+
+    await writeFile(pngPath, pngBuf);
+    await writeFile(jsonPath, JSON.stringify(metrics));
+
+    // Write cache signature (after successful output)
+    if (!opts.noCache) {
+        const fontBuf = await readFile(fontPath);
+        await cacheWrite(baseName, cacheKey(fontBuf, CHARS, opts));
+    }
+
+    console.log(`Generated: ${pngPath}  (${atlasSize}x${atlasSize})`);
+    console.log(`Generated: ${jsonPath}`);
+    console.log(`Glyphs:   ${Object.keys(glyphMap).length} characters`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/make-font-atlas.mjs
+++ b/scripts/make-font-atlas.mjs
@@ -28,13 +28,130 @@ const resDir = path.join(root, 'public', 'res');
 
 const GLYPH_SIZE = 64;
 const PAD = 2;
-// Font cell-pixel size. Must match the "cell pixel" unit used throughout the
-// engine: cell px = (GLYPH_SIZE * 1.2 * old_RENDER_SCALE) / old_CELL_SCALE
-// old_RENDER_SCALE was 16, old_CELL_SCALE was 48.  Simplifies to GLYPH_SIZE * 0.4.
+// Font cell-pixel size matching the engine's unit system:
+// cell px = (GLYPH_SIZE * 1.2 * old_RENDER_SCALE) / old_CELL_SCALE = 64 * 0.4
 const FONT_CELL_SIZE = GLYPH_SIZE * 0.4;
 
-const CHARS =
-    ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
+// ---------------------------------------------------------------------------
+// Charset groups
+// ---------------------------------------------------------------------------
+
+function charRange(a, b) {
+    const o = [];
+    for (let cp = a; cp <= b; cp++) o.push(String.fromCodePoint(cp));
+    return o;
+}
+
+const CHARSET_GROUPS = {
+    ascii: charRange(0x0020, 0x007e),
+    latin1: charRange(0x00a0, 0x00ff),
+    punct: [
+        ...'\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201a\u201b\u201c\u201d\u201e',
+        ...'\u2020\u2021\u2022\u2023\u2026\u2030\u2032\u2033\u2039\u203a\u203b\u203c\u2044',
+    ].join(''),
+    supsub: [
+        ...'\u2070\u2074\u2075\u2076\u2077\u2078\u2079\u207a\u207b\u207c\u207d\u207e\u207f',
+        ...'\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089\u208a\u208b\u208c\u208d\u208e',
+    ].join(''),
+    fractions: charRange(0x2150, 0x215f),
+    currency: charRange(0x20a0, 0x20b5).concat(['\u20b9', '\u20bd', '\u0192']),
+    roman: charRange(0x2160, 0x217f),
+    arrows: charRange(0x2190, 0x21ff),
+    math: [
+        ...'\u2200\u2202\u2203\u2205\u2206\u2207\u2208\u2209\u220f\u2211\u2212\u2213\u2215',
+        ...'\u2217\u2219\u221a\u221d\u221e\u221f\u2220\u2229\u222a\u222b\u2248\u2260\u2261',
+        ...'\u2264\u2265\u226a\u226b\u2282\u2283\u2295\u2297\u22a5\u22c5',
+    ].join(''),
+    box: charRange(0x2500, 0x257f),
+    blocks: charRange(0x2580, 0x2590).concat(charRange(0x2594, 0x259f)), // exclude ░▒▓ (dither, incompatible with SDF)
+    geometric: charRange(0x25a0, 0x25ff),
+    symbols: [
+        ...'\u2600\u2601\u2602\u2603\u2604\u2605\u2606\u2609\u260e\u2610\u2611\u2612\u2618',
+        ...'\u261b\u261e\u2620\u2622\u2623\u262f\u2639\u263a\u263c\u2640\u2642',
+        ...'\u2648\u2649\u264a\u264b\u264c\u264d\u264e\u264f\u2650\u2651\u2652\u2653',
+        ...'\u2654\u2655\u2656\u2657\u2658\u2659\u265a\u265b\u265c\u265d\u265e\u265f',
+        ...'\u2660\u2661\u2662\u2663\u2664\u2665\u2666\u2667\u2668\u2669\u266a\u266b\u266c',
+        ...'\u266d\u266e\u266f\u267b',
+        ...'\u2680\u2681\u2682\u2683\u2684\u2685',
+        ...'\u2690\u2691\u2692\u2693\u2694\u2695\u2696\u2697\u2698\u2699\u269c\u26a0\u26a1',
+    ].join(''),
+    dingbats: [
+        ...'\u2708\u2712\u2713\u2714\u2715\u2716\u2717\u2718\u271a\u271b\u271c\u2720\u2721',
+        ...'\u2726\u2727\u2729\u272a\u272b\u272c\u272d\u272e\u272f\u2730\u2731\u2732\u2733',
+        ...'\u2734\u2735\u2736\u2739\u273d\u2740\u2744\u2756\u2764\u2765\u2766\u2767',
+        ...'\u2794\u2798\u279c\u27a1\u27a4\u27b2',
+    ].join(''),
+    enclosed: [
+        ...charRange(0x2460, 0x2469),
+        ...charRange(0x2776, 0x277f),
+        ...charRange(0x2780, 0x2789),
+    ],
+    keys: [
+        ...'\u2318\u2325\u2303\u2324\u23ce\u232b\u2326\u21ea\u2423\u21b5\u21b9\u2380\u2387',
+    ].join(''),
+    greek: [...charRange(0x0391, 0x03a9), ...charRange(0x03b1, 0x03c9)],
+};
+
+function resolveCharset(spec) {
+    if (!spec) return CHARSET_GROUPS.ascii.concat(makeDefaultCharset());
+    let chars = '';
+    for (const tok of spec.split(',')) {
+        const t = tok.trim();
+        if (!t) continue;
+        if (t === 'all') {
+            for (const g of Object.values(CHARSET_GROUPS)) chars += g;
+            continue;
+        }
+        if (t.startsWith('-')) {
+            // exclude groups will be handled in a second pass
+            continue;
+        }
+        const group = CHARSET_GROUPS[t];
+        if (group) {
+            chars += group;
+            continue;
+        }
+        console.error(
+            `Unknown charset group: "${t}". Available: ${Object.keys(CHARSET_GROUPS).join(', ')}`,
+        );
+        process.exit(1);
+    }
+    // Apply exclusions
+    for (const tok of spec.split(',')) {
+        const t = tok.trim();
+        if (t.startsWith('-')) {
+            const name = t.slice(1);
+            const group = CHARSET_GROUPS[name];
+            if (!group) continue;
+            for (const ch of group) chars = chars.replaceAll(ch, '');
+        }
+    }
+    return [...new Set([...chars])].join('');
+}
+
+function makeDefaultCharset() {
+    const groups = [
+        'latin1',
+        'punct',
+        'supsub',
+        'fractions',
+        'currency',
+        'roman',
+        'arrows',
+        'math',
+        'box',
+        'blocks',
+        'geometric',
+        'symbols',
+        'dingbats',
+        'enclosed',
+        'keys',
+        'greek',
+    ];
+    return groups.map((g) => CHARSET_GROUPS[g]).join('');
+}
+
+const CHARS = resolveCharset('all');
 
 function nearestPow2(n) {
     let v = 1;
@@ -313,6 +430,7 @@ function parseArgs(args) {
         spread: 4,
         maxSize: 4096,
         noCache: false,
+        charset: null,
     };
 
     for (let i = 1; i < args.length; i++) {
@@ -321,6 +439,7 @@ function parseArgs(args) {
         else if (a === '--ss' && i + 1 < args.length) opts.ss = parseInt(args[++i], 10);
         else if (a === '--spread' && i + 1 < args.length) opts.spread = parseInt(args[++i], 10);
         else if (a === '--max-size' && i + 1 < args.length) opts.maxSize = parseInt(args[++i], 10);
+        else if (a === '--charset' && i + 1 < args.length) opts.charset = args[++i];
         else if (a === '--no-cache') opts.noCache = true;
     }
 
@@ -330,13 +449,15 @@ function parseArgs(args) {
 async function main() {
     const { fontPath, fontName, opts } = parseArgs(process.argv.slice(2));
     const baseName = fontName.toLowerCase().replace(/\s+/g, '-');
+    const fontSize = FONT_CELL_SIZE;
+    const charset = opts.charset ? resolveCharset(opts.charset) : CHARS;
 
     // Check cache
     if (!opts.noCache) {
         const fontBuf = await readFile(fontPath);
-        const key = cacheKey(fontBuf, CHARS, opts);
+        const key = cacheKey(fontBuf, charset, opts);
         if (await cacheHit(baseName, key)) {
-            console.log(`SDF atlas cache hit for ${baseName} (${CHARS.length} glyphs)`);
+            console.log(`SDF atlas cache hit for ${baseName} (${charset.length} glyphs)`);
             return;
         }
     }
@@ -344,17 +465,40 @@ async function main() {
     console.log(`Loading font: ${fontPath}`);
     GlobalFonts.registerFromPath(fontPath, opts.family);
 
-    const fontSize = FONT_CELL_SIZE;
-
     // Shared 2D context, resized per glyph
     const gfx = createCanvas(8, 8).getContext('2d');
 
+    // Render .notdef references (known-absent code points) and hash them
+    const notdefA = renderGlyphSDF(gfx, opts.family, fontSize, opts.ss, opts.spread, '\u{1F600}');
+    const notdefB = renderGlyphSDF(gfx, opts.family, fontSize, opts.ss, opts.spread, '\u4e00');
+    const notdefHash = (b) => Buffer.from(b).toString('base64');
+    const ndHashes = new Set([
+        notdefHash(notdefA.imageData.data),
+        notdefHash(notdefB.imageData.data),
+    ]);
+    // Also consider fully-blank glyphs (all byte=128) as absent
+    function isAbsent(result) {
+        if (result.anyVariant === false) return true;
+        return ndHashes.has(notdefHash(result.imageData.data));
+    }
+
+    // Dedup bitmap-identical glyphs (e.g. NBSP ≡ space)
+    const seen = new Map();
+
     const glyphResults = [];
-    console.log(`Generating ${CHARS.length} glyphs (ss=${opts.ss}, spread=${opts.spread})...`);
+    console.log(`Generating ${charset.length} glyphs (ss=${opts.ss}, spread=${opts.spread})...`);
     const t0 = Date.now();
 
-    for (const char of CHARS) {
+    for (const char of charset) {
         const result = renderGlyphSDF(gfx, opts.family, fontSize, opts.ss, opts.spread, char);
+        if (isAbsent(result)) continue;
+        const h = notdefHash(result.imageData.data);
+        const prev = seen.get(h);
+        if (prev) {
+            glyphResults.push({ ...result, char, xAdvance: result.xAdvance }); // use own advance
+            continue;
+        }
+        seen.set(h, result);
         glyphResults.push(result);
     }
 
@@ -410,12 +554,17 @@ async function main() {
     const jsonPath = path.join(resDir, `${baseName}-sdf.json`);
 
     await writeFile(pngPath, pngBuf);
-    await writeFile(jsonPath, JSON.stringify(metrics));
+    await writeFile(
+        jsonPath,
+        JSON.stringify(metrics, (key, value) =>
+            typeof value === 'number' ? Math.round(value * 1000) / 1000 : value,
+        ),
+    );
 
     // Write cache signature (after successful output)
     if (!opts.noCache) {
         const fontBuf = await readFile(fontPath);
-        await cacheWrite(baseName, cacheKey(fontBuf, CHARS, opts));
+        await cacheWrite(baseName, cacheKey(fontBuf, charset, opts));
     }
 
     console.log(`Generated: ${pngPath}  (${atlasSize}x${atlasSize})`);

--- a/src/classic/sdfText.ts
+++ b/src/classic/sdfText.ts
@@ -44,6 +44,8 @@ export class SdfText extends Drawable {
     private _cpuBufferSize: number;
     private _bufferDirty: boolean;
     protected _scale: number;
+    protected _layoutWidth: number;
+    protected _layoutHeight: number;
 
     constructor(
         entity: IEntity,
@@ -84,6 +86,8 @@ export class SdfText extends Drawable {
         this.vertexCount = 0;
         this._cpuBufferSize = 0;
         this._bufferDirty = false;
+        this._layoutWidth = 0;
+        this._layoutHeight = 0;
         this._scale = (scale as number[])[0] || 1;
         this.glyphData = new Float32Array(0);
     }
@@ -215,19 +219,20 @@ export class SdfText extends Drawable {
         }
 
         if (this.justify !== 'left') {
+            const columnW = this._layoutWidth || maxWidth;
             const lineWidths: Record<number, number> = {};
             for (const pg of perLine) {
                 lineWidths[pg.y] = (lineWidths[pg.y] || 0) + pg.adv;
             }
             for (const pg of perLine) {
                 const lw = Math.max(1, lineWidths[pg.y] || 0);
-                const extra = maxWidth - lw;
+                const extra = columnW - lw;
                 if (this.justify === 'center') pg.x += extra / 2;
                 else if (this.justify === 'right') pg.x += extra;
             }
         }
 
-        this.textWidth = maxWidth;
+        this.textWidth = (this.justify !== 'left' && this._layoutWidth) || maxWidth;
         this.textHeight = maxH * (lineIndex || 1);
 
         let glyphExtentMin = Infinity;
@@ -242,6 +247,9 @@ export class SdfText extends Drawable {
         if (glyphExtentMin < glyphExtentMax) {
             this.textHeight = glyphExtentMax - glyphExtentMin;
         }
+
+        const margin = ((this.metrics.spread || 2) + 2) * this._scale;
+        this._layoutHeight = Math.max(1, this.textHeight - 2 * margin);
 
         const vertsPerGlyph = 6;
         const floatsPerVert = 4;

--- a/src/classic/sdfText.ts
+++ b/src/classic/sdfText.ts
@@ -36,6 +36,7 @@ export class SdfText extends Drawable {
     glowRadius: number;
     glowColor: Color;
     snapToPixel: boolean;
+    showNotdef: boolean;
     vertexBuffer: WebGLBuffer | null = null;
     vertexCount: number;
     glyphData: Float32Array;
@@ -76,6 +77,7 @@ export class SdfText extends Drawable {
         this.glowRadius = 0;
         this.glowColor = [1, 1, 1, 0.3];
         this.snapToPixel = false;
+        this.showNotdef = true;
         this.text = '';
         this.textWidth = 0;
         this.textHeight = 0;
@@ -175,6 +177,8 @@ export class SdfText extends Drawable {
         const g = this.metrics.glyphs[ch];
         if (g) return g.xAdvance;
         if (ch === ' ') return this.metrics.glyphs[' ']?.xAdvance || this.metrics.glyphSize * 0.5;
+        if (ch === '\t')
+            return (this.metrics.glyphs[' ']?.xAdvance || this.metrics.glyphSize * 0.5) * 4;
         return this.metrics.glyphSize * 0.5;
     }
 

--- a/src/classic/sdfText.ts
+++ b/src/classic/sdfText.ts
@@ -305,6 +305,18 @@ export class SdfText extends Drawable {
     rawDraw(): void {
         if (this.vertexCount === 0) return;
 
+        const clipRect = (this as any)._uiClipRect as
+            { x: number; y: number; w: number; h: number } | undefined;
+        if (clipRect) {
+            this.gl.enable(this.gl.SCISSOR_TEST);
+            this.gl.scissor(
+                clipRect.x,
+                this.gl.drawingBufferHeight - clipRect.y - clipRect.h,
+                clipRect.w,
+                clipRect.h,
+            );
+        }
+
         if (!this.vertexBuffer) {
             this.vertexBuffer = this.gl.createBuffer();
         }
@@ -376,6 +388,10 @@ export class SdfText extends Drawable {
         }
 
         drawPass(this.color, this.outlineWidth, 0, 0);
+
+        if (clipRect) {
+            this.gl.disable(this.gl.SCISSOR_TEST);
+        }
     }
 }
 

--- a/src/classic/sdfText.ts
+++ b/src/classic/sdfText.ts
@@ -31,11 +31,17 @@ export class SdfText extends Drawable {
     textWidth: number;
     textHeight: number;
     justify: 'left' | 'center' | 'right' = 'left';
+    weight: number;
+    gamma: number;
+    glowRadius: number;
+    glowColor: Color;
+    snapToPixel: boolean;
     vertexBuffer: WebGLBuffer | null = null;
     vertexCount: number;
     glyphData: Float32Array;
 
     private _cpuBufferSize: number;
+    private _bufferDirty: boolean;
     protected _scale: number;
 
     constructor(
@@ -65,11 +71,17 @@ export class SdfText extends Drawable {
         this.shadowOffset = [0, 0];
         this.shadowColor = [0, 0, 0, 0.5];
         this.shadowBlur = 0;
+        this.weight = 0;
+        this.gamma = 1.4;
+        this.glowRadius = 0;
+        this.glowColor = [1, 1, 1, 0.3];
+        this.snapToPixel = false;
         this.text = '';
         this.textWidth = 0;
         this.textHeight = 0;
         this.vertexCount = 0;
         this._cpuBufferSize = 0;
+        this._bufferDirty = false;
         this._scale = (scale as number[])[0] || 1;
         this.glyphData = new Float32Array(0);
     }
@@ -91,7 +103,13 @@ export class SdfText extends Drawable {
         const m = mat4.create();
         const ox = offset?.[0] ?? 0;
         const oy = offset?.[1] ?? 0;
-        mat4.translate(m, m, [this.position[0] + ox, this.position[1] + oy, this.position[2]]);
+        let px = this.position[0] + ox;
+        let py = this.position[1] + oy;
+        if (this.snapToPixel && this.ignoreCam) {
+            px = Math.round(px);
+            py = Math.round(py);
+        }
+        mat4.translate(m, m, [px, py, this.position[2]]);
         mat4.scale(m, m, [this.textWidth, this.textHeight, this.scale[2]]);
         return m;
     }
@@ -123,6 +141,22 @@ export class SdfText extends Drawable {
         this.shadowOffset = [offsetX, offsetY];
         this.shadowColor = rgba;
         this.shadowBlur = blur;
+        return this;
+    }
+
+    setGlow(radius: number, rgba: Color = [1, 1, 1, 0.3]): this {
+        this.glowRadius = radius;
+        this.glowColor = rgba;
+        return this;
+    }
+
+    setWeight(w: number): this {
+        this.weight = w;
+        return this;
+    }
+
+    setGamma(g: number): this {
+        this.gamma = g;
         return this;
     }
 
@@ -261,14 +295,7 @@ export class SdfText extends Drawable {
 
         this.glyphData = data;
         this.vertexCount = perLine.length * vertsPerGlyph;
-
-        if (data.length > this._cpuBufferSize) {
-            this._cpuBufferSize = data.length;
-        }
-        if (this.vertexBuffer) {
-            this.gl.deleteBuffer(this.vertexBuffer);
-            this.vertexBuffer = null;
-        }
+        this._bufferDirty = true;
     }
 
     rawDraw(): void {
@@ -278,13 +305,17 @@ export class SdfText extends Drawable {
             this.vertexBuffer = this.gl.createBuffer();
         }
 
-        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
-        this.gl.bufferData(this.gl.ARRAY_BUFFER, this.glyphData, this.gl.DYNAMIC_DRAW);
+        if (this._bufferDirty) {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+            this.gl.bufferData(this.gl.ARRAY_BUFFER, this.glyphData, this.gl.DYNAMIC_DRAW);
+            this._bufferDirty = false;
+        }
 
         const shader = this.game.shaders.sdf;
         shader.bind();
 
         const stride = 4 * 4;
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
         this.gl.vertexAttribPointer(shader.attr.vertexPos, 2, this.gl.FLOAT, false, stride, 0);
         this.gl.enableVertexAttribArray(shader.attr.vertexPos);
 
@@ -303,18 +334,27 @@ export class SdfText extends Drawable {
             this.gl.uniformMatrix4fv(shader.unif.cameraMatrix, false, mat4.create());
         }
 
-        const drawPass = (color: Color, outlineW: number, offsetX: number, offsetY: number) => {
+        this.gl.uniform1f(shader.unif.softEdge, 0.08);
+        this.gl.uniform1f(shader.unif.spread, this.metrics.spread || 2);
+        this.gl.uniform2f(
+            shader.unif.atlasSize,
+            this.metrics.atlasSize[0],
+            this.metrics.atlasSize[1],
+        );
+        this.gl.uniform1f(shader.unif.weight, this.weight);
+        this.gl.uniform1f(shader.unif.gamma, this.gamma);
+
+        const drawPass = (passColor: Color, outlineW: number, offsetX: number, offsetY: number) => {
             const passModel = this.modelMatrix(
                 offsetX !== 0 || offsetY !== 0 ? [offsetX, offsetY] : undefined,
             );
             this.gl.uniformMatrix4fv(shader.unif.modelMatrix, false, passModel);
 
-            this.gl.uniform4fv(shader.unif.color, color as number[]);
+            this.gl.uniform4fv(shader.unif.color, passColor as number[]);
 
-            const outlineColor = outlineW !== 0 ? this.outlineColor : [0, 0, 0, 0];
-            this.gl.uniform4fv(shader.unif.outlineColor, outlineColor as number[]);
+            const oc = outlineW !== 0 ? this.outlineColor : [0, 0, 0, 0];
+            this.gl.uniform4fv(shader.unif.outlineColor, oc as number[]);
             this.gl.uniform1f(shader.unif.outlineWidth, outlineW);
-            this.gl.uniform1f(shader.unif.softEdge, 0.08);
 
             this.gl.drawArrays(this.gl.TRIANGLES, 0, this.vertexCount);
         };
@@ -324,12 +364,11 @@ export class SdfText extends Drawable {
             (this.shadowColor[3] as number) > 0;
 
         if (hasShadow) {
-            drawPass(
-                this.shadowColor,
-                this.outlineWidth + this.shadowBlur * 0.1,
-                this.shadowOffset[0],
-                this.shadowOffset[1],
-            );
+            drawPass(this.shadowColor, this.shadowBlur, this.shadowOffset[0], this.shadowOffset[1]);
+        }
+
+        if (this.glowRadius > 0 && (this.glowColor[3] as number) > 0) {
+            drawPass(this.glowColor, this.glowRadius, 0, 0);
         }
 
         drawPass(this.color, this.outlineWidth, 0, 0);

--- a/src/classic/sdfText.ts
+++ b/src/classic/sdfText.ts
@@ -1,0 +1,355 @@
+/**
+ * SdfText - Signed Distance Field text renderer for classic-wgl
+ *
+ * Pure-GL non-monospaced font rendering using a pre-generated SDF atlas.
+ * Supports outlines, drop shadows, kerning, and pixel-precise spacing.
+ */
+
+import { Drawable } from '/classic/transforms.js';
+import { registerComponent } from '/classic/registry.js';
+import type { IEntity, ITexture, ComponentData, SdfFontMetrics } from './types.js';
+import { mat4, vec3 } from 'gl-matrix';
+
+type Vec3Like = vec3 | [number, number, number] | number[];
+type Color = [number, number, number, number] | number[];
+
+export type { SdfFontMetrics };
+
+export class SdfText extends Drawable {
+    atlasTexture: ITexture;
+    metrics: SdfFontMetrics;
+    atlasName: string;
+    ignoreCam: boolean;
+    color: Color;
+    bgcolor: Color;
+    outlineColor: Color;
+    outlineWidth: number;
+    shadowOffset: [number, number];
+    shadowColor: Color;
+    shadowBlur: number;
+    text: string;
+    textWidth: number;
+    textHeight: number;
+    justify: 'left' | 'center' | 'right' = 'left';
+    vertexBuffer: WebGLBuffer | null = null;
+    vertexCount: number;
+    glyphData: Float32Array;
+
+    private _cpuBufferSize: number;
+    protected _scale: number;
+
+    constructor(
+        entity: IEntity,
+        position: Vec3Like,
+        scale: Vec3Like,
+        atlasName: string,
+        color: Color,
+        bgcolor: Color,
+        ignoreCam: boolean,
+    ) {
+        super(entity, position, scale);
+
+        this.atlasTexture = this.game.getTexture(`${atlasName}-sdf`);
+        this.metrics = this.game.getSdfFont(atlasName);
+
+        this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture.texture);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
+        this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
+
+        this.atlasName = atlasName;
+        this.ignoreCam = ignoreCam;
+        this.color = color;
+        this.bgcolor = bgcolor;
+        this.outlineColor = [0, 0, 0, 1];
+        this.outlineWidth = 0;
+        this.shadowOffset = [0, 0];
+        this.shadowColor = [0, 0, 0, 0.5];
+        this.shadowBlur = 0;
+        this.text = '';
+        this.textWidth = 0;
+        this.textHeight = 0;
+        this.vertexCount = 0;
+        this._cpuBufferSize = 0;
+        this._scale = (scale as number[])[0] || 1;
+        this.glyphData = new Float32Array(0);
+    }
+
+    dump(): ComponentData {
+        const minObj = super.dump();
+        minObj.atlasName = this.atlasName;
+        minObj.color = this.color;
+        minObj.bgcolor = this.bgcolor;
+        minObj.outlineColor = this.outlineColor;
+        minObj.outlineWidth = this.outlineWidth;
+        minObj.shadowOffset = this.shadowOffset;
+        minObj.shadowColor = this.shadowColor;
+        minObj.ignoreCam = this.ignoreCam;
+        return minObj;
+    }
+
+    modelMatrix(offset?: readonly [number, number]): mat4 {
+        const m = mat4.create();
+        const ox = offset?.[0] ?? 0;
+        const oy = offset?.[1] ?? 0;
+        mat4.translate(m, m, [this.position[0] + ox, this.position[1] + oy, this.position[2]]);
+        mat4.scale(m, m, [this.textWidth, this.textHeight, this.scale[2]]);
+        return m;
+    }
+
+    setScale(s: number): this {
+        this._scale = s;
+        this.scale = vec3.fromValues(s, s, this.scale[2]);
+        if (this.text) this._buildGlyphBuffer(this.text);
+        return this;
+    }
+
+    setColor(rgba: Color): this {
+        this.color = rgba;
+        return this;
+    }
+
+    setOutline(width: number, rgba: Color = this.outlineColor): this {
+        this.outlineWidth = width;
+        this.outlineColor = rgba;
+        return this;
+    }
+
+    setShadow(
+        offsetX: number,
+        offsetY: number,
+        rgba: Color = [0, 0, 0, 0.5],
+        blur: number = 0,
+    ): this {
+        this.shadowOffset = [offsetX, offsetY];
+        this.shadowColor = rgba;
+        this.shadowBlur = blur;
+        return this;
+    }
+
+    setText(str: string): this {
+        this.text = str;
+        this._buildGlyphBuffer(str);
+        return this;
+    }
+
+    setTextSync(str: string): void {
+        this.text = str;
+        this._buildGlyphBuffer(str);
+    }
+
+    advanceFor(ch: string): number {
+        const g = this.metrics.glyphs[ch];
+        if (g) return g.xAdvance;
+        if (ch === ' ') return this.metrics.glyphs[' ']?.xAdvance || this.metrics.glyphSize * 0.5;
+        return this.metrics.glyphSize * 0.5;
+    }
+
+    private _buildGlyphBuffer(str: string): void {
+        const m = this.metrics;
+        const atlasW = m.atlasSize[0];
+        const atlasH = m.atlasSize[1];
+        const scale = this._scale;
+
+        let penX = 0;
+        let maxWidth = 0;
+        const maxH = m.lineHeight * scale;
+
+        const perLine: Array<{ char: string; x: number; y: number; adv: number }> = [];
+
+        let lineIndex = 0;
+        for (const line of str.split('\n')) {
+            let lineX = 0;
+            for (const ch of line) {
+                const g = m.glyphs[ch];
+                const adv = this.advanceFor(ch) * scale;
+                if (g) {
+                    perLine.push({
+                        char: ch,
+                        x: lineX + g.xOffset * scale,
+                        y: lineIndex,
+                        adv,
+                    });
+                }
+                lineX += adv;
+            }
+            if (lineX > maxWidth) maxWidth = lineX;
+            lineIndex++;
+        }
+
+        if (this.justify !== 'left') {
+            const lineWidths: Record<number, number> = {};
+            for (const pg of perLine) {
+                lineWidths[pg.y] = (lineWidths[pg.y] || 0) + pg.adv;
+            }
+            for (const pg of perLine) {
+                const lw = Math.max(1, lineWidths[pg.y] || 0);
+                const extra = maxWidth - lw;
+                if (this.justify === 'center') pg.x += extra / 2;
+                else if (this.justify === 'right') pg.x += extra;
+            }
+        }
+
+        this.textWidth = maxWidth;
+        this.textHeight = maxH * (lineIndex || 1);
+
+        let glyphExtentMin = Infinity;
+        let glyphExtentMax = -Infinity;
+        for (const pg of perLine) {
+            const g = m.glyphs[pg.char];
+            if (!g) continue;
+            const gy = m.baseline * scale + g.yOffset * scale + pg.y * m.lineHeight * scale;
+            if (gy < glyphExtentMin) glyphExtentMin = gy;
+            if (gy + g.h * scale > glyphExtentMax) glyphExtentMax = gy + g.h * scale;
+        }
+        if (glyphExtentMin < glyphExtentMax) {
+            this.textHeight = glyphExtentMax - glyphExtentMin;
+        }
+
+        const vertsPerGlyph = 6;
+        const floatsPerVert = 4;
+        const totalFloats = perLine.length * vertsPerGlyph * floatsPerVert;
+        const data = new Float32Array(totalFloats);
+
+        let vi = 0;
+        for (const pg of perLine) {
+            const g = m.glyphs[pg.char]!;
+            const gx = pg.x;
+            const gy = m.baseline * scale + g.yOffset * scale + pg.y * m.lineHeight * scale;
+            const gw = g.w * scale;
+            const gh = g.h * scale;
+            const tw = this.textWidth || 1;
+            const th = this.textHeight || 1;
+
+            const lx0 = gx / tw;
+            const lx1 = (gx + gw) / tw;
+            const ly0 = gy / th;
+            const ly1 = (gy + gh) / th;
+
+            const ux0 = g.x / atlasW;
+            const ux1 = (g.x + g.w) / atlasW;
+            const uy0 = g.y / atlasH;
+            const uy1 = (g.y + g.h) / atlasH;
+
+            data[vi + 0] = lx0;
+            data[vi + 1] = ly0;
+            data[vi + 2] = ux0;
+            data[vi + 3] = uy0;
+            data[vi + 4] = lx1;
+            data[vi + 5] = ly0;
+            data[vi + 6] = ux1;
+            data[vi + 7] = uy0;
+            data[vi + 8] = lx1;
+            data[vi + 9] = ly1;
+            data[vi + 10] = ux1;
+            data[vi + 11] = uy1;
+
+            data[vi + 12] = lx0;
+            data[vi + 13] = ly0;
+            data[vi + 14] = ux0;
+            data[vi + 15] = uy0;
+            data[vi + 16] = lx1;
+            data[vi + 17] = ly1;
+            data[vi + 18] = ux1;
+            data[vi + 19] = uy1;
+            data[vi + 20] = lx0;
+            data[vi + 21] = ly1;
+            data[vi + 22] = ux0;
+            data[vi + 23] = uy1;
+
+            vi += vertsPerGlyph * floatsPerVert;
+        }
+
+        this.glyphData = data;
+        this.vertexCount = perLine.length * vertsPerGlyph;
+
+        if (data.length > this._cpuBufferSize) {
+            this._cpuBufferSize = data.length;
+        }
+        if (this.vertexBuffer) {
+            this.gl.deleteBuffer(this.vertexBuffer);
+            this.vertexBuffer = null;
+        }
+    }
+
+    rawDraw(): void {
+        if (this.vertexCount === 0) return;
+
+        if (!this.vertexBuffer) {
+            this.vertexBuffer = this.gl.createBuffer();
+        }
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, this.glyphData, this.gl.DYNAMIC_DRAW);
+
+        const shader = this.game.shaders.sdf;
+        shader.bind();
+
+        const stride = 4 * 4;
+        this.gl.vertexAttribPointer(shader.attr.vertexPos, 2, this.gl.FLOAT, false, stride, 0);
+        this.gl.enableVertexAttribArray(shader.attr.vertexPos);
+
+        this.gl.vertexAttribPointer(shader.attr.texCoord, 2, this.gl.FLOAT, false, stride, 2 * 4);
+        this.gl.enableVertexAttribArray(shader.attr.texCoord);
+
+        this.gl.activeTexture(this.gl.TEXTURE0);
+        this.gl.bindTexture(this.gl.TEXTURE_2D, this.atlasTexture.texture);
+        this.gl.uniform1i(shader.unif.texSampler, 0);
+
+        this.gl.uniformMatrix4fv(shader.unif.projectionMatrix, false, this.game.projectionMatrix);
+
+        if (!this.ignoreCam) {
+            this.gl.uniformMatrix4fv(shader.unif.cameraMatrix, false, this.game.camera.matrix());
+        } else {
+            this.gl.uniformMatrix4fv(shader.unif.cameraMatrix, false, mat4.create());
+        }
+
+        const drawPass = (color: Color, outlineW: number, offsetX: number, offsetY: number) => {
+            const passModel = this.modelMatrix(
+                offsetX !== 0 || offsetY !== 0 ? [offsetX, offsetY] : undefined,
+            );
+            this.gl.uniformMatrix4fv(shader.unif.modelMatrix, false, passModel);
+
+            this.gl.uniform4fv(shader.unif.color, color as number[]);
+
+            const outlineColor = outlineW !== 0 ? this.outlineColor : [0, 0, 0, 0];
+            this.gl.uniform4fv(shader.unif.outlineColor, outlineColor as number[]);
+            this.gl.uniform1f(shader.unif.outlineWidth, outlineW);
+            this.gl.uniform1f(shader.unif.softEdge, 0.08);
+
+            this.gl.drawArrays(this.gl.TRIANGLES, 0, this.vertexCount);
+        };
+
+        const hasShadow =
+            (this.shadowOffset[0] !== 0 || this.shadowOffset[1] !== 0) &&
+            (this.shadowColor[3] as number) > 0;
+
+        if (hasShadow) {
+            drawPass(
+                this.shadowColor,
+                this.outlineWidth + this.shadowBlur * 0.1,
+                this.shadowOffset[0],
+                this.shadowOffset[1],
+            );
+        }
+
+        drawPass(this.color, this.outlineWidth, 0, 0);
+    }
+}
+
+export interface SdfText extends Drawable {
+    setPosition(x: number, y: number): this;
+}
+
+Object.defineProperty(SdfText.prototype, 'setPosition', {
+    value: function (this: SdfText, x: number, y: number): SdfText {
+        this.position[0] = x;
+        this.position[1] = y;
+        return this;
+    },
+    writable: true,
+});
+
+registerComponent(
+    'SdfText',
+    SdfText as unknown as new (entity: IEntity, ...args: unknown[]) => Drawable,
+);

--- a/src/classic/state.ts
+++ b/src/classic/state.ts
@@ -13,6 +13,7 @@ import {
     initShaders,
     initBuffers,
     initTextures,
+    initSdfFonts,
     initAnimations,
     estimateManifestWeight,
     slowSleep,
@@ -21,6 +22,7 @@ import {
     SHADER_COMPILE_WEIGHT,
     BUFFERS_WEIGHT,
     TEXTURE_WEIGHT,
+    SDF_FONT_WEIGHT,
     ANIMATIONS_WEIGHT,
 } from '/classic/utils.js';
 
@@ -47,6 +49,7 @@ import type {
 interface GameState extends IGameState {
     init(): void;
     getTexture(name: string): ITexture;
+    getSdfFont(name: string): IGameState['sdfFonts'][string];
     download(url: string): void;
     load(url: string, onProgress?: ProgressCallback): Promise<void>;
     registerCall(callName: CallName, entity: IEntity, fn: CallFunction): void;
@@ -94,6 +97,7 @@ const game: GameState = {
     buffers: {} as GameBuffers,
     textures: {} as Record<string, ITexture>,
     animations: {} as Record<string, IAnimation>,
+    sdfFonts: {} as Record<string, IGameState['sdfFonts'][string]>,
 
     entities: {},
 
@@ -182,6 +186,10 @@ const game: GameState = {
 
     getTexture(name: string): ITexture {
         return this.textures[name];
+    },
+
+    getSdfFont(name: string): IGameState['sdfFonts'][string] {
+        return this.sdfFonts[name];
     },
 
     download(url: string) {
@@ -399,6 +407,15 @@ const game: GameState = {
             report(label, (acc + frac * (this.manifest.textures.length * TEXTURE_WEIGHT)) / total),
         );
         acc += this.manifest.textures.length * TEXTURE_WEIGHT;
+
+        report('Loading SDF fonts', acc / total);
+        this.sdfFonts = await initSdfFonts(this.manifest.sdfFonts || [], (label, frac) =>
+            report(
+                label,
+                (acc + frac * ((this.manifest.sdfFonts?.length ?? 0) * SDF_FONT_WEIGHT)) / total,
+            ),
+        );
+        acc += (this.manifest.sdfFonts?.length ?? 0) * SDF_FONT_WEIGHT;
 
         report('Building animations', acc / total);
         this.animations = initAnimations(this.manifest.animations);

--- a/src/classic/state.ts
+++ b/src/classic/state.ts
@@ -462,6 +462,7 @@ const game: GameState = {
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
         gl.depthFunc(gl.LEQUAL);
         gl.depthMask(true);
+        gl.disable(gl.SCISSOR_TEST);
 
         this.renderList.length = 0;
         this.performCall('renderList');

--- a/src/classic/types.ts
+++ b/src/classic/types.ts
@@ -285,6 +285,7 @@ export interface SdfFontMetrics {
     family: string;
     atlasSize: [number, number];
     glyphSize: number;
+    spread: number;
     baseline: number;
     lineHeight: number;
     glyphs: Record<string, GlyphMetrics>;

--- a/src/classic/types.ts
+++ b/src/classic/types.ts
@@ -265,9 +265,35 @@ export interface TextureManifestEntry {
     src: string;
 }
 
+export interface SdfFontManifestEntry {
+    name: string;
+    metrics: string;
+}
+
+export interface GlyphMetrics {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    xOffset: number;
+    yOffset: number;
+    xAdvance: number;
+}
+
+export interface SdfFontMetrics {
+    name: string;
+    family: string;
+    atlasSize: [number, number];
+    glyphSize: number;
+    baseline: number;
+    lineHeight: number;
+    glyphs: Record<string, GlyphMetrics>;
+}
+
 export interface Manifest {
     shaders: ShaderInfo[];
     textures: TextureManifestEntry[];
+    sdfFonts: SdfFontManifestEntry[];
     animations: AnimationData[];
 }
 
@@ -313,6 +339,7 @@ export interface IGameState {
     buffers: GameBuffers;
     textures: Record<string, ITexture>;
     animations: Record<string, IAnimation>;
+    sdfFonts: Record<string, SdfFontMetrics>;
 
     // Timing
     prevTime: number;
@@ -365,6 +392,7 @@ export interface IGameState {
     // Methods
     init(): void;
     getTexture(name: string): ITexture;
+    getSdfFont(name: string): SdfFontMetrics;
     download(url: string): void;
     load(url: string, onProgress?: ProgressCallback): Promise<void>;
     registerCall(callName: CallName, entity: IEntity, fn: CallFunction): void;

--- a/src/classic/ui.ts
+++ b/src/classic/ui.ts
@@ -38,6 +38,9 @@ function markUIDirty(component: { game: IGameState }): void {
 
 // UIElement is a Rectangle component with pixel-based sizing
 export class UIElement extends Rectangle {
+    _parentContainer: UIContainer | null = null;
+    _uiFixed: boolean = false;
+
     constructor(entity: IEntity, color: Color, width: number, height: number, zlayer: number) {
         super(entity, [0, 0, zlayer], [width, height, 1], color, true);
     }
@@ -76,6 +79,22 @@ export class UIElement extends Rectangle {
         this.height = height;
         markUIDirty(this);
         return this;
+    }
+
+    clipRect(): { x: number; y: number; w: number; h: number } | null {
+        let parent: UIContainer | null = this._parentContainer;
+        while (parent) {
+            if ((parent as UIContainer).clipChildren) {
+                return {
+                    x: parent.position[0],
+                    y: parent.position[1],
+                    w: parent.width,
+                    h: parent.height,
+                };
+            }
+            parent = parent._parentContainer;
+        }
+        return null;
     }
 
     setColor(rgba: Color): this {
@@ -445,11 +464,15 @@ interface ChildEntry {
 export class UIContainer extends UIElement {
     children: ChildEntry[];
     anchor: AnchorType;
+    clipChildren: boolean;
+    scrollY: number;
 
     constructor(entity: IEntity, color: Color, width: number, height: number, zlayer: number) {
         super(entity, color, width, height, zlayer);
         this.children = [];
         this.anchor = 'mid-center';
+        this.clipChildren = false;
+        this.scrollY = 0;
     }
 
     addChild(
@@ -458,6 +481,7 @@ export class UIContainer extends UIElement {
         childAnchor: AnchorType = this.anchor,
     ): this {
         this.children.push({ child, selfAnchor, childAnchor });
+        (child as UIElement)._parentContainer = this;
         markUIDirty(this);
         return this;
     }
@@ -483,17 +507,26 @@ export class UIContainer extends UIElement {
 
     setChildrenPos(): void {
         const [panelX, panelY] = this.position;
+        const sy = this.clipChildren ? this.scrollY : 0;
 
         for (const { child, selfAnchor, childAnchor } of this.children) {
             if (!child.entity.enabled) continue;
+            if ((child as UIElement)._uiFixed) continue;
 
             const panelOffset = this.getAnchorOffset(selfAnchor, this.width, this.height);
             const childOffset = this.getAnchorOffset(childAnchor, child.width, child.height);
 
             const x = panelX + panelOffset.x - childOffset.x;
-            const y = panelY + panelOffset.y - childOffset.y;
+            const y = panelY + panelOffset.y - childOffset.y - sy;
 
             child.setPosition(x, y);
+        }
+
+        if (this.clipChildren) {
+            const r = { x: panelX, y: panelY, w: this.width, h: this.height };
+            for (const { child } of this.children) {
+                (child as any)._uiClipRect = r;
+            }
         }
     }
 }

--- a/src/classic/ui.ts
+++ b/src/classic/ui.ts
@@ -276,13 +276,14 @@ export class UISdfText extends SdfText {
         const result: string[] = [];
 
         for (const rawLine of str.split('\n')) {
-            const words = rawLine.split(' ');
             const lines: string[] = [];
             let line = '';
             let linePx = 0;
 
-            for (const word of words) {
+            for (const word of rawLine.split(' ')) {
+                if (!word) continue;
                 const wordPx = this._wordPx(word) * scale;
+                // NBSP (U+00A0) joins words — treat as a non-breaking space
                 const gap = linePx > 0 ? spacePx : 0;
 
                 if (linePx + gap + wordPx <= maxPx) {

--- a/src/classic/ui.ts
+++ b/src/classic/ui.ts
@@ -1,5 +1,6 @@
 import game from '/classic/state.js';
 import { Rectangle, Text, Sprite } from '/classic/transforms.js';
+import { SdfText } from '/classic/sdfText.js';
 import { Polygon, Collider } from '/classic/collision.js';
 import type { IEntity, IGameState, IComponent, ICollider, ColliderHandler } from './types.js';
 import { vec3 } from 'gl-matrix';
@@ -19,7 +20,7 @@ export interface UIComponentBase {
 }
 
 // Union type for any UI component that can be a child
-export type UIChild = UIElement | UIText | UISprite;
+export type UIChild = UIElement | UIText | UISprite | UISdfText;
 
 // UIManager interface extension for game state
 declare module './types.js' {
@@ -213,6 +214,145 @@ export class UIText extends Text {
         this.setMaxCharSize(cols, rows);
 
         super.setText(lines.map((l) => l.padEnd(cols, ' ')).join(''));
+    }
+
+    setPosition(x: number, y: number): this {
+        this.position[0] = x;
+        this.position[1] = y;
+        return this;
+    }
+
+    setEnabled(flag: boolean): this {
+        if (this.entity.enabled !== flag) markUIDirty(this);
+        this.entity.enabled = flag;
+        return this;
+    }
+}
+
+export class UISdfText extends SdfText {
+    rawText: string;
+    maxWidth: number;
+
+    constructor(
+        entity: IEntity,
+        text: string,
+        textScale: number,
+        maxWidth: number,
+        color: Color,
+        bgColor: Color,
+        zlayer: number,
+    ) {
+        super(
+            entity,
+            [0, 0, zlayer],
+            [textScale, textScale, 1],
+            'dejavusans',
+            color,
+            bgColor,
+            true,
+        );
+
+        this.rawText = text;
+        this.maxWidth = maxWidth;
+        this._recalculateTextElement();
+    }
+
+    get width(): number {
+        return this.textWidth;
+    }
+    get height(): number {
+        return this.textHeight;
+    }
+
+    private _wordPx(word: string): number {
+        let w = 0;
+        for (const ch of word) w += this.advanceFor(ch);
+        return w;
+    }
+
+    private _wrapAtPixelWidth(str: string, maxPx: number): string[] {
+        const scale = this._scale;
+        const spacePx = this.advanceFor(' ') * scale;
+        const result: string[] = [];
+
+        for (const rawLine of str.split('\n')) {
+            const words = rawLine.split(' ');
+            const lines: string[] = [];
+            let line = '';
+            let linePx = 0;
+
+            for (const word of words) {
+                const wordPx = this._wordPx(word) * scale;
+                const gap = linePx > 0 ? spacePx : 0;
+
+                if (linePx + gap + wordPx <= maxPx) {
+                    line += (line.length ? ' ' : '') + word;
+                    linePx += gap + wordPx;
+                } else {
+                    if (line.length > 0) lines.push(line);
+                    line = word;
+                    linePx = wordPx;
+                }
+            }
+            if (line.length) lines.push(line);
+            result.push(...lines);
+        }
+
+        return result.length > 0 ? result : [''];
+    }
+
+    setText(str: string): this {
+        if (str === this.rawText) return this;
+
+        this.rawText = str;
+        this._recalculateTextElement();
+        markUIDirty(this);
+        return this;
+    }
+
+    setTextScale(newScale: number): this {
+        if (newScale === this._scale) return this;
+
+        this.setScale(newScale);
+        this.rawText = this.text;
+        this._recalculateTextElement();
+        markUIDirty(this);
+        return this;
+    }
+
+    setTextColor(rgba: Color): this {
+        this.color = rgba;
+        return this;
+    }
+
+    setColor(rgba: Color): this {
+        this.bgcolor = rgba;
+        this._recalculateTextElement();
+        return this;
+    }
+
+    setMaxWidth(number: number): this {
+        if (number === this.maxWidth) return this;
+
+        this.maxWidth = number;
+        this._recalculateTextElement();
+        markUIDirty(this);
+        return this;
+    }
+
+    setJustify(align: 'left' | 'center' | 'right'): this {
+        if (align === this.justify) return this;
+        this.justify = align;
+        this._recalculateTextElement();
+        markUIDirty(this);
+        return this;
+    }
+
+    private _recalculateTextElement(): void {
+        const lines = this._wrapAtPixelWidth(this.rawText || '', this.maxWidth);
+
+        const joinedText = lines.join('\n');
+        super.setTextSync(joinedText);
     }
 
     setPosition(x: number, y: number): this {
@@ -641,6 +781,28 @@ export class UIManager {
         return element;
     }
 
+    spawnSdfText(
+        text: string = 'Text',
+        textScale: number = 1,
+        maxWidth: number = 400,
+        color: Color = [1, 1, 1, 1],
+        bgColor: Color = [0, 0, 0, 0],
+    ): UISdfText {
+        const name = this._generateName('sdftext');
+        const entity = this.game.spawnEntity(name);
+        const element = entity.addComponent(
+            UISdfText,
+            text,
+            textScale,
+            maxWidth,
+            color,
+            bgColor,
+            this.zlayer,
+        ) as UISdfText;
+        this.elements.set(name, element as unknown as UIElement);
+        return element;
+    }
+
     spawnSprite(
         texture: string = 'editorIcons',
         width: number = 64,
@@ -697,6 +859,7 @@ export class UIManager {
             text?: string;
             textScale?: number;
             textColor?: Color;
+            sdfText?: boolean;
             sprite?: string;
             spriteFrame?: number;
             spriteTileSet?: [number, number];
@@ -704,9 +867,9 @@ export class UIManager {
             hover?: boolean;
             clickFeedback?: number;
         },
-    ): { container: UIContainer; collider: Collider; child?: UIText | UISprite } {
+    ): { container: UIContainer; collider: Collider; child?: UIText | UISdfText | UISprite } {
         const container = this.spawnContainer(width, height, color);
-        let child: UIText | UISprite | undefined;
+        let child: UIText | UISdfText | UISprite | undefined;
         if (opts?.sprite) {
             child = this.spawnSprite(
                 opts.sprite,
@@ -716,13 +879,24 @@ export class UIManager {
                 opts.spriteTileSet ?? [1, 1],
             );
         } else if (opts?.text) {
-            child = this.spawnText(
-                opts.text,
-                opts.textScale ?? 0.5,
-                100,
-                opts.textColor ?? [1, 1, 1, 1],
-                [0, 0, 0, 0],
-            );
+            if (opts?.sdfText) {
+                const sdfScale = (opts.textScale ?? 0.5) * 2.5;
+                child = this.spawnSdfText(
+                    opts.text,
+                    sdfScale,
+                    300,
+                    opts.textColor ?? [1, 1, 1, 1],
+                    [0, 0, 0, 0],
+                );
+            } else {
+                child = this.spawnText(
+                    opts.text,
+                    opts.textScale ?? 0.5,
+                    100,
+                    opts.textColor ?? [1, 1, 1, 1],
+                    [0, 0, 0, 0],
+                );
+            }
         }
         if (child) {
             container.addChild(child, 'mid-center', 'mid-center');

--- a/src/classic/ui.ts
+++ b/src/classic/ui.ts
@@ -280,7 +280,7 @@ export class UISdfText extends SdfText {
         return this.textWidth;
     }
     get height(): number {
-        return this.textHeight;
+        return this._layoutHeight || this.textHeight;
     }
 
     private _wordPx(word: string): number {
@@ -369,6 +369,7 @@ export class UISdfText extends SdfText {
     }
 
     private _recalculateTextElement(): void {
+        this._layoutWidth = this.justify !== 'left' ? this.maxWidth : 0;
         const lines = this._wrapAtPixelWidth(this.rawText || '', this.maxWidth);
 
         const joinedText = lines.join('\n');

--- a/src/classic/utils.ts
+++ b/src/classic/utils.ts
@@ -549,6 +549,12 @@ export async function initSdfFonts(
             throw new Error(`Failed to load font metrics: ${entry.metrics}`);
         }
         fonts[entry.name] = (await resp.json()) as SdfFontMetrics;
+        if (fonts[entry.name].spread === undefined) {
+            console.warn(
+                `SDF font "${entry.name}" is missing "spread" in metrics JSON. ` +
+                    'Re-run make-font-atlas.mjs or the atlas may be stale.',
+            );
+        }
         stepDone += 1;
     }
 

--- a/src/classic/utils.ts
+++ b/src/classic/utils.ts
@@ -3,6 +3,8 @@ import { SimplexNoise } from '/lib/simplex-noise.js';
 import type {
     ShaderInfo,
     TextureManifestEntry,
+    SdfFontManifestEntry,
+    SdfFontMetrics,
     AnimationData,
     IShader,
     ITexture,
@@ -171,6 +173,7 @@ export const SHADER_FETCH_WEIGHT = 2; // vertex + fragment source fetches
 export const SHADER_COMPILE_WEIGHT = 1; // compile + link
 export const BUFFERS_WEIGHT = 1;
 export const TEXTURE_WEIGHT = 1; // image download + upload
+export const SDF_FONT_WEIGHT = 1;
 export const ANIMATIONS_WEIGHT = 1;
 
 export function estimateManifestWeight(manifest: Manifest): number {
@@ -179,6 +182,7 @@ export function estimateManifestWeight(manifest: Manifest): number {
         manifest.shaders.length * (SHADER_FETCH_WEIGHT + SHADER_COMPILE_WEIGHT) +
         BUFFERS_WEIGHT +
         manifest.textures.length * TEXTURE_WEIGHT +
+        (manifest.sdfFonts?.length ?? 0) * SDF_FONT_WEIGHT +
         ANIMATIONS_WEIGHT
     );
 }
@@ -214,6 +218,7 @@ export function initShaderProgram(
     gl: WebGLRenderingContext,
     vsSource: string,
     fsSource: string,
+    attributes?: string[],
 ): WebGLProgram | null {
     const vertexShader = loadShader(gl, gl.VERTEX_SHADER, vsSource);
     const fragmentShader = loadShader(gl, gl.FRAGMENT_SHADER, fsSource);
@@ -230,6 +235,13 @@ export function initShaderProgram(
 
     gl.attachShader(shaderProgram, vertexShader);
     gl.attachShader(shaderProgram, fragmentShader);
+
+    if (attributes) {
+        for (let i = 0; i < attributes.length; i++) {
+            gl.bindAttribLocation(shaderProgram, i, attributes[i]);
+        }
+    }
+
     gl.linkProgram(shaderProgram);
 
     if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
@@ -280,7 +292,12 @@ export class Shader implements IShader {
 
     compile(): void {
         console.log('Compiling', this.name, '...');
-        this.program = initShaderProgram(this.gl, this.vertexCode, this.fragmentCode);
+        this.program = initShaderProgram(
+            this.gl,
+            this.vertexCode,
+            this.fragmentCode,
+            this.attributes,
+        );
 
         if (!this.program) {
             throw new Error(`Failed to compile shader: ${this.name}`);
@@ -505,6 +522,37 @@ export async function initTextures(
     }
 
     return textures;
+}
+
+// ============================================================================
+// SDF Font Metrics
+// ============================================================================
+
+export async function initSdfFonts(
+    entries: SdfFontManifestEntry[],
+    onProgress?: ProgressCallback,
+): Promise<Record<string, SdfFontMetrics>> {
+    const fonts: Record<string, SdfFontMetrics> = {};
+
+    let stepDone = 0;
+    const report = (label: string) => {
+        if (onProgress) {
+            onProgress(label, stepDone / (entries.length || 1));
+        }
+    };
+
+    for (const entry of entries) {
+        report(`Loading font metrics: ${entry.name}`);
+        await slowSleep();
+        const resp = await fetch(entry.metrics);
+        if (!resp.ok) {
+            throw new Error(`Failed to load font metrics: ${entry.metrics}`);
+        }
+        fonts[entry.name] = (await resp.json()) as SdfFontMetrics;
+        stepDone += 1;
+    }
+
+    return fonts;
 }
 
 // ============================================================================

--- a/src/demo/prefabs.ts
+++ b/src/demo/prefabs.ts
@@ -25,6 +25,7 @@ declare module '/classic/types.js' {
         uiConsumedClick?: boolean;
         panelMenuOpen?: boolean;
         debugFootprints?: boolean;
+        _scrollContainers?: { x: number; y: number; w: number; h: number }[];
     }
 }
 
@@ -48,6 +49,15 @@ export function initCameraControllerWASD(): void {
         if (game.isKeyDown('KeyD')) game.camera.position[0] += game.scrollSpeed * game.deltaTime;
 
         if (Math.abs(game.mouseWheel) > 0.01) {
+            const sc = game._scrollContainers;
+            if (sc && sc.length > 0) {
+                const mx = game.mousePos[0];
+                const my = game.mousePos[1];
+                if (sc.some((r) => mx >= r.x && mx <= r.x + r.w && my >= r.y && my <= r.y + r.h)) {
+                    return;
+                }
+            }
+
             game.camera.scale[0] += game.mouseWheel * game.deltaTime;
             game.camera.scale[1] += game.mouseWheel * game.deltaTime;
 

--- a/src/demo/uiPrefabs.ts
+++ b/src/demo/uiPrefabs.ts
@@ -1,6 +1,6 @@
 import game from '/classic/state.js';
 import { Tilemap, IsometricNavMesh } from '/classic/isometric.js';
-import { UIManager, UIText, UISprite, UIElement, UIContainer } from '/classic/ui.js';
+import { UIManager, UIText, UISdfText, UISprite, UIElement, UIContainer } from '/classic/ui.js';
 import { Collider } from '/classic/collision.js';
 import {
     PRESET_ORDER,
@@ -64,9 +64,9 @@ export function initUI(): void {
 
 /** Top bar: FPS counter (left), title (center), controls hint (right). */
 function initTopBar(UI: UIManager): void {
-    const barH = Math.round(32 * _uiScale);
+    const barH = Math.round(56 * _uiScale);
     const textScale = 0.4 * _uiScale;
-    const titleScale = 0.6 * _uiScale;
+    const titleScale = 1.5 * _uiScale;
 
     const topBar = UI.spawnContainer(UI.root.width, barH, [0, 0, 0, 0.5]);
     UI.root.addChild(topBar, 'top-center', 'top-center');
@@ -74,16 +74,24 @@ function initTopBar(UI: UIManager): void {
     const fpsText = UI.spawnText('FPS', textScale, 100, [0, 0.6, 0, 1], [0, 0, 0, 0]);
     topBar.addChild(fpsText, 'mid-left', 'mid-left');
 
-    const title = UI.spawnText('CLASSIC WGL', titleScale, 400, [1, 0.53, 0.3, 1], [0, 0, 0, 0]);
+    const title = UI.spawnSdfText(
+        'CLASSIC WGL',
+        titleScale,
+        UI.root.width,
+        [1, 0.53, 0.3, 1],
+        [0, 0, 0, 0],
+    );
+    title.setOutline(0.12, [0.1, 0.05, 0, 1]);
     topBar.addChild(title, 'mid-center', 'mid-center');
 
-    const infoText = UI.spawnText(
-        'WASD MOVE | SCROLL ZOOM',
-        textScale,
+    const infoText = UI.spawnSdfText(
+        'WASD MOVE\nSCROLL ZOOM',
+        1.0 * _uiScale,
         400,
         [1, 0.2, 0.6, 1],
         [0, 0, 0, 0],
     );
+    infoText.setJustify('center');
     topBar.addChild(infoText, 'mid-right', 'mid-right');
 
     let lastFPS = 0;
@@ -303,7 +311,7 @@ function initToolButtons(UI: UIManager): void {
     ];
 
     const maxLabelLen = Math.max(...menuItems.map((m) => m.label.length));
-    const glyphPixelW = 16 * _uiScale;
+    const glyphPixelW = Math.round(20 * _uiScale);
     const menuW = maxLabelLen * glyphPixelW + menuPadding * 2;
     const menuH = menuItems.length * menuItemH + menuGap * (menuItems.length - 1) + menuPadding * 2;
 
@@ -319,7 +327,14 @@ function initToolButtons(UI: UIManager): void {
             game.agentSelected = !(game.agentSelected ?? true);
             return true;
         },
-        { text: 'A', textScale: 0.55 * _uiScale, priority: 1, hover: true, clickFeedback: 5 },
+        {
+            sdfText: true,
+            text: 'A',
+            textScale: 0.55 * _uiScale,
+            priority: 1,
+            hover: true,
+            clickFeedback: 5,
+        },
     );
 
     // Menu panel background
@@ -340,10 +355,10 @@ function initToolButtons(UI: UIManager): void {
             },
             { priority: 3 },
         );
-        const label = UI.spawnText(
+        const label = UI.spawnSdfText(
             item.label,
-            menuFontScale,
-            maxLabelLen + 2,
+            menuFontScale * 2.5,
+            maxLabelLen * 35,
             [1, 1, 1, 1],
             [0, 0, 0, 0],
         );
@@ -543,7 +558,7 @@ function initNavPalette(UI: UIManager): UIContainer {
 /** Height editing tool widget: value row + scale row + set/blend toggle. */
 function initHeightWidget(UI: UIManager): UIContainer {
     const btnSize = Math.round(32 * _uiScale);
-    const labelW = Math.round(50 * _uiScale);
+    const labelW = Math.round(70 * _uiScale);
     const gap = Math.round(4 * _uiScale);
     const widgetW = gap * 4 + btnSize * 2 + labelW;
     const rowH = btnSize;
@@ -570,11 +585,11 @@ function initHeightWidget(UI: UIManager): UIContainer {
             game.editorHeight = (game.editorHeight ?? 0) - 1;
             return true;
         },
-        { text: '-', textScale: 0.6 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '-', textScale: 0.6 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(hMinus, 'top-left', 'top-left');
 
-    const hLabel = UI.spawnText('0', 0.5 * _uiScale, 60, [1, 1, 1, 1], [0, 0, 0, 0]);
+    const hLabel = UI.spawnSdfText('0', 1.25 * _uiScale, 300, [1, 1, 1, 1], [0, 0, 0, 0]);
     container.addChild(hLabel, 'top-left', 'top-left');
 
     const { container: hPlus } = UI.spawnButton(
@@ -586,7 +601,7 @@ function initHeightWidget(UI: UIManager): UIContainer {
             game.editorHeight = (game.editorHeight ?? 0) + 1;
             return true;
         },
-        { text: '+', textScale: 0.6 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '+', textScale: 0.6 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(hPlus, 'top-left', 'top-left');
 
@@ -601,11 +616,11 @@ function initHeightWidget(UI: UIManager): UIContainer {
             updateHeightScale();
             return true;
         },
-        { text: 's-', textScale: 0.45 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: 's-', textScale: 0.45 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(sMinus, 'top-left', 'top-left');
 
-    const sLabel = UI.spawnText('x1', 0.45 * _uiScale, 60, [1, 1, 1, 1], [0, 0, 0, 0]);
+    const sLabel = UI.spawnSdfText('x1', 1.125 * _uiScale, 300, [1, 1, 1, 1], [0, 0, 0, 0]);
     container.addChild(sLabel, 'top-left', 'top-left');
 
     const { container: sPlus } = UI.spawnButton(
@@ -618,7 +633,7 @@ function initHeightWidget(UI: UIManager): UIContainer {
             updateHeightScale();
             return true;
         },
-        { text: 's+', textScale: 0.45 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: 's+', textScale: 0.45 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(sPlus, 'top-left', 'top-left');
 
@@ -632,7 +647,7 @@ function initHeightWidget(UI: UIManager): UIContainer {
             game.heightEditMode = game.heightEditMode === 'set' ? 'blend' : 'set';
             return true;
         },
-        { text: 'blend', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: 'blend', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(modeBtn, 'top-left', 'top-left');
 
@@ -661,7 +676,7 @@ function initHeightWidget(UI: UIManager): UIContainer {
 
         hLabel.setText((game.editorHeight ?? 0).toString());
         sLabel.setText('x' + (game.heightScaleMultiplier ?? 1).toString());
-        (modeTxt as UIText).setText(game.heightEditMode ?? 'blend');
+        (modeTxt as UISdfText).setText(game.heightEditMode ?? 'blend');
         UI.refreshLayout();
     });
 
@@ -673,8 +688,8 @@ function initHeightWidget(UI: UIManager): UIContainer {
 function initLightWidget(UI: UIManager): UIContainer {
     const btnSize = Math.round(36 * _uiScale);
     const smallBtn = Math.round(28 * _uiScale);
-    const labelW = Math.round(110 * _uiScale);
-    const dirW = Math.round(60 * _uiScale);
+    const labelW = Math.round(200 * _uiScale);
+    const dirW = Math.round(200 * _uiScale);
     const gap = Math.round(4 * _uiScale);
     const buttonGap = Math.round(12 * _uiScale);
     const presetRowW = gap * 4 + btnSize * 2 + labelW;
@@ -703,11 +718,17 @@ function initLightWidget(UI: UIManager): UIContainer {
             applyLightPreset(prev);
             return true;
         },
-        { text: '<<', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '<<', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(presetPrev, 'top-left', 'top-left');
 
-    const presetLabel = UI.spawnText('Sunny Day', 0.45 * _uiScale, 120, [1, 1, 1, 1], [0, 0, 0, 0]);
+    const presetLabel = UI.spawnSdfText(
+        'Sunny Day',
+        1.125 * _uiScale,
+        400,
+        [1, 1, 1, 1],
+        [0, 0, 0, 0],
+    );
     container.addChild(presetLabel, 'top-left', 'top-left');
 
     const { container: presetNext } = UI.spawnButton(
@@ -723,12 +744,12 @@ function initLightWidget(UI: UIManager): UIContainer {
             applyLightPreset(next);
             return true;
         },
-        { text: '>>', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '>>', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(presetNext, 'top-left', 'top-left');
 
     // Row 2: azimuth
-    const azLabel = UI.spawnText('az: 45deg', 0.45 * _uiScale, 80, [1, 1, 1, 1], [0, 0, 0, 0]);
+    const azLabel = UI.spawnSdfText('az: 45deg', 1.125 * _uiScale, 300, [1, 1, 1, 1], [0, 0, 0, 0]);
     container.addChild(azLabel, 'top-left', 'top-left');
 
     const { container: azMinus } = UI.spawnButton(
@@ -742,7 +763,7 @@ function initLightWidget(UI: UIManager): UIContainer {
             game.lightPreset = 'custom';
             return true;
         },
-        { text: '-', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '-', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(azMinus, 'top-left', 'top-left');
 
@@ -757,12 +778,12 @@ function initLightWidget(UI: UIManager): UIContainer {
             game.lightPreset = 'custom';
             return true;
         },
-        { text: '+', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '+', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(azPlus, 'top-left', 'top-left');
 
     // Row 3: elevation
-    const elLabel = UI.spawnText('el: 45deg', 0.45 * _uiScale, 80, [1, 1, 1, 1], [0, 0, 0, 0]);
+    const elLabel = UI.spawnSdfText('el: 45deg', 1.125 * _uiScale, 300, [1, 1, 1, 1], [0, 0, 0, 0]);
     container.addChild(elLabel, 'top-left', 'top-left');
 
     const { container: elMinus } = UI.spawnButton(
@@ -776,7 +797,7 @@ function initLightWidget(UI: UIManager): UIContainer {
             game.lightPreset = 'custom';
             return true;
         },
-        { text: '-', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '-', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(elMinus, 'top-left', 'top-left');
 
@@ -791,7 +812,7 @@ function initLightWidget(UI: UIManager): UIContainer {
             game.lightPreset = 'custom';
             return true;
         },
-        { text: '+', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
+        { sdfText: true, text: '+', textScale: 0.4 * _uiScale, hover: true, clickFeedback: 5 },
     );
     container.addChild(elPlus, 'top-left', 'top-left');
 

--- a/src/demo/uiPrefabs.ts
+++ b/src/demo/uiPrefabs.ts
@@ -34,6 +34,7 @@ let _tilePalette: UIContainer | null = null;
 let _navPalette: UIContainer | null = null;
 let _heightWidget: UIContainer | null = null;
 let _lightWidget: UIContainer | null = null;
+let _textShowcase: UIContainer | null = null;
 let _uiScale = 1;
 
 /**
@@ -59,6 +60,7 @@ export function initUI(): void {
     _navPalette = initNavPalette(UI);
     _heightWidget = initHeightWidget(UI);
     _lightWidget = initLightWidget(UI);
+    _textShowcase = initTextShowcase(UI);
     initEditorModeControl(UI);
 }
 
@@ -307,6 +309,15 @@ function initToolButtons(UI: UIManager): void {
                 isOpen = false;
             },
             isActive: () => game.debugFootprints ?? false,
+        },
+        {
+            label: 'Text Demo',
+            action: () => {
+                game.editorTarget = game.editorTarget === 'textDemo' ? 'none' : 'textDemo';
+                game.uiConsumedClick = true;
+                isOpen = false;
+            },
+            isActive: () => game.editorTarget === 'textDemo',
         },
     ];
 
@@ -856,6 +867,131 @@ function initLightWidget(UI: UIManager): UIContainer {
     return container;
 }
 
+/** SDF text rendering showcase panel. */
+function initTextShowcase(UI: UIManager): UIContainer {
+    const uiBorder = Math.round(10 * _uiScale);
+    const widgetW = Math.round(800 * _uiScale);
+    const widgetH = Math.round(400 * _uiScale);
+    const pad = Math.round(12 * _uiScale);
+
+    const container = UI.spawnContainer(widgetW, widgetH, [0.06, 0.06, 0.12, 0.92]);
+    UI.addColliderToElem(container).consumesClick = true;
+
+    const labelScale = 0.75 * _uiScale;
+    const lineH = Math.round(28 * _uiScale);
+
+    // Scale ramp
+    const scaleLabel = UI.spawnSdfText(
+        'Scale ramp:',
+        labelScale,
+        300,
+        [0.7, 0.7, 0.7, 1],
+        [0, 0, 0, 0],
+    );
+    container.addChild(scaleLabel, 'top-left', 'top-left');
+    scaleLabel.setPosition(pad, pad);
+
+    const scaleSamples = UI.spawnSdfText(
+        'Handgloves 0123',
+        labelScale,
+        600,
+        [1, 1, 1, 1],
+        [0, 0, 0, 0],
+    );
+    container.addChild(scaleSamples, 'top-left', 'top-left');
+    scaleSamples.setPosition(pad, pad + lineH);
+    scaleSamples.setTextScale(labelScale);
+    scaleSamples.setOutline(0.5, [0.1, 0.05, 0, 1]);
+
+    // Weight + outline row
+    const wLabel = UI.spawnSdfText(
+        'Weight −0.08 / outline 1px:',
+        labelScale * 0.8,
+        400,
+        [0.7, 0.7, 0.7, 1],
+        [0, 0, 0, 0],
+    );
+    container.addChild(wLabel, 'top-left', 'top-left');
+    wLabel.setPosition(pad, pad + lineH * 3);
+
+    const wSample = UI.spawnSdfText('BOLD', labelScale * 1.5, 300, [1, 0.5, 0.2, 1], [0, 0, 0, 0]);
+    container.addChild(wSample, 'top-left', 'top-left');
+    wSample.setPosition(pad, pad + lineH * 4);
+    wSample.setWeight(-0.08);
+    wSample.setOutline(1, [0.1, 0.02, 0, 1]);
+
+    // Justification
+    const jLabel = UI.spawnSdfText(
+        'Justification: left / center / right',
+        labelScale * 0.8,
+        400,
+        [0.7, 0.7, 0.7, 1],
+        [0, 0, 0, 0],
+    );
+    container.addChild(jLabel, 'top-left', 'top-left');
+    jLabel.setPosition(pad, pad + lineH * 6);
+
+    const jLeft = UI.spawnSdfText('left', labelScale, 180, [0.3, 0.8, 1, 1], [0, 0, 0, 0]);
+    container.addChild(jLeft, 'top-left', 'top-left');
+    jLeft.setPosition(pad, pad + lineH * 7);
+    jLeft.setJustify('left');
+
+    const jCenter = UI.spawnSdfText('center', labelScale, 180, [0.3, 1, 0.5, 1], [0, 0, 0, 0]);
+    container.addChild(jCenter, 'top-left', 'top-left');
+    jCenter.setPosition(pad, pad + lineH * 8.5);
+    jCenter.setJustify('center');
+
+    const jRight = UI.spawnSdfText('right', labelScale, 180, [1, 0.8, 0.3, 1], [0, 0, 0, 0]);
+    container.addChild(jRight, 'top-left', 'top-left');
+    jRight.setPosition(pad, pad + lineH * 10);
+    jRight.setJustify('right');
+
+    // Special characters row
+    const glyphLabel = UI.spawnSdfText(
+        '♔ ♕ ♖ ✓ ✗ ❤ ♻ ☠ ⚡ ★ ☆ ● ◆ № ½ ™ € ▲ ▼ █ ┌─┐',
+        labelScale,
+        widgetW - pad * 2,
+        [1, 0.8, 0.4, 1],
+        [0, 0, 0, 0],
+    );
+    container.addChild(glyphLabel, 'top-left', 'top-left');
+    glyphLabel.setPosition(pad, pad + lineH * 12);
+
+    // Shadow / glow demo
+    const shadowLabel = UI.spawnSdfText(
+        'Shadow (2,2 outl 2) / Glow',
+        labelScale * 0.8,
+        400,
+        [0.7, 0.7, 0.7, 1],
+        [0, 0, 0, 0],
+    );
+    container.addChild(shadowLabel, 'top-left', 'top-left');
+    shadowLabel.setPosition(pad, pad + lineH * 14);
+
+    const shadowSample = UI.spawnSdfText(
+        'SHADOW',
+        labelScale * 1.2,
+        300,
+        [1, 0.9, 0.3, 1],
+        [0, 0, 0, 0],
+    );
+    container.addChild(shadowSample, 'top-left', 'top-left');
+    shadowSample.setPosition(pad, pad + lineH * 15);
+    shadowSample.setShadow(2, 2, [0, 0, 0, 0.4], 2);
+
+    UI.root.entity.registerCall('update', () => {
+        const cw = game.canvas!.width;
+        const ch = game.canvas!.height;
+        const x0 = cw - uiBorder - widgetW;
+        const y0 = ch - uiBorder - widgetH;
+        container.setPosition(x0, y0);
+        UI.refreshLayout();
+    });
+
+    container.setEnabled(false);
+    return container;
+}
+
 /** Toggles palette/nav-mesh/height-widget visibility each frame based on game.editorTarget. */
 function initEditorModeControl(UI: UIManager): void {
     const navMeshEntity = game.getEntity('tilemapNavigation')!;
@@ -865,6 +1001,7 @@ function initEditorModeControl(UI: UIManager): void {
         if (_navPalette) _navPalette.setEnabled(game.editorTarget === 'navMesh');
         if (_heightWidget) _heightWidget.setEnabled(game.editorTarget === 'height');
         if (_lightWidget) _lightWidget.setEnabled(game.editorTarget === 'light');
+        if (_textShowcase) _textShowcase.setEnabled(game.editorTarget === 'textDemo');
         navMeshEntity.enabled = game.editorTarget === 'navMesh';
     });
 }

--- a/src/demo/uiPrefabs.ts
+++ b/src/demo/uiPrefabs.ts
@@ -66,7 +66,7 @@ export function initUI(): void {
 
 /** Top bar: FPS counter (left), title (center), controls hint (right). */
 function initTopBar(UI: UIManager): void {
-    const barH = Math.round(56 * _uiScale);
+    const barH = Math.round(68 * _uiScale);
     const textScale = 0.4 * _uiScale;
     const titleScale = 1.5 * _uiScale;
 
@@ -341,7 +341,7 @@ function initToolButtons(UI: UIManager): void {
         {
             sdfText: true,
             text: 'A',
-            textScale: 0.55 * _uiScale,
+            textScale: 0.42 * _uiScale,
             priority: 1,
             hover: true,
             clickFeedback: 5,
@@ -889,7 +889,7 @@ function initTextShowcase(UI: UIManager): UIContainer {
 
     const labelScale = 0.75 * _uiScale;
     const lineH = Math.round(28 * _uiScale);
-    const contentH = lineH * 17;
+    const contentH = lineH * 18;
 
     const scaleLabel = UI.spawnSdfText(
         'Scale ramp:',
@@ -1020,12 +1020,12 @@ function initTextShowcase(UI: UIManager): UIContainer {
         wLabel.setPosition(x0 + pad, y0 + pad + lineH * 3 - sy);
         wSample.setPosition(x0 + pad, y0 + pad + lineH * 4 - sy);
         jLabel.setPosition(x0 + pad, y0 + pad + lineH * 6 - sy);
-        jLeft.setPosition(x0 + pad, y0 + pad + lineH * 7 - sy);
-        jCenter.setPosition(x0 + pad, y0 + pad + lineH * 8.5 - sy);
-        jRight.setPosition(x0 + pad, y0 + pad + lineH * 10 - sy);
-        glyphLabel.setPosition(x0 + pad, y0 + pad + lineH * 12 - sy);
-        shadowLabel.setPosition(x0 + pad, y0 + pad + lineH * 14 - sy);
-        shadowSample.setPosition(x0 + pad, y0 + pad + lineH * 15 - sy);
+        jLeft.setPosition(x0 + pad, y0 + pad + lineH * 7.5 - sy);
+        jCenter.setPosition(x0 + pad, y0 + pad + lineH * 9.5 - sy);
+        jRight.setPosition(x0 + pad, y0 + pad + lineH * 11.5 - sy);
+        glyphLabel.setPosition(x0 + pad, y0 + pad + lineH * 13.5 - sy);
+        shadowLabel.setPosition(x0 + pad, y0 + pad + lineH * 15.5 - sy);
+        shadowSample.setPosition(x0 + pad, y0 + pad + lineH * 16.5 - sy);
 
         // Scrollbar thumb
         if (maxScroll > 0) {

--- a/src/demo/uiPrefabs.ts
+++ b/src/demo/uiPrefabs.ts
@@ -867,20 +867,30 @@ function initLightWidget(UI: UIManager): UIContainer {
     return container;
 }
 
-/** SDF text rendering showcase panel. */
+/** SDF text rendering showcase panel with scroll and scissor clipping. */
 function initTextShowcase(UI: UIManager): UIContainer {
     const uiBorder = Math.round(10 * _uiScale);
     const widgetW = Math.round(800 * _uiScale);
     const widgetH = Math.round(400 * _uiScale);
     const pad = Math.round(12 * _uiScale);
+    const scrollW = Math.round(8 * _uiScale);
 
     const container = UI.spawnContainer(widgetW, widgetH, [0.06, 0.06, 0.12, 0.92]);
     UI.addColliderToElem(container).consumesClick = true;
+    container.clipChildren = true;
+
+    const scrollTrack = UI.spawnElement(scrollW, widgetH, [0.15, 0.15, 0.15, 0.6]);
+    container.addChild(scrollTrack, 'mid-right', 'mid-right');
+    scrollTrack._uiFixed = true;
+
+    const scrollThumb = UI.spawnElement(scrollW, 40, [0.4, 0.4, 0.4, 0.8]);
+    container.addChild(scrollThumb, 'mid-right', 'mid-right');
+    scrollThumb._uiFixed = true;
 
     const labelScale = 0.75 * _uiScale;
     const lineH = Math.round(28 * _uiScale);
+    const contentH = lineH * 17;
 
-    // Scale ramp
     const scaleLabel = UI.spawnSdfText(
         'Scale ramp:',
         labelScale,
@@ -889,7 +899,6 @@ function initTextShowcase(UI: UIManager): UIContainer {
         [0, 0, 0, 0],
     );
     container.addChild(scaleLabel, 'top-left', 'top-left');
-    scaleLabel.setPosition(pad, pad);
 
     const scaleSamples = UI.spawnSdfText(
         'Handgloves 0123',
@@ -899,11 +908,9 @@ function initTextShowcase(UI: UIManager): UIContainer {
         [0, 0, 0, 0],
     );
     container.addChild(scaleSamples, 'top-left', 'top-left');
-    scaleSamples.setPosition(pad, pad + lineH);
     scaleSamples.setTextScale(labelScale);
     scaleSamples.setOutline(0.5, [0.1, 0.05, 0, 1]);
 
-    // Weight + outline row
     const wLabel = UI.spawnSdfText(
         'Weight −0.08 / outline 1px:',
         labelScale * 0.8,
@@ -912,15 +919,12 @@ function initTextShowcase(UI: UIManager): UIContainer {
         [0, 0, 0, 0],
     );
     container.addChild(wLabel, 'top-left', 'top-left');
-    wLabel.setPosition(pad, pad + lineH * 3);
 
     const wSample = UI.spawnSdfText('BOLD', labelScale * 1.5, 300, [1, 0.5, 0.2, 1], [0, 0, 0, 0]);
     container.addChild(wSample, 'top-left', 'top-left');
-    wSample.setPosition(pad, pad + lineH * 4);
     wSample.setWeight(-0.08);
     wSample.setOutline(1, [0.1, 0.02, 0, 1]);
 
-    // Justification
     const jLabel = UI.spawnSdfText(
         'Justification: left / center / right',
         labelScale * 0.8,
@@ -929,35 +933,46 @@ function initTextShowcase(UI: UIManager): UIContainer {
         [0, 0, 0, 0],
     );
     container.addChild(jLabel, 'top-left', 'top-left');
-    jLabel.setPosition(pad, pad + lineH * 6);
 
-    const jLeft = UI.spawnSdfText('left', labelScale, 180, [0.3, 0.8, 1, 1], [0, 0, 0, 0]);
+    const jLeft = UI.spawnSdfText(
+        'The quick brown fox jumps over the lazy dog.',
+        labelScale,
+        widgetW - pad * 2 - scrollW,
+        [0.3, 0.8, 1, 1],
+        [0, 0, 0, 0],
+    );
     container.addChild(jLeft, 'top-left', 'top-left');
-    jLeft.setPosition(pad, pad + lineH * 7);
     jLeft.setJustify('left');
 
-    const jCenter = UI.spawnSdfText('center', labelScale, 180, [0.3, 1, 0.5, 1], [0, 0, 0, 0]);
+    const jCenter = UI.spawnSdfText(
+        'The quick brown fox jumps over the lazy dog.',
+        labelScale,
+        widgetW - pad * 2 - scrollW,
+        [0.3, 1, 0.5, 1],
+        [0, 0, 0, 0],
+    );
     container.addChild(jCenter, 'top-left', 'top-left');
-    jCenter.setPosition(pad, pad + lineH * 8.5);
     jCenter.setJustify('center');
 
-    const jRight = UI.spawnSdfText('right', labelScale, 180, [1, 0.8, 0.3, 1], [0, 0, 0, 0]);
+    const jRight = UI.spawnSdfText(
+        'The quick brown fox jumps over the lazy dog.',
+        labelScale,
+        widgetW - pad * 2 - scrollW,
+        [1, 0.8, 0.3, 1],
+        [0, 0, 0, 0],
+    );
     container.addChild(jRight, 'top-left', 'top-left');
-    jRight.setPosition(pad, pad + lineH * 10);
     jRight.setJustify('right');
 
-    // Special characters row
     const glyphLabel = UI.spawnSdfText(
         '♔ ♕ ♖ ✓ ✗ ❤ ♻ ☠ ⚡ ★ ☆ ● ◆ № ½ ™ € ▲ ▼ █ ┌─┐',
         labelScale,
-        widgetW - pad * 2,
+        widgetW - pad * 2 - scrollW,
         [1, 0.8, 0.4, 1],
         [0, 0, 0, 0],
     );
     container.addChild(glyphLabel, 'top-left', 'top-left');
-    glyphLabel.setPosition(pad, pad + lineH * 12);
 
-    // Shadow / glow demo
     const shadowLabel = UI.spawnSdfText(
         'Shadow (2,2 outl 2) / Glow',
         labelScale * 0.8,
@@ -966,7 +981,6 @@ function initTextShowcase(UI: UIManager): UIContainer {
         [0, 0, 0, 0],
     );
     container.addChild(shadowLabel, 'top-left', 'top-left');
-    shadowLabel.setPosition(pad, pad + lineH * 14);
 
     const shadowSample = UI.spawnSdfText(
         'SHADOW',
@@ -976,7 +990,6 @@ function initTextShowcase(UI: UIManager): UIContainer {
         [0, 0, 0, 0],
     );
     container.addChild(shadowSample, 'top-left', 'top-left');
-    shadowSample.setPosition(pad, pad + lineH * 15);
     shadowSample.setShadow(2, 2, [0, 0, 0, 0.4], 2);
 
     UI.root.entity.registerCall('update', () => {
@@ -985,6 +998,50 @@ function initTextShowcase(UI: UIManager): UIContainer {
         const x0 = cw - uiBorder - widgetW;
         const y0 = ch - uiBorder - widgetH;
         container.setPosition(x0, y0);
+
+        if (container.entity.enabled) {
+            game._scrollContainers = [{ x: x0, y: y0, w: widgetW, h: widgetH }];
+        }
+
+        // Scroll
+        const maxScroll = Math.max(0, contentH - widgetH);
+        const mx = game.mousePos[0];
+        const my = game.mousePos[1];
+        const mouseInside = mx >= x0 && mx <= x0 + widgetW && my >= y0 && my <= y0 + widgetH;
+        if (maxScroll > 0 && game.panelMenuOpen !== true && mouseInside) {
+            container.scrollY += -game.mouseWheel * 30;
+            container.scrollY = Math.max(0, Math.min(maxScroll, container.scrollY));
+        }
+
+        const sy = container.scrollY;
+
+        scaleLabel.setPosition(x0 + pad, y0 + pad - sy);
+        scaleSamples.setPosition(x0 + pad, y0 + pad + lineH - sy);
+        wLabel.setPosition(x0 + pad, y0 + pad + lineH * 3 - sy);
+        wSample.setPosition(x0 + pad, y0 + pad + lineH * 4 - sy);
+        jLabel.setPosition(x0 + pad, y0 + pad + lineH * 6 - sy);
+        jLeft.setPosition(x0 + pad, y0 + pad + lineH * 7 - sy);
+        jCenter.setPosition(x0 + pad, y0 + pad + lineH * 8.5 - sy);
+        jRight.setPosition(x0 + pad, y0 + pad + lineH * 10 - sy);
+        glyphLabel.setPosition(x0 + pad, y0 + pad + lineH * 12 - sy);
+        shadowLabel.setPosition(x0 + pad, y0 + pad + lineH * 14 - sy);
+        shadowSample.setPosition(x0 + pad, y0 + pad + lineH * 15 - sy);
+
+        // Scrollbar thumb
+        if (maxScroll > 0) {
+            const thumbH = Math.max(20, (widgetH / contentH) * widgetH);
+            const thumbY = y0 + (sy / maxScroll) * (widgetH - thumbH);
+            scrollTrack.setSize(scrollW, widgetH);
+            scrollTrack.setPosition(x0 + widgetW - scrollW, y0);
+            scrollThumb.setSize(scrollW, thumbH);
+            scrollThumb.setPosition(x0 + widgetW - scrollW, thumbY);
+            scrollTrack.setEnabled(true);
+            scrollThumb.setEnabled(true);
+        } else {
+            scrollTrack.setEnabled(false);
+            scrollThumb.setEnabled(false);
+        }
+
         UI.refreshLayout();
     });
 

--- a/src/shaders/sdf.frag
+++ b/src/shaders/sdf.frag
@@ -1,4 +1,9 @@
 precision mediump float;
+
+#ifdef GL_OES_standard_derivatives
+#extension GL_OES_standard_derivatives : enable
+#endif
+
 varying mediump vec2 vTexCoord;
 
 uniform sampler2D texSampler;
@@ -6,23 +11,48 @@ uniform vec4 color;
 uniform vec4 outlineColor;
 uniform float outlineWidth;
 uniform float softEdge;
+uniform float spread;
+uniform vec2 atlasSize;
+uniform float weight;
+uniform float gamma;
 
 void main(void ) {
     float distance = texture2D(texSampler, vTexCoord).r;
-    float edge = 0.5;
+    float edge = 0.5 - weight;
 
-    float alpha = smoothstep(edge - softEdge, edge + softEdge, distance);
+    float w;
+
+    #ifdef GL_OES_standard_derivatives
+    vec2 uvPx = fwidth(vTexCoord) * atlasSize;
+    float pxRange = 2.0 * spread / max(length(uvPx), 1e-5);
+    w = clamp(0.5 / pxRange, 0.0001, 0.5);
+    #else
+    w = softEdge;
+    #endif
+
+    float alpha = smoothstep(edge - w, edge + w, distance);
 
     float outlineAlpha = 0.0;
     if (outlineWidth > 0.001 || outlineWidth < -0.001) {
-        float absWidth = abs(outlineWidth);
-        float outlineEdge = outlineWidth > 0.0 ? edge - absWidth : edge + absWidth;
-        outlineAlpha = smoothstep(outlineEdge - softEdge, outlineEdge + softEdge, distance);
+        float outlineSDF = outlineWidth / (2.0 * spread);
+        float outlineEdge = edge - outlineSDF;
+        outlineAlpha = smoothstep(outlineEdge - w, outlineEdge + w, distance);
     }
 
-    vec4 result;
-    result.rgb = mix(outlineColor.rgb, color.rgb, alpha);
-    result.a = max(alpha, outlineAlpha);
+    float fillAlpha = alpha * color.a;
+    float outAlpha = outlineAlpha * outlineColor.a;
 
-    gl_FragColor = result;
+    vec4 result;
+
+    result.rgb = mix(outlineColor.rgb, color.rgb, alpha) * (outAlpha + fillAlpha);
+    result.a = outAlpha + fillAlpha * (1.0 - outAlpha);
+
+    // per-frame alpha is controlled from JS side via color.a / outlineColor.a
+
+    float finalA = clamp(result.a, 0.0, 1.0);
+    if (gamma > 0.001) {
+        result.rgb *= pow(finalA, gamma - 1.0);
+    }
+
+    gl_FragColor = vec4(result.rgb, finalA);
 }

--- a/src/shaders/sdf.frag
+++ b/src/shaders/sdf.frag
@@ -1,0 +1,28 @@
+precision mediump float;
+varying mediump vec2 vTexCoord;
+
+uniform sampler2D texSampler;
+uniform vec4 color;
+uniform vec4 outlineColor;
+uniform float outlineWidth;
+uniform float softEdge;
+
+void main(void ) {
+    float distance = texture2D(texSampler, vTexCoord).r;
+    float edge = 0.5;
+
+    float alpha = smoothstep(edge - softEdge, edge + softEdge, distance);
+
+    float outlineAlpha = 0.0;
+    if (outlineWidth > 0.001 || outlineWidth < -0.001) {
+        float absWidth = abs(outlineWidth);
+        float outlineEdge = outlineWidth > 0.0 ? edge - absWidth : edge + absWidth;
+        outlineAlpha = smoothstep(outlineEdge - softEdge, outlineEdge + softEdge, distance);
+    }
+
+    vec4 result;
+    result.rgb = mix(outlineColor.rgb, color.rgb, alpha);
+    result.a = max(alpha, outlineAlpha);
+
+    gl_FragColor = result;
+}

--- a/src/shaders/sdf.vert
+++ b/src/shaders/sdf.vert
@@ -1,0 +1,13 @@
+attribute vec4 vertexPos;
+attribute vec2 texCoord;
+
+uniform mat4 modelMatrix;
+uniform mat4 cameraMatrix;
+uniform mat4 projectionMatrix;
+
+varying mediump vec2 vTexCoord;
+
+void main(void ) {
+    gl_Position = projectionMatrix * cameraMatrix * modelMatrix * vertexPos;
+    vTexCoord = texCoord;
+}

--- a/tests/classic/sdfText.test.ts
+++ b/tests/classic/sdfText.test.ts
@@ -10,6 +10,7 @@ const TEST_METRICS: SdfFontMetrics = {
     family: 'Test',
     atlasSize: [512, 512],
     glyphSize: 64,
+    spread: 4,
     baseline: 48,
     lineHeight: 83.2,
     glyphs: {
@@ -71,6 +72,8 @@ function createMockShader() {
             outlineColor: {},
             outlineWidth: {},
             softEdge: {},
+            spread: {},
+            atlasSize: {},
         },
     };
 }

--- a/tests/classic/sdfText.test.ts
+++ b/tests/classic/sdfText.test.ts
@@ -442,3 +442,65 @@ describe('UISdfText', () => {
         expect(instance.text).toBe('CBA');
     });
 });
+
+describe('UISdfText advance + buffer', () => {
+    let game: IGameState;
+
+    beforeEach(() => {
+        game = createMockGame({
+            textures: { 'test-sdf': createMockTexture() } as any,
+            shaders: { sdf: createMockShader(), solid: createMockSolidShader() } as any,
+            sdfFonts: { test: TEST_METRICS } as any,
+            getSdfFont: vi.fn(() => TEST_METRICS) as any,
+        });
+    });
+
+    it('advanceFor returns consistent widths for wrap and layout', async () => {
+        const { SdfText: SdfTextClass } = await loadSdfText();
+        const entity = new Entity(game, 1, 'advtest');
+        const instance = entity.addComponent(
+            SdfTextClass as any,
+            [0, 0, 0],
+            [1, 1, 1],
+            'test',
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            true,
+        ) as SdfText;
+
+        const advH = instance.advanceFor('H');
+        const advSpace = instance.advanceFor(' ');
+        const advUnknown = instance.advanceFor('\u4e00');
+        expect(advH).toBe(56);
+        expect(advSpace).toBe(18);
+        expect(advUnknown).toBe(32); // fallback = glyphSize * 0.5
+    });
+
+    it('skips bufferData on subsequent rawDraw calls when text unchanged', async () => {
+        const { SdfText: SdfTextClass } = await loadSdfText();
+        const entity = new Entity(game, 1, 'bufdirty');
+        const instance = entity.addComponent(
+            SdfTextClass as any,
+            [0, 0, 0],
+            [1, 1, 1],
+            'test',
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            true,
+        ) as SdfText;
+        instance.setText('AB');
+
+        const gl = (instance as any).gl as WebGLRenderingContext & {
+            bufferData: ReturnType<typeof vi.fn>;
+        };
+        const bufCalls = (gl.bufferData as ReturnType<typeof vi.fn>).mock.calls.length;
+
+        instance.rawDraw();
+        const calls1 = (gl.bufferData as ReturnType<typeof vi.fn>).mock.calls.length;
+        instance.rawDraw();
+        const calls2 = (gl.bufferData as ReturnType<typeof vi.fn>).mock.calls.length;
+
+        expect(calls1 - bufCalls).toBe(1);
+        expect(calls2).toBe(calls1); // no new bufferData call
+    });
+});

--- a/tests/classic/sdfText.test.ts
+++ b/tests/classic/sdfText.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Entity } from '/classic/ecs.js';
+import { createMockGame } from '../helpers/mockGame.js';
+import type { IGameState } from '/classic/types.js';
+import type { SdfText } from '/classic/sdfText.js';
+import type { SdfFontMetrics } from '/classic/sdfText.js';
+
+const TEST_METRICS: SdfFontMetrics = {
+    name: 'test',
+    family: 'Test',
+    atlasSize: [512, 512],
+    glyphSize: 64,
+    baseline: 48,
+    lineHeight: 83.2,
+    glyphs: {
+        A: { x: 0, y: 0, w: 64, h: 64, xOffset: 0, yOffset: -56, xAdvance: 52.0 },
+        B: { x: 64, y: 0, w: 64, h: 64, xOffset: 0, yOffset: -56, xAdvance: 52.0 },
+        C: { x: 128, y: 0, w: 64, h: 64, xOffset: 0, yOffset: -56, xAdvance: 48.0 },
+        ' ': { x: 192, y: 0, w: 64, h: 64, xOffset: 0, yOffset: 0, xAdvance: 18.0 },
+        W: { x: 256, y: 0, w: 64, h: 64, xOffset: 0, yOffset: -56, xAdvance: 76.0 },
+        '.': { x: 320, y: 0, w: 64, h: 64, xOffset: 0, yOffset: -12, xAdvance: 18.0 },
+        i: { x: 384, y: 0, w: 64, h: 64, xOffset: -8, yOffset: -56, xAdvance: 22.0 },
+        l: { x: 448, y: 0, w: 64, h: 64, xOffset: 0, yOffset: -56, xAdvance: 22.0 },
+        H: { x: 0, y: 64, w: 64, h: 64, xOffset: 0, yOffset: -56, xAdvance: 56.0 },
+        e: { x: 64, y: 64, w: 64, h: 64, xOffset: 0, yOffset: -44, xAdvance: 44.0 },
+        o: { x: 128, y: 64, w: 64, h: 64, xOffset: 0, yOffset: -44, xAdvance: 44.0 },
+    },
+};
+
+function createMockTexture() {
+    return {
+        image: { width: 512, height: 512 } as HTMLImageElement,
+        bind: vi.fn(),
+        name: 'test-sdf',
+        gl: {} as WebGLRenderingContext,
+        texture: {} as WebGLTexture,
+    };
+}
+
+function createMockSolidShader() {
+    return {
+        bind: vi.fn(),
+        unbind: vi.fn(),
+        gl: {} as WebGLRenderingContext,
+        name: 'solid',
+        program: {} as WebGLProgram,
+        attr: { vertexPos: 0 },
+        unif: {
+            modelMatrix: {},
+            cameraMatrix: {},
+            projectionMatrix: {},
+            color: {},
+        },
+    };
+}
+
+function createMockShader() {
+    return {
+        bind: vi.fn(),
+        unbind: vi.fn(),
+        gl: {} as WebGLRenderingContext,
+        name: 'sdf',
+        program: {} as WebGLProgram,
+        attr: { vertexPos: 0, texCoord: 1 },
+        unif: {
+            modelMatrix: {},
+            cameraMatrix: {},
+            projectionMatrix: {},
+            texSampler: {},
+            color: {},
+            outlineColor: {},
+            outlineWidth: {},
+            softEdge: {},
+        },
+    };
+}
+
+async function loadSdfText() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (await import('/classic/sdfText.js')) as any;
+}
+
+async function loadUiSdfText() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (await import('/classic/ui.js')) as any;
+}
+
+describe('SdfText', () => {
+    let game: IGameState;
+
+    beforeEach(() => {
+        game = createMockGame({
+            textures: { 'test-sdf': createMockTexture() } as any,
+            shaders: { sdf: createMockShader(), solid: createMockSolidShader() } as any,
+            sdfFonts: { test: TEST_METRICS } as any,
+            getSdfFont: vi.fn((name: string) => {
+                return TEST_METRICS;
+            }) as any,
+        });
+    });
+
+    describe('construction', () => {
+        it('loads metrics synchronously from game state', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            expect(instance.metrics).toBe(TEST_METRICS);
+            expect(instance.vertexCount).toBe(0);
+            expect(instance.color).toEqual([1, 1, 1, 1]);
+            expect(instance.bgcolor).toEqual([0, 0, 0, 0]);
+            expect(instance.outlineWidth).toBe(0);
+            expect(instance.ignoreCam).toBe(true);
+        });
+    });
+
+    describe('setText', () => {
+        it('builds vertex data synchronously', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setText('A');
+
+            expect(instance.vertexCount).toBe(6);
+            expect(instance.glyphData.length).toBe(6 * 4);
+        });
+
+        it('computes correct textWidth from advance values', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setText('ABC');
+
+            const expectedWidth = 52 + 52 + 48;
+            expect(instance.textWidth).toBeCloseTo(expectedWidth, 0);
+        });
+
+        it('distinguishes wide and narrow characters', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setText('W');
+            const wideWidth = instance.textWidth;
+
+            instance.setText('i');
+            const narrowWidth = instance.textWidth;
+
+            expect(wideWidth).toBeGreaterThan(narrowWidth);
+        });
+
+        it('handles spaces with space advance', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setText('A A');
+
+            const expected = 52 + 18 + 52;
+            expect(instance.textWidth).toBeCloseTo(expected, 0);
+        });
+
+        it('produces valid UV atlas coordinates', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setText('A');
+
+            const data = instance.glyphData;
+
+            for (let v = 0; v < 6; v++) {
+                const uvX = data[v * 4 + 2];
+                const uvY = data[v * 4 + 3];
+
+                expect(uvX).toBeGreaterThanOrEqual(0);
+                expect(uvX).toBeLessThanOrEqual(1);
+                expect(uvY).toBeGreaterThanOrEqual(0);
+                expect(uvY).toBeLessThanOrEqual(1);
+            }
+        });
+
+        it('clears vertex data for empty string', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setText('A');
+            expect(instance.vertexCount).toBe(6);
+
+            instance.setText('');
+            expect(instance.vertexCount).toBe(0);
+        });
+    });
+
+    describe('outline', () => {
+        it('defaults to no outline', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            expect(instance.outlineWidth).toBe(0);
+        });
+
+        it('setOutline configures outline width and color', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setOutline(0.1, [1, 0, 0, 1]);
+            expect(instance.outlineWidth).toBe(0.1);
+            expect(instance.outlineColor).toEqual([1, 0, 0, 1]);
+        });
+    });
+
+    describe('shadow', () => {
+        it('defaults to no shadow offset', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            expect(instance.shadowOffset).toEqual([0, 0]);
+        });
+
+        it('setShadow configures shadow offset and color', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setShadow(2, 3, [0, 0, 0, 0.8], 1);
+            expect(instance.shadowOffset).toEqual([2, 3]);
+            expect(instance.shadowColor).toEqual([0, 0, 0, 0.8]);
+        });
+    });
+
+    describe('rawDraw', () => {
+        it('binds shader and draws vertices', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+            instance.setText('ABC');
+
+            const drawArraysSpy = game.gl.drawArrays as ReturnType<typeof vi.fn>;
+            instance.rawDraw();
+
+            expect(drawArraysSpy).toHaveBeenCalled();
+            const callArgs = drawArraysSpy.mock.calls[0];
+            expect(callArgs[0]).toBe(0x0004);
+            expect(callArgs[2]).toBe(instance.vertexCount);
+        });
+
+        it('skips draw call when vertexCount is 0', async () => {
+            const { SdfText: SdfTextClass } = await loadSdfText();
+            const entity = new Entity(game, 1, 'sdftext');
+            const instance = entity.addComponent(
+                SdfTextClass as any,
+                [0, 0, 0],
+                [1, 1, 1],
+                'test',
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                true,
+            ) as SdfText;
+
+            const drawArraysSpy = game.gl.drawArrays as ReturnType<typeof vi.fn>;
+            drawArraysSpy.mockClear();
+            instance.rawDraw();
+
+            expect(drawArraysSpy).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('UISdfText', () => {
+    let game: IGameState;
+
+    beforeEach(() => {
+        game = createMockGame({
+            textures: { 'dejavusans-sdf': createMockTexture() } as any,
+            shaders: { sdf: createMockShader(), solid: createMockSolidShader() } as any,
+            sdfFonts: { dejavusans: TEST_METRICS } as any,
+            getSdfFont: vi.fn((name: string) => {
+                return { dejavusans: TEST_METRICS }[name];
+            }) as any,
+        });
+    });
+
+    it('builds text synchronously in constructor', async () => {
+        const { UISdfText: UISdfTextClass } = await loadUiSdfText();
+        const entity = new Entity(game, 1, 'uisdf');
+        const instance = entity.addComponent(
+            UISdfTextClass as any,
+            'Hello World',
+            1,
+            500,
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            0,
+        ) as SdfText;
+
+        expect(instance.text).toBe('Hello World');
+        expect(instance.vertexCount).toBe(54);
+    });
+
+    it('breaks long text into multiple lines', async () => {
+        const { UISdfText: UISdfTextClass } = await loadUiSdfText();
+        const entity = new Entity(game, 1, 'uisdf');
+        const instance = entity.addComponent(
+            UISdfTextClass as any,
+            'A B',
+            1,
+            60,
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            0,
+        ) as SdfText;
+
+        expect(instance.text).toBe('A\nB');
+    });
+
+    it('handles empty string', async () => {
+        const { UISdfText: UISdfTextClass } = await loadUiSdfText();
+        const entity = new Entity(game, 1, 'uisdf');
+        const instance = entity.addComponent(
+            UISdfTextClass as any,
+            '',
+            1,
+            100,
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            0,
+        ) as SdfText;
+
+        expect(instance.text).toBe('');
+        expect(instance.vertexCount).toBe(0);
+    });
+
+    it('updates text synchronously via setText', async () => {
+        const { UISdfText: UISdfTextClass } = await loadUiSdfText();
+        const entity = new Entity(game, 1, 'uisdf');
+        const instance = entity.addComponent(
+            UISdfTextClass as any,
+            'ABC',
+            1,
+            400,
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            0,
+        ) as SdfText;
+
+        instance.setText('CBA');
+        expect(instance.text).toBe('CBA');
+    });
+});

--- a/tests/classic/shader.test.ts
+++ b/tests/classic/shader.test.ts
@@ -70,6 +70,7 @@ function createMockShaderGL(overrides: Partial<ShaderGL> = {}): ShaderGL {
             return true;
         }),
         getProgramInfoLog: vi.fn(() => ''),
+        bindAttribLocation: vi.fn(),
         getAttribLocation: vi.fn(() => 0),
         getUniformLocation: vi.fn(() => ({})),
         useProgram: vi.fn(),

--- a/tests/classic/utils.test.ts
+++ b/tests/classic/utils.test.ts
@@ -118,21 +118,27 @@ describe('estimateManifestWeight', () => {
     const texture = { name: 't', src: '/res/t.png' };
 
     it('counts each shader as fetch (2) plus compile (1)', () => {
-        const manifest = { shaders: [shader, shader], textures: [], animations: [] } as Manifest;
-        expect(estimateManifestWeight(manifest)).toBe(2 + 2 * 3 + 1 + 0 + 1);
+        const manifest = {
+            shaders: [shader, shader],
+            textures: [],
+            sdfFonts: [],
+            animations: [],
+        } as Manifest;
+        expect(estimateManifestWeight(manifest)).toBe(2 + 2 * 3 + 1 + 0 + 0 + 1);
     });
 
     it('counts each texture as one unit', () => {
         const manifest = {
             shaders: [],
             textures: [texture, texture, texture],
+            sdfFonts: [],
             animations: [],
         } as Manifest;
-        expect(estimateManifestWeight(manifest)).toBe(2 + 0 + 1 + 3 * 1 + 1);
+        expect(estimateManifestWeight(manifest)).toBe(2 + 0 + 1 + 3 * 1 + 0 + 1);
     });
 
     it('accounts for manifest, buffers and animations overhead', () => {
-        const manifest = { shaders: [], textures: [], animations: [] } as Manifest;
-        expect(estimateManifestWeight(manifest)).toBe(2 + 0 + 1 + 0 + 1);
+        const manifest = { shaders: [], textures: [], sdfFonts: [], animations: [] } as Manifest;
+        expect(estimateManifestWeight(manifest)).toBe(2 + 0 + 1 + 0 + 0 + 1);
     });
 });

--- a/tests/helpers/mockGame.ts
+++ b/tests/helpers/mockGame.ts
@@ -44,6 +44,7 @@ export function createMockGL(): WebGLRenderingContext {
         uniform4fv: vi.fn(),
         uniform1i: vi.fn(),
         uniform1f: vi.fn(),
+        uniform2f: vi.fn(),
         drawElements: vi.fn(),
         drawArrays: vi.fn(),
         activeTexture: vi.fn(),

--- a/tests/helpers/mockGame.ts
+++ b/tests/helpers/mockGame.ts
@@ -21,19 +21,37 @@ export function createMockGL(): WebGLRenderingContext {
         ARRAY_BUFFER: 0x8892,
         ELEMENT_ARRAY_BUFFER: 0x8893,
         STATIC_DRAW: 0x88e4,
+        DYNAMIC_DRAW: 0x88e8,
         FLOAT: 0x1406,
         UNSIGNED_SHORT: 0x1403,
         LINE_LOOP: 0x0002,
         TRIANGLES: 0x0004,
+        TEXTURE0: 0x84c0,
+        TEXTURE_2D: 0x0de1,
+        TEXTURE_BINDING_2D: 0x8069,
+        TEXTURE_MIN_FILTER: 0x2801,
+        TEXTURE_MAG_FILTER: 0x2800,
+        LINEAR: 0x2601,
+        NEAREST: 0x2600,
+        CURRENT_PROGRAM: 0x8b8d,
         createBuffer: vi.fn(() => ({})),
+        deleteBuffer: vi.fn(),
         bindBuffer: vi.fn(),
         bufferData: vi.fn(),
         vertexAttribPointer: vi.fn(),
         enableVertexAttribArray: vi.fn(),
         uniformMatrix4fv: vi.fn(),
         uniform4fv: vi.fn(),
+        uniform1i: vi.fn(),
+        uniform1f: vi.fn(),
         drawElements: vi.fn(),
         drawArrays: vi.fn(),
+        activeTexture: vi.fn(),
+        bindTexture: vi.fn(),
+        texParameteri: vi.fn(),
+        getParameter: vi.fn(() => null),
+        getUniform: vi.fn(() => 0),
+        getError: vi.fn(() => 0),
     };
 
     return gl as unknown as WebGLRenderingContext;
@@ -59,6 +77,10 @@ export function createMockPhysics(): IPhysicsProvider {
 export function createMockGame(overrides: Partial<IGameState> = {}): IGameState {
     const gl = createMockGL();
 
+    const textures: Record<string, unknown> = {};
+    const shaders: Record<string, unknown> = {};
+    const sdfFonts: Record<string, unknown> = {};
+
     const base = {
         gl,
         physics: createMockPhysics(),
@@ -66,6 +88,48 @@ export function createMockGame(overrides: Partial<IGameState> = {}): IGameState 
         calls: {},
         canvas: { width: 800, height: 600 } as unknown as HTMLCanvasElement,
         mousePos: vec3.create(),
+        projectionMatrix: new Float32Array(16),
+        camera: {
+            matrix: vi.fn(() => new Float32Array(16)),
+        },
+        textures,
+        shaders,
+        buffers: {
+            quad: {
+                verts: {
+                    bind: vi.fn(),
+                    unbind: vi.fn(),
+                    gl: gl as unknown as WebGLRenderingContext,
+                    buffer: {},
+                },
+                indices: {
+                    bind: vi.fn(),
+                    unbind: vi.fn(),
+                    gl: gl as unknown as WebGLRenderingContext,
+                    buffer: {},
+                },
+                uvs: {
+                    bind: vi.fn(),
+                    unbind: vi.fn(),
+                    gl: gl as unknown as WebGLRenderingContext,
+                    buffer: {},
+                },
+            },
+        },
+        sdfFonts,
+        getTexture: vi.fn((name: string) => {
+            if (textures[name]) return textures[name];
+            return {
+                image: { width: 512, height: 512 } as HTMLImageElement,
+                bind: vi.fn(),
+                name,
+                gl: gl as unknown as WebGLRenderingContext,
+                texture: {} as unknown as WebGLTexture,
+            };
+        }),
+        getSdfFont: vi.fn((name: string) => {
+            return sdfFonts[name];
+        }),
         registerCall: vi.fn(),
         unregisterCall: vi.fn(),
         ...overrides,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
                 'src/classic/registry.ts',
                 'src/classic/loader.ts',
                 'src/classic/consoleLog.ts',
+                'src/classic/sdfText.ts',
             ],
         },
     },


### PR DESCRIPTION
<!-- pr-msg-meta
branch: sdf-text
base: dev-ui-spawnbutton
submitted:
  github: ___
-->

## Add `SdfText` renderer with build-time atlas and word-wrap UI

### Motivation

The engine had no in-canvas text rendering — every string required a
full `Text` component that renders to an FBO per string with
expensive per-frame GL state switching.  SDF (signed distance field)
text renders each glyph as a vertex-buffered quad from a
pre-generated atlas, enabling crisp, scalable text with proper alpha
compositing, outlines, shadows, and glow — all in a single draw pass
with zero FBO overhead.

The build-time atlas generator (`scripts/make-font-atlas.mjs`)
produces the SDF texture + metrics JSON without any runtime font
parsing, so text loads synchronously during `loadResources()`
alongside the existing shader/texture pipeline.

### Src of research

The SDF text approach follows the standard GPU-text rendering
literature,

- https://steamcdn-a.akamaihd.net/apps/valve/2007
  /SIGGRAPH2007_AlphaTestedMagnification.pdf (Green, Valve
  SIGGRAPH 2007)
- https://github.com/Chlumsky/msdf-atlas-gen (Chlumský,
  multi-channel SDF atlas generator)

### Summary of changes

- Add `SdfText` class (`src/classic/sdfText.ts`) — synchronous
  vertex-buffer text renderer with per-glyph atlas UV mapping,
  `setText()`, `setOutline()`, `setShadow()`, `setGlow()`,
  `setWeight()`, `setGamma()`, `advanceFor()` character-width lookup,
  and a `_bufferDirty` flag that skips redundant GPU uploads when
  text hasn't changed.
  * Interleaved `Float32Array` vertex buffer ([posX,posY,uvX,uvY] ×
    6 verts/glyph) uploaded once per `setText()`, drawn via
    `drawArrays(GL_TRIANGLES)`.
  * `modelMatrix(offset?)` folds shadow/glow offsets into translation
    before the `S(textWidth, textHeight)` scale, keeping offsets in
    screen pixels.
  * LINEAR filtering on atlas texture overridden in constructor after
    engine default NEAREST.

- Add `UISdfText` (`src/classic/ui.ts`) — extends `SdfText` with
  word-wrap to pixel width (via `_wrapAtPixelWidth()`), hard `\n`
  break, `'left'` / `'center'` / `'right'` per-line justification,
  and layout-aware height (`_layoutHeight` = ink bounds minus SDF
  spread margin) so the UI anchor system places text by its visible
  glyphs, not the padded atlas cell.
  * `spawnSdfText()` factory: `UIManager.spawnSdfText(text, scale,
    maxWidth, color, bgcolor, justify?)` → returns a positioned
    `UISdfText`.

- Add `scripts/make-font-atlas.mjs` — build-time atlas generator
  using `@napi-rs/canvas` (dev-only).  Rasterises `.ttf`/`.otf`
  fonts, computes separable Felzenszwalb EDT (O(n) per glyph →
  pixel-accurate distance field), super-samples at 12× for
  anti-aliased edges, shelf-packs glyph cells into a power-of-two
  atlas PNG, and emits a metrics JSON.
  * SHA-256 cache key (font bytes + charset + params); cached `.sig`
    sidecar avoids redundant regeneration across builds.
  * CLI: `--family`, `--ss`, `--spread`, `--max-size`, `--charset`
    (18 named groups: ASCII, Latin1, math, box-draw, arrows,
    dingbats, keys, etc.; `--charset all` → ~935 glyphs on 2048²
    atlas).
  * `.notdef` detection via bitmap hash comparison prevents blank
    glyphs.

- Add `sdf.frag` / `sdf.vert` shaders — fragment shader with
  derivative-based AA (`fwidth(vTexCoord) × atlasSize → 1 /
  pxRange`), fill:outline alpha compositing, `weight` uniform for
  faux bold/light (edge shift), `gamma` for perceptual blending.
  Falls back to `softEdge` uniform when `GL_OES_standard_derivatives`
  is unavailable.

- Wire `sdfFonts` into `game` state (`state.ts`, `types.ts`,
  `utils.ts`) — `game.sdfFonts` dictionary, `getSdfFont(name)`,
  `initSdfFonts()` synchronous metrics loader (warns if `spread`
  field missing), `Manifest.sdfFonts[]`, `SdfFontMetrics` /
  `GlyphMetrics` types.  Manifest example:
  ```json
  { "sdfFonts": [
    { "name": "dejavusans",
      "metrics": "/res/dejavusans-sdf.json" }
  ] }
  ```
  * `manifest.json` updated with `dejavusans` font + `dejavusans-sdf`
    texture + `sdf` shader with all uniforms declared.

- Add SDF text demo showcase panel (`src/demo/uiPrefabs.ts`,
  `prefabs.ts`) — scrollable panel with live samples for scale,
  weight (bold ↔ light), justification (left/center/right), outline,
  and shadow.  Wired to the editor tool palette as `textDemo` target;
  scissor-test clipped via `UIContainer._uiClipRect` propagation.

- Add `tests/classic/sdfText.test.ts` (506 lines) — covers `SdfText`
  construction defaults, `setText` vertex data (6 verts/glyph,
  interleaved pos+UV), glyph advance widths, UV atlas bounds
  `[0..1]`, empty-string clear, outline/shadow config, `rawDraw` GL
  call dispatch + `bufferData` skip on unchanged text, and
  `UISdfText` word-wrap / justification / layout.

- Add `classic-sdf-text` engine skill (461 lines in
  `.claude/skills/classic-sdf-text/`) documenting the full subsystem:
  architecture, atlas generator, coordinate system, shader uniforms,
  GL requirements (`bindAttribLocation` before `linkProgram`, LINEAR
  filter override, interleaved buffer format, scissor-test clipping),
  `UISdfText` features (wrap, justify, outline, shadow, glow,
  snapToPixel), manifest integration, and a 22-entry common-pitfalls
  table.

- Expand test mocks (`tests/helpers/mockGame.ts`) with
  `DYNAMIC_DRAW`, texture constants (`TEXTURE0`, `TEXTURE_2D`,
  `LINEAR`, etc.), `uniform1i`, `uniform1f`, `uniform2f`,
  `activeTexture`, `bindTexture`, `texParameteri`, `getParameter`,
  `getUniform`, `getError`, `deleteBuffer`, mock `buffers.quad` with
  bind/unbind, and `getSdfFont` / `getTexture` factory fns.

- Bump `assets/` submodule to v0.2.0 (includes DejaVuSans font
  source). Add `@napi-rs/canvas` (devDep) and `opentype.js` (devDep)
  to `package.json`.  Add `src/classic/sdfText.ts` to coverage scope
  in `vite.config.ts`.

- Update `classic-gl-state` and `classic-ui` engine skills with SDF
  text sections (sampler binding order, `_uiScale` / `snapToPixel`,
  `_uiFixed` children for scrollbars).

(this pr content was generated in some part by `opencode` using
`deepseek-v4-pro` (`deepseek`))
