### PR TITLE
fix debug compass rose to use iso-aligned cardinal directions

### DIFF
--- a/.claude/skills/isometric-coordinates/SKILL.md
+++ b/.claude/skills/isometric-coordinates/SKILL.md
@@ -59,25 +59,39 @@ correctly separating them.
 
 ### Iso ↔ cardinal / screen mapping
 
-In this engine, the iso-grid directions map to cardinal compass points and
-screen directions as follows (verify with the debug compass rose overlay):
+Cardinals are aligned with iso-grid axes (North = `−ty`, East = `+tx`, etc.).
+Verify orientations with the debug compass rose overlay:
 
-| Iso direction | Cardinal | Screen direction | Depth (`tx−ty`) |
+| Iso `(dtx, dty)` | Cardinal | Screen direction | Depth (`tx−ty`) |
 |:---|:---|:---|:---|
-| NE `(+tx, −ty)` | **N** | straight **UP** | Farthest |
-| SE `(+tx, +ty)` | **E** | straight **RIGHT** | Mid |
-| SW `(−tx, +ty)` | **S** | straight **DOWN** | Closest |
-| NW `(−tx, −ty)` | **W** | straight **LEFT** | Mid |
+| `(+tx, 0)` | **E** | right-up 2:1 | rising |
+| `(0, +ty)` | **S** | right-down 2:1 | rising |
+| `(−tx, 0)` | **W** | left-down 2:1 | falling |
+| `(0, −ty)` | **N** | left-up 2:1 | falling |
 
-Intercardinals (NE/SE/SW/NW in compass terms) map to the 2:1 diagonal screen
-vectors between these cardinals:
+The intercardinals (NE/SE/SW/NW in compass terms) are the tile-grid edges
+that run along the screen axes:
 
-| Compass | Iso `(dtx, dty)` | Screen vector |
-|:---|:---|:---|
-| **NE** | `(+1, 0)` | right-up 2:1 |
-| **SE** | `(0, +1)` | right-down 2:1 |
-| **SW** | `(−1, 0)` | left-down 2:1 |
-| **NW** | `(0, −1)` | left-up 2:1 |
+| Compass | Iso `(dtx, dty)` | Screen vector | Depth (`tx−ty`) |
+|:---|:---|:---|:---|
+| **NE** | `(+1, −1)` | straight UP | Farthest |
+| **SE** | `(+1, +1)` | straight RIGHT | Mid |
+| **SW** | `(−1, +1)` | straight DOWN | Closest |
+| **NW** | `(−1, −1)` | straight LEFT | Mid |
+
+### Screen projection formula
+
+The 2:1 dimetric projection (`scale(1, 0.5, 1) · Rz(−45°)`) means for any tile
+delta `(dtx, dty)` at tilemap scale `s`:
+
+```
+screen_x = s · (dtx + dty)
+screen_y = s · (dty − dtx) / 2
+```
+
+This is equivalent to an orthographic camera at elevation `asin(0.5)` = 30°.
+Spritesheets must be rendered at 30° elevation or the implied ground plane
+will not match the tile grid.
 
 ---
 

--- a/.claude/skills/isometric-tilemap/SKILL.md
+++ b/.claude/skills/isometric-tilemap/SKILL.md
@@ -47,24 +47,24 @@ On-screen:
 
 ### Iso ↔ cardinal / screen mapping
 
-The iso-grid directions map to cardinal compass points. Use the debug overlay
-("Footprints" toggle in DEV menu) to verify:
+Cardinals align with iso-grid axes. Verify with the debug compass rose
+overlay ("Footprints" toggle in DEV menu):
 
-| Iso direction | Cardinal | Screen | `(dtx, dty)` |
-|:---|:---|:---|:---|
-| NE | **N** | straight UP | `(+1, −1)` |
-| SE | **E** | straight RIGHT | `(+1, +1)` |
-| SW | **S** | straight DOWN | `(−1, +1)` |
-| NW | **W** | straight LEFT | `(−1, −1)` |
+| Iso `(dtx, dty)` | Cardinal | Screen vector |
+|:---|:---|:---|
+| `(+tx, 0)` | **E** | right-up 2:1 |
+| `(0, +ty)` | **S** | right-down 2:1 |
+| `(−tx, 0)` | **W** | left-down 2:1 |
+| `(0, −ty)` | **N** | left-up 2:1 |
 
-Intercardinals map to 2:1 diagonal screen vectors:
+Intercardinals run along the screen axes:
 
 | Compass | Iso | Screen vector |
 |:---|:---|:---|
-| NE | `(+1, 0)` | right-up 2:1 |
-| SE | `(0, +1)` | right-down 2:1 |
-| SW | `(−1, 0)` | left-down 2:1 |
-| NW | `(0, −1)` | left-up 2:1 |
+| NE | `(+1, −1)` | straight UP |
+| SE | `(+1, +1)` | straight RIGHT |
+| SW | `(−1, +1)` | straight DOWN |
+| NW | `(−1, −1)` | straight LEFT |
 
 ### The depth axis is `tx − ty`, NOT `tx + ty`
 
@@ -500,6 +500,62 @@ pathfinder.findPath(start, end).then((p) => {
 
 Without this, the agent snaps to tile vertices (e.g. `[100, 50]`) instead of
 tile centers (`[100.5, 50.5]`).
+
+### Agent direction → spritesheet row mapping
+
+Direction is computed in **tile coordinates** from the path delta:
+
+```typescript
+const delta = vec2.sub(target, start);
+const radians = Math.atan2(delta[1], delta[0]);  // atan2(dty, dtx)
+this.direction = radians * (180 / Math.PI);
+this.animIndex = Math.floor(this.direction / 45);
+if (this.animIndex < 0) this.animIndex = 8 + this.animIndex;
+```
+
+The `animDirs` array maps sector index → animation name suffix,
+using tile-aligned cardinal names (consistent with the engine's iso-grid):
+
+```typescript
+const animDirs = [
+    'East',     // 0: (+tx, 0)      → screen right-up   (atan2 +0°)
+    'SouthEast',// 1: (+tx, +ty)    → screen straight-right (+45°)
+    'South',    // 2: (0, +ty)      → screen right-down (+90°)
+    'SouthWest',// 3: (-tx, +ty)    → screen straight-down (+135°)
+    'West',     // 4: (-tx, 0)      → screen left-down  (±180°)
+    'NorthWest',// 5: (-tx, -ty)    → screen straight-left (−135°)
+    'North',    // 6: (0, -ty)      → screen left-up    (−90°)
+    'NorthEast',// 7: (+tx, -ty)    → screen straight-up (−45°)
+];
+```
+
+`anim.play('walk' + animDirs[this.animIndex])` → `walkNorth` etc.
+The manifest maps each animation name to a tile-range on the spritesheet.
+
+The manifest entries are ordered **North-first** (not East-first like
+`animDirs`). This is a deliberate offset — `animDirs` is the bridge
+between tile-space atan2 and the names. The manifest row order:
+
+| Manifest entry | Tiles | Row | `animDirs` idx |
+|:---|---:|---:|---:|
+| `walkNorth` | 0–19 | 0 | 6 |
+| `walkNorthWest` | 32–51 | 1 | 5 |
+| `walkWest` | 64–83 | 2 | 4 |
+| `walkSouthWest` | 96–115 | 3 | 3 |
+| `walkSouth` | 128–147 | 4 | 2 |
+| `walkSouthEast` | 160–179 | 5 | 1 |
+| `walkEast` | 192–211 | 6 | 0 |
+| `walkNorthEast` | 224–243 | 7 | 7 |
+
+Each walk row uses 20 frames out of 32 available columns — the remaining
+12 are transparent padding. Idle entries follow the same pattern starting
+at tile 256 (row 8).
+
+Per-tile pixel size: `tilePixelSize = [image.width / tileSetSize[0],
+image.height / tileSetSize[1]]`. For humanoid.png (2048², `[32,16]`),
+each tile is 64×128 px. The `frame` value in `state.json` is a flat
+tile index resolved per the same grid math (`col = frame % columns,
+row = floor(frame / columns)`).
 
 ---
 

--- a/src/classic/state.ts
+++ b/src/classic/state.ts
@@ -653,12 +653,12 @@ const game: GameState = {
             drawLine(roseCx - gx, roseCy - gx / 2, roseCx + gx, roseCy + gx / 2, gridColor);
             drawLine(roseCx - gx, roseCy + gx / 2, roseCx + gx, roseCy - gx / 2, gridColor);
 
-            // 4 cardinal spokes
+            // 4 cardinal spokes (iso-aligned: N = (0,-ty), E = (+tx,0), S = (0,+ty), W = (-tx,0))
             const spokeColor = [1.0, 1.0, 0.8, 0.85] as number[];
-            drawLine(roseCx, roseCy, roseCx, roseCy - roseR, spokeColor); // N = straight UP
-            drawLine(roseCx, roseCy, roseCx + roseR, roseCy, spokeColor); // E = straight RIGHT
-            drawLine(roseCx, roseCy, roseCx, roseCy + roseR, spokeColor); // S = straight DOWN
-            drawLine(roseCx, roseCy, roseCx - roseR, roseCy, spokeColor); // W = straight LEFT
+            drawLine(roseCx, roseCy, roseCx - roseR, roseCy - roseR / 2, spokeColor); // N = iso (0,-ty)
+            drawLine(roseCx, roseCy, roseCx + roseR, roseCy - roseR / 2, spokeColor); // E = iso (+tx,0)
+            drawLine(roseCx, roseCy, roseCx + roseR, roseCy + roseR / 2, spokeColor); // S = iso (0,+ty)
+            drawLine(roseCx, roseCy, roseCx - roseR, roseCy + roseR / 2, spokeColor); // W = iso (-tx,0)
 
             // XYZ axes
             drawLine(xyzCx, xyzCy, xyzCx + xyzLen, xyzCy - xyzLen / 2, [1.0, 0.3, 0.3, 0.9]); // X

--- a/src/demo/uiPrefabs.ts
+++ b/src/demo/uiPrefabs.ts
@@ -129,6 +129,13 @@ function initTopBar(UI: UIManager): void {
     const roseE = UI.spawnText('E', axisFontScale, axisMaxW, [1.0, 1.0, 0.8, 1], [0, 0, 0, 0]);
     const roseS = UI.spawnText('S', axisFontScale, axisMaxW, [1.0, 1.0, 0.8, 1], [0, 0, 0, 0]);
     const roseW = UI.spawnText('W', axisFontScale, axisMaxW, [1.0, 1.0, 0.8, 1], [0, 0, 0, 0]);
+    const diagFontScale = 0.22 * _uiScale;
+    const diagMaxW = Math.ceil(4 * 32 * diagFontScale);
+    const diagColor: [number, number, number, number] = [1.0, 1.0, 0.8, 0.5];
+    const roseNE = UI.spawnText('NE', diagFontScale, diagMaxW, diagColor, [0, 0, 0, 0]);
+    const roseSE = UI.spawnText('SE', diagFontScale, diagMaxW, diagColor, [0, 0, 0, 0]);
+    const roseSW = UI.spawnText('SW', diagFontScale, diagMaxW, diagColor, [0, 0, 0, 0]);
+    const roseNW = UI.spawnText('NW', diagFontScale, diagMaxW, diagColor, [0, 0, 0, 0]);
     const axisX = UI.spawnText('X', axisFontScale, axisMaxW, [1.0, 0.3, 0.3, 1], [0, 0, 0, 0]);
     const axisY = UI.spawnText('Y', axisFontScale, axisMaxW, [0.3, 1.0, 0.3, 1], [0, 0, 0, 0]);
     const axisZ = UI.spawnText('Z', axisFontScale, axisMaxW, [0.4, 0.4, 1.0, 1], [0, 0, 0, 0]);
@@ -166,13 +173,22 @@ function initTopBar(UI: UIManager): void {
             const aL = 35 * _uiScale;
 
             roseN.setEnabled(true);
-            roseN.setPosition(rcX - 5 * _uiScale, rcY - rR - 14 * _uiScale);
+            roseN.setPosition(rcX - rR - 14 * _uiScale, rcY - rR / 2 - 12 * _uiScale);
             roseE.setEnabled(true);
-            roseE.setPosition(rcX + rR + 4, rcY - 6 * _uiScale);
+            roseE.setPosition(rcX + rR + 2, rcY - rR / 2 - 6 * _uiScale);
             roseS.setEnabled(true);
-            roseS.setPosition(rcX - 5 * _uiScale, rcY + rR + 4);
+            roseS.setPosition(rcX + rR + 2, rcY + rR / 2 + 2);
             roseW.setEnabled(true);
-            roseW.setPosition(rcX - rR - 14 * _uiScale, rcY - 6 * _uiScale);
+            roseW.setPosition(rcX - rR - 14 * _uiScale, rcY + rR / 2 + 2);
+
+            roseNE.setEnabled(true);
+            roseNE.setPosition(rcX - 7 * _uiScale, rcY - rR - 10 * _uiScale);
+            roseSE.setEnabled(true);
+            roseSE.setPosition(rcX + rR - 7 * _uiScale, rcY - 4 * _uiScale);
+            roseSW.setEnabled(true);
+            roseSW.setPosition(rcX - 7 * _uiScale, rcY + rR + 2);
+            roseNW.setEnabled(true);
+            roseNW.setPosition(rcX - rR - 7 * _uiScale, rcY - 4 * _uiScale);
 
             axisX.setEnabled(true);
             axisX.setPosition(axX + aL + 4, axY - aL / 2 - 8 * _uiScale);
@@ -215,6 +231,10 @@ function initTopBar(UI: UIManager): void {
             roseE.setEnabled(false);
             roseS.setEnabled(false);
             roseW.setEnabled(false);
+            roseNE.setEnabled(false);
+            roseSE.setEnabled(false);
+            roseSW.setEnabled(false);
+            roseNW.setEnabled(false);
             axisX.setEnabled(false);
             axisY.setEnabled(false);
             axisZ.setEnabled(false);


### PR DESCRIPTION
<!-- pr-msg-meta
branch: iso-compass-fix
base: sdf-text
submitted:
  github: ___
-->

## Fix debug compass rose and skills to iso-aligned cardinal
##   directions

### Motivation

The debug compass overlay ("Footprints" toggle) drew cardinal spokes
in screen-aligned directions (N = UP, E = RIGHT, etc.). The skill
docs replicated this mapping. The engine's actual iso-grid uses
tile-aligned cardinals: N = (0, -ty) = left-up, E = (+tx, 0) =
right-up, S = (0, +ty) = right-down, W = (-tx, 0) = left-down.
Keeping coordinate systems aligned avoids confusion when reasoning
about direction, animation selection, and tile-space navigation.

### Summary of changes

- Fix `state.ts` cardinal spoke vectors from screen-aligned to
  iso-aligned; reposition N/S/E/W labels on spoke endpoints.
- Add NE/SE/SW/NW diagonal compass labels at smaller scale and lower
  opacity in `uiPrefabs.ts`.
- Correct cardinal and intercardinal mapping tables in
  `isometric-coordinates` and `isometric-tilemap` skills.
- Add screen projection formula and `ISO_SQUASH = 0.5` invariant to
  `isometric-coordinates`.
- Add agent direction → spritesheet row mapping section to
  `isometric-tilemap`, documenting `animDirs`, `animIndex`, manifest
  row order, and `tileSetSize` resolution.

(this pr content was generated in some part by `opencode` using
`deepseek-v4-pro` (`deepseek`))
