### PR TITLE
Improve LRV vehicle pathing, turning, and cliff-jump

### DIFF
--- a/crates/classic-core/src/components/mod.rs
+++ b/crates/classic-core/src/components/mod.rs
@@ -374,6 +374,20 @@ pub struct IsoVehicle {
     /// offsets and tile scale at spawn).
     #[serde(skip)]
     pub track_px: f32,
+    /// Collision footprint for pathfinding: integer tile offsets from the body
+    /// anchor cell (copied from the vehicle def at spawn).  A* erodes the nav
+    /// grid by this footprint before searching (issue #35).
+    #[serde(skip)]
+    pub path_footprint: Vec<(i32, i32)>,
+    /// Max heading change while driving, in radians per second (copied from the
+    /// vehicle def at spawn).  Drives the bounded-turn follow controller.
+    #[serde(skip)]
+    pub turn_rate: f32,
+    /// Max safe drop (pixels) the suspension absorbs; the A* may route a
+    /// downward jump within this distance (copied from the vehicle def at
+    /// spawn).  `0` disables jumps.
+    #[serde(skip)]
+    pub safe_fall_px: f32,
 
     // -- transient simulation state (not serialized) ----------------------
     /// Per-wheel, per-direction tile-space offset from the body, derived from
@@ -400,6 +414,16 @@ pub struct IsoVehicle {
     /// Index of the waypoint currently being driven toward.
     #[serde(skip)]
     pub path_idx: usize,
+    /// Whether the body is airborne (off the supporting terrain).  Persisted so
+    /// `vehicle_goto` can reject new paths until the wheels are back on the
+    /// ground (issue #40).
+    #[serde(skip)]
+    pub airborne: bool,
+    /// Continuous body heading (tile-space radians, `atan2(dy, dx)`).  Steered
+    /// by the bounded-turn follow controller; `direction` is its 8-way
+    /// quantization for sprite-frame selection (issue #35).
+    #[serde(skip)]
+    pub heading: f32,
 }
 
 fn default_vehicle_speed() -> f32 {
@@ -427,6 +451,9 @@ impl Default for IsoVehicle {
             roll_levels: 1,
             roll_max: 20.0f32.to_radians(),
             track_px: 0.0,
+            path_footprint: vec![(0, 0)],
+            turn_rate: 720.0f32.to_radians(),
+            safe_fall_px: 0.0,
             wheel_tile_offsets: [[[0.0, 0.0]; 8]; 4],
             altitude: 0.0,
             vel_z: 0.0,
@@ -434,6 +461,8 @@ impl Default for IsoVehicle {
             wheel_v: [0.0; 4],
             path: Vec::new(),
             path_idx: 0,
+            airborne: false,
+            heading: 0.0,
         }
     }
 }

--- a/crates/classic-core/src/pathfinder.rs
+++ b/crates/classic-core/src/pathfinder.rs
@@ -33,23 +33,26 @@ impl Ord for Key {
 /// A single cell coordinate on the nav grid.
 pub type GridCell = (i32, i32);
 
-/// Run 8-directional A* from `from` to `to` on a grid of `size_x × size_y`
-/// cells.  `nav_data[i]` must be 1 (walkable) or 0 (blocked).
+/// Core 8-directional A* over a `size_x × size_y` grid.  `step_cost(current,
+/// neighbor)` returns `Some(cost)` when the move is allowed and `None` when
+/// blocked.  Neighbours are the 8 surrounding cells (bounds-checked here).
 ///
-/// Returns the full path (including `from` and `to`) as vec of integer
-/// cell coordinates, or `None` if no path exists.
-pub fn find_path(
-    nav_data: &[i32],
+/// Returns the full path (including `from` and `to`) or `None` when no route
+/// exists.  The heuristic is admissible for 8-directional grids with cardinal
+/// cost 1.0 and diagonal cost √2; callers that add a cost multiplier (e.g. a
+/// jump penalty) must keep it ≥ 1.0 so the heuristic stays admissible.
+fn a_star<F>(
     size_x: i32,
     size_y: i32,
-    mut from: GridCell,
-    mut to: GridCell,
-) -> Option<Vec<GridCell>> {
-    // Clamp targets to valid range.
-    from.0 = from.0.clamp(0, size_x - 1);
-    from.1 = from.1.clamp(0, size_y - 1);
-    to.0 = to.0.clamp(0, size_x - 1);
-    to.1 = to.1.clamp(0, size_y - 1);
+    from: GridCell,
+    to: GridCell,
+    mut step_cost: F,
+) -> Option<Vec<GridCell>>
+where
+    F: FnMut(GridCell, GridCell) -> Option<f32>,
+{
+    let from = (from.0.clamp(0, size_x - 1), from.1.clamp(0, size_y - 1));
+    let to = (to.0.clamp(0, size_x - 1), to.1.clamp(0, size_y - 1));
 
     let flatten = |x: i32, y: i32| -> usize { (x + y * size_x) as usize };
 
@@ -93,11 +96,8 @@ pub fn find_path(
                 continue;
             }
             let n_idx = flatten(nx, ny);
-            if nav_data[n_idx] == 0 {
-                continue;
-            }
+            let Some(step_cost) = step_cost(current, (nx, ny)) else { continue };
 
-            let step_cost = if dx != 0 && dy != 0 { (2.0_f32).sqrt() } else { 1.0 };
             let tentative_g = g_cost[cur_idx].min(inf) + step_cost;
 
             if tentative_g < g_cost[n_idx] {
@@ -114,6 +114,240 @@ pub fn find_path(
     }
 
     None
+}
+
+/// Run 8-directional A* from `from` to `to` on a grid of `size_x × size_y`
+/// cells.  `nav_data[i]` must be 1 (walkable) or 0 (blocked).
+///
+/// Returns the full path (including `from` and `to`) as vec of integer
+/// cell coordinates, or `None` if no path exists.
+pub fn find_path(
+    nav_data: &[i32],
+    size_x: i32,
+    size_y: i32,
+    from: GridCell,
+    to: GridCell,
+) -> Option<Vec<GridCell>> {
+    a_star(size_x, size_y, from, to, |current, neighbour| {
+        let idx = (neighbour.0 + neighbour.1 * size_x) as usize;
+        if nav_data[idx] == 0 {
+            return None;
+        }
+        Some(if neighbour.0 != current.0 && neighbour.1 != current.1 {
+            (2.0_f32).sqrt()
+        } else {
+            1.0
+        })
+    })
+}
+
+/// Erode a walkability grid by a footprint of integer tile offsets: a cell is
+/// passable in the output only when every footprint offset, relative to that
+/// cell, is walkable in the input.
+///
+/// This is the standard "obstacle inflation" pass for multi-tile agents — the
+/// agent is treated as a point on the eroded grid, so the existing 1×1 A* runs
+/// unchanged.  `footprint` is a slice of `(dx, dy)` offsets from the anchor
+/// cell; a 1×1 agent uses `&[(0, 0)]`, a 3×3 vehicle uses all 9 offsets in
+/// `-1..=1 × -1..=1`.
+pub fn erode_for_footprint(
+    nav_data: &[i32],
+    size_x: i32,
+    size_y: i32,
+    footprint: &[GridCell],
+) -> Vec<i32> {
+    let total = (size_x * size_y) as usize;
+    let mut eroded = vec![1_i32; total];
+
+    for y in 0..size_y {
+        for x in 0..size_x {
+            let mut passable = true;
+            for &(ox, oy) in footprint {
+                let cx = x + ox;
+                let cy = y + oy;
+                if cx < 0 || cx >= size_x || cy < 0 || cy >= size_y {
+                    passable = false;
+                    break;
+                }
+                let idx = (cx + cy * size_x) as usize;
+                if nav_data[idx] == 0 {
+                    passable = false;
+                    break;
+                }
+            }
+            eroded[(x + y * size_x) as usize] = if passable { 1 } else { 0 };
+        }
+    }
+
+    eroded
+}
+
+/// Run footprint-aware A*: erode `nav_data` by `footprint` (see
+/// [`erode_for_footprint`]) then run the standard 1×1 search on the result.
+///
+/// The `from` cell is exempted from the erosion check so an already-placed
+/// vehicle can path *out* of a spot whose footprint barely overlaps an
+/// obstacle; the goal must still be reachable with the full footprint.
+pub fn find_path_for_footprint(
+    nav_data: &[i32],
+    size_x: i32,
+    size_y: i32,
+    from: GridCell,
+    to: GridCell,
+    footprint: &[GridCell],
+) -> Option<Vec<GridCell>> {
+    let mut eroded = erode_for_footprint(nav_data, size_x, size_y, footprint);
+    // Relax the start: the agent is already there, so only neighbour cells are
+    // held to the footprint rule during expansion.
+    let from_idx = (from.0.clamp(0, size_x - 1) + from.1.clamp(0, size_y - 1) * size_x) as usize;
+    if let Some(cell) = eroded.get_mut(from_idx) {
+        *cell = 1;
+    }
+    find_path(&eroded, size_x, size_y, from, to)
+}
+
+/// Derive a vehicle-specific slope-feasibility walkability grid from a vertex
+/// height grid: `1` where the vehicle can stand (i.e. *some* heading keeps its
+/// pitch/roll within limits), `0` otherwise.
+///
+/// Unlike a per-tile gradient (which flags a flat tile sitting next to a cliff
+/// because one corner is on the cliff top), this samples the terrain at the
+/// vehicle's wheel positions — `±wheelbase/2` front-rear and `±track/2`
+/// left-right — in each of the 8 headings, using the same bilinear surface the
+/// simulation drives on.  A tile is walkable when at least one heading keeps
+/// `|pitch| ≤ max_pitch` and `|roll| ≤ max_roll`.
+#[allow(clippy::too_many_arguments)]
+pub fn derive_vehicle_slope_nav(
+    heights: &[f32],
+    size_x: i32,
+    size_y: i32,
+    height_scale: f32,
+    tile_scale: f32,
+    wheelbase_px: f32,
+    track_px: f32,
+    max_pitch: f32,
+    max_roll: f32,
+) -> Vec<i32> {
+    let mut out = vec![0i32; (size_x * size_y) as usize];
+    if wheelbase_px <= 0.0 || track_px <= 0.0 {
+        return out;
+    }
+    let half_wb = (wheelbase_px / tile_scale.max(1e-6)) * 0.5;
+    let half_tr = (track_px / tile_scale.max(1e-6)) * 0.5;
+    let max_pitch_tan = max_pitch.tan();
+    let max_roll_tan = max_roll.tan();
+
+    for y in 0..size_y {
+        for x in 0..size_x {
+            let cx = x as f32 + 0.5;
+            let cy = y as f32 + 0.5;
+            let mut walkable = false;
+            for d in 0..8 {
+                let angle = d as f32 * std::f32::consts::FRAC_PI_4;
+                let (hx, hy) = (angle.cos(), angle.sin());
+                let (lx, ly) = (-hy, hx);
+                let front = crate::tilemap::bilinear_height(
+                    heights,
+                    size_x,
+                    size_y,
+                    cx + hx * half_wb,
+                    cy + hy * half_wb,
+                );
+                let rear = crate::tilemap::bilinear_height(
+                    heights,
+                    size_x,
+                    size_y,
+                    cx - hx * half_wb,
+                    cy - hy * half_wb,
+                );
+                let left = crate::tilemap::bilinear_height(
+                    heights,
+                    size_x,
+                    size_y,
+                    cx + lx * half_tr,
+                    cy + ly * half_tr,
+                );
+                let right = crate::tilemap::bilinear_height(
+                    heights,
+                    size_x,
+                    size_y,
+                    cx - lx * half_tr,
+                    cy - ly * half_tr,
+                );
+                let pitch = (front - rear).abs() * height_scale / wheelbase_px;
+                let roll = (left - right).abs() * height_scale / track_px;
+                if pitch <= max_pitch_tan && roll <= max_roll_tan {
+                    walkable = true;
+                    break;
+                }
+            }
+            out[(y * size_x + x) as usize] = walkable as i32;
+        }
+    }
+    out
+}
+
+/// Footprint-, slope- and jump-aware A* for a wheeled vehicle.
+///
+/// `walkable` is the combined grid (`structural` AND slope-feasible): `1` = a
+/// normal walk.  `structural` is obstacle-free walkability, used only to check
+/// that a jump's landing zone is not inside an obstacle.  `heights` is the
+/// vertex grid `(size_x+1) × (size_y+1)`.  A *downward* step whose drop (in
+/// pixels, `drop_units · height_scale`) is within `safe_fall_px` is allowed as
+/// a jump even when `walkable` marks the target blocked (a small cliff the
+/// suspension can absorb), provided the target is lower and obstacle-free; its
+/// cost is scaled by `jump_cost` (≥ 1.0 discourages jumps).  `safe_fall_px ≤ 0`
+/// disables jumps.
+#[allow(clippy::too_many_arguments)]
+pub fn find_path_for_footprint_with_jumps(
+    walkable: &[i32],
+    structural: &[i32],
+    heights: &[f32],
+    size_x: i32,
+    size_y: i32,
+    from: GridCell,
+    to: GridCell,
+    footprint: &[GridCell],
+    height_scale: f32,
+    safe_fall_px: f32,
+    jump_cost: f32,
+) -> Option<Vec<GridCell>> {
+    let mut walk_eroded = erode_for_footprint(walkable, size_x, size_y, footprint);
+    let struct_eroded = if safe_fall_px > 0.0 {
+        erode_for_footprint(structural, size_x, size_y, footprint)
+    } else {
+        Vec::new()
+    };
+    // Relax the start: the agent is already there, so only neighbour cells are
+    // held to the footprint rule during expansion.
+    let from_idx = (from.0.clamp(0, size_x - 1) + from.1.clamp(0, size_y - 1) * size_x) as usize;
+    if let Some(cell) = walk_eroded.get_mut(from_idx) {
+        *cell = 1;
+    }
+
+    let vw = size_x as usize + 1;
+    let cell_height = |x: i32, y: i32| -> f32 {
+        let i = y as usize * vw + x as usize;
+        (heights[i] + heights[i + 1] + heights[i + vw] + heights[i + vw + 1]) * 0.25
+    };
+
+    a_star(size_x, size_y, from, to, |current, neighbour| {
+        let idx = (neighbour.0 + neighbour.1 * size_x) as usize;
+        let diagonal = neighbour.0 != current.0 && neighbour.1 != current.1;
+        let base = if diagonal { (2.0_f32).sqrt() } else { 1.0 };
+
+        if walk_eroded[idx] == 1 {
+            return Some(base);
+        }
+        if safe_fall_px > 0.0 && struct_eroded[idx] == 1 {
+            let drop = (cell_height(current.0, current.1) - cell_height(neighbour.0, neighbour.1))
+                * height_scale;
+            if drop > 0.0 && drop <= safe_fall_px {
+                return Some(base * jump_cost);
+            }
+        }
+        None
+    })
 }
 
 /// Chebyshev-approximation heuristic (admissible for 8-directional grid).
@@ -255,5 +489,244 @@ mod tests {
         let grid = simple_grid();
         let path = find_path(&grid, 5, 5, (2, 2), (2, 2)).expect("path");
         assert_eq!(path, vec![(2, 2), (2, 2)]);
+    }
+
+    fn footprint_3x3() -> Vec<GridCell> {
+        let mut fp = Vec::new();
+        for dy in -1..=1 {
+            for dx in -1..=1 {
+                fp.push((dx, dy));
+            }
+        }
+        fp
+    }
+
+    #[test]
+    fn footprint_point_equals_plain_a_star() {
+        let mut grid = simple_grid();
+        grid[6] = 0; // (1,1) blocked
+        let plain = find_path(&grid, 5, 5, (0, 0), (4, 4)).unwrap();
+        let foot = find_path_for_footprint(&grid, 5, 5, (0, 0), (4, 4), &[(0, 0)]).unwrap();
+        assert_eq!(plain, foot);
+    }
+
+    #[test]
+    fn three_wide_corridor_lets_3x3_through() {
+        // 7x7 grid: block everything left of column 1 and right of column 3,
+        // leaving an exactly-3-wide vertical corridor (columns 1..=3) that a
+        // 3x3 vehicle fits through along x=2.
+        let w = 7;
+        let h = 7;
+        let mut grid = vec![1_i32; (w * h) as usize];
+        for y in 0..h {
+            grid[(y * w) as usize] = 0;
+            grid[(4 + y * w) as usize] = 0;
+            grid[(5 + y * w) as usize] = 0;
+            grid[(6 + y * w) as usize] = 0;
+        }
+        let fp = footprint_3x3();
+        let path = find_path_for_footprint(&grid, w, h, (2, 1), (2, 5), &fp);
+        assert!(path.is_some(), "3x3 should path a 3-wide corridor");
+    }
+
+    #[test]
+    fn two_wide_corridor_blocks_3x3() {
+        // Same wall layout but a 2-wide corridor (columns 2..=3) — a 3x3
+        // vehicle cannot fit, so no path exists.
+        let w = 7;
+        let h = 7;
+        let mut grid = vec![1_i32; (w * h) as usize];
+        for y in 0..h {
+            grid[(y * w) as usize] = 0;
+            grid[(1 + y * w) as usize] = 0;
+            grid[(4 + y * w) as usize] = 0;
+            grid[(5 + y * w) as usize] = 0;
+            grid[(6 + y * w) as usize] = 0;
+        }
+        let fp = footprint_3x3();
+        let path = find_path_for_footprint(&grid, w, h, (2, 0), (3, 6), &fp);
+        assert!(path.is_none(), "3x3 must not path a 2-wide corridor");
+    }
+
+    #[test]
+    fn footprint_blocks_diagonal_corner_cut() {
+        // A 1x1 agent can cut the diagonal gap between two blocked cells; a 3x3
+        // footprint cannot (it would overlap a blocked cell).
+        let w: i32 = 5;
+        let h: i32 = 5;
+        let mut grid = vec![1_i32; (w * h) as usize];
+        grid[w as usize] = 0; // (0,1) blocked
+        grid[1] = 0; // (1,0) blocked
+
+        // 1x1 can squeeze diagonally from (0,0) to (2,2).
+        assert!(find_path(&grid, w, h, (0, 0), (2, 2)).is_some());
+        // 3x3 anchored at (0,0) overlaps blocked cells and cannot.
+        let fp = footprint_3x3();
+        assert!(find_path_for_footprint(&grid, w, h, (0, 0), (2, 2), &fp).is_none());
+    }
+
+    /// A vertex height grid of `(size+1)^2`, `h = slope * x`.
+    fn ramp_heights(size: i32, slope: f32) -> Vec<f32> {
+        let n = (size + 1) as usize;
+        let mut h = vec![0.0f32; n * n];
+        for y in 0..n {
+            for x in 0..n {
+                h[y * n + x] = slope * x as f32;
+            }
+        }
+        h
+    }
+
+    /// Slope-nav params for a vehicle with ~2-tile wheelbase, 1-tile track,
+    /// 20° pitch/roll limits (matching the LRV tuning).
+    fn slope_params() -> (f32, f32, f32, f32) {
+        (45.0 * 2.0, 45.0 * 1.0, 20.0f32.to_radians(), 20.0f32.to_radians())
+    }
+
+    #[test]
+    fn vehicle_slope_nav_flat_is_all_walkable() {
+        let size = 4;
+        let n = (size + 1) as usize;
+        let heights = vec![1.0f32; n * n];
+        let (wb, tr, pitch, roll) = slope_params();
+        let nav = derive_vehicle_slope_nav(&heights, size, size, 32.0, 45.0, wb, tr, pitch, roll);
+        assert!(nav.iter().all(|&v| v == 1));
+    }
+
+    #[test]
+    fn vehicle_slope_nav_allows_gentle_and_blocks_steep() {
+        let size = 16;
+        // A 0.375 units/tile ramp is within 20° over a 2-tile wheelbase.
+        let gentle = ramp_heights(size, 0.375);
+        let (wb, tr, pitch, roll) = slope_params();
+        let nav = derive_vehicle_slope_nav(&gentle, size, size, 32.0, 45.0, wb, tr, pitch, roll);
+        assert!(nav.iter().all(|&v| v == 1), "0.375/tile should be drivable");
+
+        // A 1.0 units/tile ramp exceeds 20° (pitch = atan(1·32/45) ≈ 35°).
+        let steep = ramp_heights(size, 1.0);
+        let nav = derive_vehicle_slope_nav(&steep, size, size, 32.0, 45.0, wb, tr, pitch, roll);
+        assert!(nav.iter().all(|&v| v == 0), "1.0/tile should exceed the pitch limit");
+    }
+
+    #[test]
+    fn vehicle_slope_nav_keeps_cliff_adjacent_flat_walkable() {
+        // A 2-unit cliff at x=2: high plateau (x<2) drops to low (x>=2).  The
+        // flat tile at x=2 (beside the cliff) must stay walkable — the vehicle
+        // stands on flat ground even though one tile away is a cliff.
+        let w = 8;
+        let h = 8;
+        let n = (w + 1) as usize;
+        let mut heights = vec![0.0f32; n * n];
+        for y in 0..n {
+            for x in 0..n {
+                heights[y * n + x] = if x < 2 { 2.0 } else { 0.0 };
+            }
+        }
+        let (wb, tr, pitch, roll) = slope_params();
+        let nav = derive_vehicle_slope_nav(&heights, w, h, 32.0, 45.0, wb, tr, pitch, roll);
+        // The flat tile just past the cliff (x=2) is walkable.
+        assert_eq!(nav[(2 + 4 * w) as usize], 1, "flat tile beside the cliff should be walkable");
+        // The high plateau (x=0) is also flat and walkable.
+        assert_eq!(nav[(4 * w) as usize], 1);
+    }
+
+    /// A 5x5 scene with a 2-unit cliff between a high plateau (x<2) and a low
+    /// plateau (x>=2).  `walkable` marks the cliff-face column (x=1) blocked;
+    /// `structural` is all-walkable.
+    fn cliff_grids() -> (Vec<i32>, Vec<i32>, Vec<f32>) {
+        let w = 5;
+        let h = 5;
+        let structural = vec![1_i32; (w * h) as usize];
+        let mut walkable = structural.clone();
+        for y in 0..h {
+            walkable[(1 + y * w) as usize] = 0; // cliff face
+        }
+        let n = (w + 1) as usize;
+        let mut heights = vec![0.0f32; n * n];
+        for y in 0..n {
+            for x in 0..n {
+                heights[y * n + x] = if x < 2 { 2.0 } else { 0.0 };
+            }
+        }
+        (walkable, structural, heights)
+    }
+
+    #[test]
+    fn jump_crosses_a_small_cliff() {
+        let (walkable, structural, heights) = cliff_grids();
+        // 1-unit drop at height_scale 32 = 32 px; safe_fall 64 px allows it.
+        let path = find_path_for_footprint_with_jumps(
+            &walkable,
+            &structural,
+            &heights,
+            5,
+            5,
+            (0, 2),
+            (4, 2),
+            &[(0, 0)],
+            32.0,
+            64.0,
+            1.3,
+        );
+        assert!(path.is_some(), "should jump down the small cliff");
+    }
+
+    #[test]
+    fn no_jump_when_safe_fall_disabled() {
+        let (walkable, structural, heights) = cliff_grids();
+        let path = find_path_for_footprint_with_jumps(
+            &walkable,
+            &structural,
+            &heights,
+            5,
+            5,
+            (0, 2),
+            (4, 2),
+            &[(0, 0)],
+            32.0,
+            0.0,
+            1.3,
+        );
+        assert!(path.is_none(), "safe_fall 0 disables jumps");
+    }
+
+    #[test]
+    fn no_jump_when_drop_too_large() {
+        let (walkable, structural, heights) = cliff_grids();
+        // 1-unit drop = 32 px exceeds a 16 px safe fall.
+        let path = find_path_for_footprint_with_jumps(
+            &walkable,
+            &structural,
+            &heights,
+            5,
+            5,
+            (0, 2),
+            (4, 2),
+            &[(0, 0)],
+            32.0,
+            16.0,
+            1.3,
+        );
+        assert!(path.is_none(), "drop larger than safe_fall must not jump");
+    }
+
+    #[test]
+    fn no_jump_upward() {
+        let (walkable, structural, heights) = cliff_grids();
+        // Climbing the cliff is a negative drop — never a jump.
+        let path = find_path_for_footprint_with_jumps(
+            &walkable,
+            &structural,
+            &heights,
+            5,
+            5,
+            (4, 2),
+            (0, 2),
+            &[(0, 0)],
+            32.0,
+            64.0,
+            1.3,
+        );
+        assert!(path.is_none(), "cannot jump uphill");
     }
 }

--- a/crates/classic-core/src/types.rs
+++ b/crates/classic-core/src/types.rs
@@ -112,6 +112,23 @@ pub struct VehicleDef {
     /// the exporter.
     #[serde(default = "default_vehicle_roll_max_deg")]
     pub roll_max_deg: f32,
+    /// Collision footprint for pathfinding: integer tile offsets from the body
+    /// anchor cell that the vehicle occupies.  `None` auto-derives the
+    /// footprint from the wheel extent at spawn (see `Engine::spawn_vehicle`);
+    /// `Some` is an explicit override.  A* treats a cell as passable only when
+    /// every offset is walkable (issue #35).
+    #[serde(default)]
+    pub path_footprint: Option<Vec<(i32, i32)>>,
+    /// Max body heading change while driving, in degrees per second.  Drives
+    /// the bounded-turn follow controller (issue #35).  Defaults high so the
+    /// movement approximates the old instant-turn behaviour for simple defs.
+    #[serde(default = "default_vehicle_turn_rate")]
+    pub turn_rate_deg_per_sec: f32,
+    /// Max drop (in pixels) the suspension absorbs without damage.  The A* may
+    /// route a downward "jump" over a small cliff whose drop is within this
+    /// distance; larger drops are impassable (issue #35).  `0` disables jumps.
+    #[serde(default)]
+    pub safe_fall_px: f32,
     pub parts: Vec<VehiclePartDef>,
 }
 
@@ -137,6 +154,10 @@ fn default_vehicle_roll_levels() -> u32 {
 
 fn default_vehicle_roll_max_deg() -> f32 {
     20.0
+}
+
+fn default_vehicle_turn_rate() -> f32 {
+    720.0
 }
 
 /// One part (body or wheel) of a [`VehicleDef`].
@@ -269,5 +290,50 @@ impl Viewport {
     /// Left=0, right=w, bottom=h, top=0, near=-10000, far=10000.
     pub fn ortho_matrix(&self) -> glam::Mat4 {
         glam::Mat4::orthographic_rh(0.0, self.width, self.height, 0.0, -10000.0, 10000.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lock the cross-repo `VehicleDef` sidecar contract: the fields the
+    /// `classic-roms` xtask injects (`turn_rate_deg_per_sec`, `safe_fall_px`)
+    /// plus the exporter's extra `depth_range` (ignored) and an absent
+    /// `path_footprint` (auto-derived at spawn).
+    #[test]
+    fn vehicle_def_deserializes_lrv_sidecar_shape() {
+        let json = serde_json::json!({
+            "name": "lrv",
+            "directions": 8,
+            "columns": 4,
+            "rows": 2,
+            "pitch_levels": 5,
+            "pitch_max_deg": 20.0,
+            "roll_levels": 3,
+            "roll_max_deg": 20.0,
+            "depth_range": 0.02400137797794352,
+            "cell": [331, 331],
+            "turn_rate_deg_per_sec": 90.0,
+            "safe_fall_px": 96.0,
+            "parts": [
+                { "name": "body", "texture": "lrvBody", "anchors": [[0.5, 0.6618]] }
+            ]
+        });
+        let def: VehicleDef = serde_json::from_value(json).expect("deserialize lrv.json");
+        assert_eq!(def.name, "lrv");
+        assert_eq!(def.turn_rate_deg_per_sec, 90.0);
+        assert_eq!(def.safe_fall_px, 96.0);
+        assert!(def.path_footprint.is_none(), "absent path_footprint -> None (auto-derive)");
+
+        // An explicit footprint deserializes into Some.
+        let json = serde_json::json!({
+            "name": "lrv",
+            "directions": 8,
+            "parts": [ { "name": "body", "texture": "lrvBody", "anchors": [[0.5, 0.6618]] } ],
+            "path_footprint": [[0, 0], [-1, -1]]
+        });
+        let def: VehicleDef = serde_json::from_value(json).expect("footprint override");
+        assert_eq!(def.path_footprint, Some(vec![(0, 0), (-1, -1)]));
     }
 }

--- a/crates/classic-demo/src/hud.rs
+++ b/crates/classic-demo/src/hud.rs
@@ -3,7 +3,8 @@
 //! `Engine::frame`.  These draw via the engine's overlay hook.
 
 use classic_core::components::{
-    DebugName, IsoSprite, SdfTextRender, TextJustify, Tilemap, Transform, UiAnchor, UiNode,
+    DebugName, IsoSprite, IsoVehicle, SdfTextRender, TextJustify, Tilemap, Transform, UiAnchor,
+    UiNode,
 };
 use classic_core::instrument::Chan;
 use classic_core::math::iso_to_cartesian_4;
@@ -487,6 +488,80 @@ pub fn draw_debug_overlay(engine: &mut Engine, state: &DemoStateRef) {
                         gfx.draw_line_loop(&rb, 4, &Mat4::IDENTITY, &cam, &[1.0, 1.0, 0.0, 0.8]);
                     }
                 }
+            }
+        }
+    }
+
+    // Vehicle path indicators (planned A* routes), gated on KeyV.
+    if state.borrow().debug_vehicle_paths {
+        let tm_entity = engine.entity_by_role(classic_core::RoleKind::Tilemap);
+        let Some(gfx) = engine.gfx.as_mut() else { return };
+        let cam = engine.camera.matrix();
+        if let Some(tm_e) = tm_entity {
+            let (iso_to_cart_world, tilemap_pos, size_x, size_y, hd, hs) = {
+                let tm = engine.world.get::<&Tilemap>(tm_e).unwrap();
+                let tm_tf = engine.world.get::<&Transform>(tm_e).unwrap();
+                let iso_to_cart = iso_to_cartesian_4() * Mat4::from_scale(tm_tf.scale);
+                (
+                    iso_to_cart,
+                    tm_tf.position,
+                    tm.size_x,
+                    tm.size_y,
+                    tm.height_data.clone(),
+                    tm.height_scale,
+                )
+            };
+            for (_e, (vehicle, tf)) in engine.world.query::<(&IsoVehicle, &Transform)>().iter() {
+                if vehicle.path.is_empty() || vehicle.path_idx >= vehicle.path.len() {
+                    continue;
+                }
+                let to_world = |px: f32, py: f32| -> [f32; 3] {
+                    let h = bilinear_height(&hd, size_x, size_y, px, py);
+                    let mut v = Vec3::new(px, py, 0.0);
+                    v = iso_to_cart_world.transform_point3(v);
+                    v += tilemap_pos;
+                    v.y -= h * hs;
+                    [v.x, v.y, v.z]
+                };
+
+                // Remaining waypoints, with the body's current position as the
+                // lead vertex so the line connects to the vehicle.
+                let mut verts: Vec<f32> =
+                    Vec::with_capacity((vehicle.path.len() - vehicle.path_idx + 1) * 3);
+                verts.extend_from_slice(&to_world(tf.position.x, tf.position.y));
+                for &[ix, iy] in &vehicle.path[vehicle.path_idx..] {
+                    verts.extend_from_slice(&to_world(ix as f32 + 0.5, iy as f32 + 0.5));
+                }
+                let buf =
+                    GlBuffer::from_slice(&gfx.gl, glow::ARRAY_BUFFER, &verts, glow::STREAM_DRAW);
+                let count = (verts.len() / 3) as i32;
+                if count >= 2 {
+                    gfx.draw_line_strip(
+                        &buf,
+                        0,
+                        count,
+                        &Mat4::IDENTITY,
+                        &cam,
+                        &[1.0, 0.6, 0.0, 0.9],
+                    );
+                }
+
+                // Diamond marker at the waypoint currently being driven toward.
+                let [tx, ty] = vehicle.path[vehicle.path_idx];
+                let px = tx as f32 + 0.5;
+                let py = ty as f32 + 0.5;
+                let diamond = [(px, py - 0.5), (px + 0.5, py), (px, py + 0.5), (px - 0.5, py)];
+                let mut ring_verts: Vec<f32> = Vec::with_capacity(12);
+                for (ix, iy) in diamond {
+                    ring_verts.extend_from_slice(&to_world(ix, iy));
+                }
+                let rb = GlBuffer::from_slice(
+                    &gfx.gl,
+                    glow::ARRAY_BUFFER,
+                    &ring_verts,
+                    glow::STREAM_DRAW,
+                );
+                gfx.draw_line_loop(&rb, 4, &Mat4::IDENTITY, &cam, &[1.0, 0.9, 0.2, 0.95]);
             }
         }
     }

--- a/crates/classic-demo/src/prefabs.rs
+++ b/crates/classic-demo/src/prefabs.rs
@@ -215,8 +215,8 @@ pub fn init_footprint_colliders(engine: &mut Engine) {
     }
 }
 
-/// Register keyboard toggles for debug overlays (F = footprints, F9 = dump,
-/// F10 = save ROM archive).
+/// Register keyboard toggles for debug overlays (F = footprints, V = vehicle
+/// paths, F9 = dump, F10 = save ROM archive).
 pub fn init_debug_toggles(engine: &mut Engine, state: &DemoStateRef) {
     let state = Rc::clone(state);
     engine.on_update(move |engine| {
@@ -226,6 +226,10 @@ pub fn init_debug_toggles(engine: &mut Engine, state: &DemoStateRef) {
                 s.editor.debug_footprints = !s.editor.debug_footprints;
                 engine.show_grid = s.editor.debug_footprints;
             }
+        }
+        if engine.input.was_key_pressed("KeyV") {
+            let mut s = state.borrow_mut();
+            s.debug_vehicle_paths = !s.debug_vehicle_paths;
         }
         // F9: dump state.json (tile/nav/height data is inlined).
         if engine.input.was_key_pressed("F9") {

--- a/crates/classic-demo/src/state.rs
+++ b/crates/classic-demo/src/state.rs
@@ -65,6 +65,8 @@ pub struct DemoState {
     pub iso_coord_x_e: Option<Entity>,
     pub iso_coord_y_e: Option<Entity>,
     pub iso_coord_z_e: Option<Entity>,
+    /// Draw each vehicle's planned A* path as a world-space overlay (KeyV).
+    pub debug_vehicle_paths: bool,
     /// The ROM guest runtime (installed by `init_guest`).
     pub guest: Option<Rc<RefCell<Box<dyn classic_guest::GuestRuntime>>>>,
 }
@@ -84,6 +86,7 @@ impl Default for DemoState {
             iso_coord_x_e: None,
             iso_coord_y_e: None,
             iso_coord_z_e: None,
+            debug_vehicle_paths: false,
             guest: None,
         }
     }

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -161,6 +161,10 @@ pub struct Engine {
     sdf_text_gpu: HashMap<hecs::Entity, SdfTextGpu>,
     last_vw: f32,
     last_vh: f32,
+    /// Cached slope-feasibility grid, keyed by `(nav_version, slope params)`.
+    /// Recomputed lazily on terrain rebuild / a different vehicle geometry.
+    /// Single-slot (the demo has one vehicle); extend to a map for many.
+    slope_nav_cache: Option<(u64, [u32; 4], Vec<i32>)>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -259,6 +263,7 @@ impl Engine {
             sdf_text_gpu: HashMap::new(),
             last_vw: 0.0,
             last_vh: 0.0,
+            slope_nav_cache: None,
         }
     }
 
@@ -1017,6 +1022,137 @@ impl Engine {
         let nav = self.world.get::<&NavMesh>(nav_entity).ok()?;
         let nav_i32: Vec<i32> = nav.data.iter().map(|&v| v as i32).collect();
         pathfinder::find_path(&nav_i32, nav.size_x, nav.size_y, from, to)
+    }
+
+    /// Footprint-aware A* over the nav mesh: treat the moving agent as a
+    /// multi-tile object by eroding the walkability grid by `footprint` (a set
+    /// of integer tile offsets from the anchor cell) before searching.  Used by
+    /// `vehicle_goto`; the humanoid `IsoAgent` keeps the plain [`find_path`].
+    pub fn find_path_for_footprint(
+        &self,
+        from: (i32, i32),
+        to: (i32, i32),
+        footprint: &[(i32, i32)],
+    ) -> Option<Vec<(i32, i32)>> {
+        let nav_entity = self.entity_by_role(RoleKind::NavMesh)?;
+        let nav = self.world.get::<&NavMesh>(nav_entity).ok()?;
+        let nav_i32: Vec<i32> = nav.data.iter().map(|&v| v as i32).collect();
+        pathfinder::find_path_for_footprint(&nav_i32, nav.size_x, nav.size_y, from, to, footprint)
+    }
+
+    /// Footprint-, slope- and jump-aware A* for a wheeled vehicle.
+    ///
+    /// Combines the structural nav (`NavMesh.data`) with a slope-feasibility
+    /// grid derived from the tilemap heights sampled at the vehicle's wheel
+    /// positions (`pitch_max`/`roll_max` limits over `wheelbase_px`/`track_px`),
+    /// then runs A* with downward jump edges: a drop within `safe_fall_px`
+    /// (suspension absorbs it) is routable even where the slope grid blocks, at
+    /// `jump_cost`× the normal cost.  `safe_fall_px <= 0` disables jumps.
+    #[allow(clippy::too_many_arguments)]
+    pub fn find_vehicle_path(
+        &mut self,
+        from: (i32, i32),
+        to: (i32, i32),
+        footprint: &[(i32, i32)],
+        pitch_max: f32,
+        roll_max: f32,
+        wheelbase_px: f32,
+        track_px: f32,
+        safe_fall_px: f32,
+        jump_cost: f32,
+    ) -> Option<Vec<(i32, i32)>> {
+        // Extract everything out of the world up front so the slope cache can
+        // be mutated without holding a `World` borrow.
+        let (nav_data, nav_size_x, nav_size_y) = {
+            let nav_entity = self.entity_by_role(RoleKind::NavMesh)?;
+            let nav = self.world.get::<&NavMesh>(nav_entity).ok()?;
+            (nav.data.clone(), nav.size_x, nav.size_y)
+        };
+        let (heights, height_scale, tile_scale, size_x, size_y) = {
+            let tm_entity = self.entity_by_role(RoleKind::Tilemap)?;
+            let tm = self.world.get::<&Tilemap>(tm_entity).ok()?;
+            (tm.height_data.clone(), tm.height_scale, tm.scale.x, tm.size_x, tm.size_y)
+        };
+
+        let structural: Vec<i32> = nav_data.iter().map(|&v| v as i32).collect();
+        let slope = self.cached_slope_nav(
+            &heights,
+            size_x,
+            size_y,
+            height_scale,
+            tile_scale,
+            wheelbase_px,
+            track_px,
+            pitch_max,
+            roll_max,
+        );
+        let walkable: Vec<i32> =
+            structural.iter().zip(slope.iter()).map(|(&s, &w)| s & w).collect();
+
+        let result = pathfinder::find_path_for_footprint_with_jumps(
+            &walkable,
+            &structural,
+            &heights,
+            nav_size_x,
+            nav_size_y,
+            from,
+            to,
+            footprint,
+            height_scale,
+            safe_fall_px,
+            jump_cost,
+        );
+        classic_core::cl_info!(
+            classic_core::instrument::Chan::Path,
+            "find_vehicle_path {} -> {}: walkable={}/{}, footprint={} tiles, pitch={:.3}rad fall={}px, found={}",
+            format!("{from:?}"),
+            format!("{to:?}"),
+            walkable.iter().filter(|&&v| v == 1).count(),
+            walkable.len(),
+            footprint.len(),
+            pitch_max.min(roll_max),
+            safe_fall_px,
+            result.is_some(),
+        );
+        result
+    }
+
+    /// The slope-feasibility grid for a vehicle, cached per `nav_version` and
+    /// slope params (recomputed only when the terrain or the vehicle geometry
+    /// changes).
+    #[allow(clippy::too_many_arguments)]
+    fn cached_slope_nav(
+        &mut self,
+        heights: &[f32],
+        size_x: i32,
+        size_y: i32,
+        height_scale: f32,
+        tile_scale: f32,
+        wheelbase_px: f32,
+        track_px: f32,
+        pitch_max: f32,
+        roll_max: f32,
+    ) -> Vec<i32> {
+        let key =
+            [pitch_max.to_bits(), roll_max.to_bits(), wheelbase_px.to_bits(), track_px.to_bits()];
+        if let Some((ver, k, grid)) = &self.slope_nav_cache {
+            if *ver == self.nav_version && *k == key {
+                return grid.clone();
+            }
+        }
+        let grid = pathfinder::derive_vehicle_slope_nav(
+            heights,
+            size_x,
+            size_y,
+            height_scale,
+            tile_scale,
+            wheelbase_px,
+            track_px,
+            pitch_max,
+            roll_max,
+        );
+        self.slope_nav_cache = Some((self.nav_version, key, grid.clone()));
+        grid
     }
 
     /// Rebuild the shared nav snapshot from the live `NavMesh` component and

--- a/crates/classic-engine/src/vehicle.rs
+++ b/crates/classic-engine/src/vehicle.rs
@@ -46,6 +46,15 @@ const SPRING_DAMPING: f32 = 8.0;
 /// off a cliff).
 const AIRBORNE_PITCH: f32 = -0.26;
 
+/// Distance from the final waypoint (in tiles) at which the pure-pursuit
+/// follower considers the goal reached and stops.
+const GOAL_TOLERANCE: f32 = 0.5;
+
+/// Cost multiplier for a downward "jump" step in A* (`>= 1.0`).  A mild
+/// penalty makes the vehicle prefer flat routes but take a jump when it
+/// clearly shortens the path.
+const JUMP_COST: f32 = 1.3;
+
 /// A terrain-height sampler snapshot, cloned once per frame so the mutation
 /// pass can sample heights without re-borrowing the world.
 struct TerrainSnapshot {
@@ -75,6 +84,102 @@ pub fn dir_index(dx: i32, dy: i32) -> usize {
         (1, -1) => 7,
         _ => 0,
     }
+}
+
+/// The heading angle (tile-space radians, `atan2(dy, dx)`) for a direction
+/// frame.  `0` = East (frame 0), `FRAC_PI_2` = South (frame 2), etc.
+fn dir_to_heading(dir: u32) -> f32 {
+    (dir % 8) as f32 * std::f32::consts::FRAC_PI_4
+}
+
+/// Quantize a continuous heading angle to the nearest of the 8 direction
+/// frames (0..7), wrapping at `2π`.
+fn heading_to_dir(heading: f32) -> u32 {
+    let theta = heading.rem_euclid(std::f32::consts::TAU);
+    (theta / std::f32::consts::FRAC_PI_4).round() as u32 % 8
+}
+
+/// Wrap an angle to `[-π, π]`.
+fn wrap_pi(a: f32) -> f32 {
+    let mut a = a;
+    while a > std::f32::consts::PI {
+        a -= std::f32::consts::TAU;
+    }
+    while a < -std::f32::consts::PI {
+        a += std::f32::consts::TAU;
+    }
+    a
+}
+
+/// Lerp a per-direction `[f32; 2]` value (wheel offset or anchor) between the
+/// two direction frames straddling a continuous heading.
+fn lerp_dir2(vals: &[[f32; 2]; 8], heading: f32) -> [f32; 2] {
+    let theta = heading.rem_euclid(std::f32::consts::TAU);
+    let dir_f = theta / std::f32::consts::FRAC_PI_4;
+    let a = dir_f.floor() as usize % 8;
+    let b = (a + 1) % 8;
+    let t = dir_f - dir_f.floor();
+    [vals[a][0] * (1.0 - t) + vals[b][0] * t, vals[a][1] * (1.0 - t) + vals[b][1] * t]
+}
+
+/// Pure-pursuit look-ahead over a waypoint path.
+///
+/// Returns `(target_x, target_y, next_idx)` where the target is the point
+/// `lookahead` tiles along the path polyline from `(x, y)` (interpolated
+/// between waypoint centers) and `next_idx` is the index of the waypoint whose
+/// segment contains the target.  The caller advances `path_idx` to `next_idx`
+/// each frame, which is always monotonic — a forward-only vehicle never
+/// backtracks to a corner it already rounded.  Waypoints the vehicle has passed
+/// are skipped up front, so a target that lies "behind" the vehicle (e.g. after
+/// overshooting a corner) can't make it spin back around.  When the path is
+/// exhausted before `lookahead`, the target is the final waypoint center and
+/// `next_idx == path.len()`.
+fn lookahead(
+    path: &[[i32; 2]],
+    path_idx: usize,
+    x: f32,
+    y: f32,
+    lookahead: f32,
+) -> (f32, f32, usize) {
+    let mut idx = path_idx;
+
+    // Skip waypoints whose segment the vehicle has already traversed (its
+    // perpendicular projection onto `path[idx] -> path[idx+1]` is past the end).
+    while idx + 1 < path.len() {
+        let (ax, ay) = (path[idx][0] as f32 + 0.5, path[idx][1] as f32 + 0.5);
+        let (bx, by) = (path[idx + 1][0] as f32 + 0.5, path[idx + 1][1] as f32 + 0.5);
+        let segx = bx - ax;
+        let segy = by - ay;
+        let seglen2 = segx * segx + segy * segy;
+        let proj = ((x - ax) * segx + (y - ay) * segy) / seglen2.max(1e-6);
+        if proj >= 1.0 {
+            idx += 1;
+        } else {
+            break;
+        }
+    }
+
+    // Walk forward from the vehicle accumulating `lookahead` tiles of distance.
+    let mut remaining = lookahead;
+    let (mut px, mut py) = (x, y);
+    while idx < path.len() {
+        let (wx, wy) = (path[idx][0] as f32 + 0.5, path[idx][1] as f32 + 0.5);
+        let dx = wx - px;
+        let dy = wy - py;
+        let seg = (dx * dx + dy * dy).sqrt();
+        if remaining <= seg {
+            let t = if seg > 1e-6 { remaining / seg } else { 0.0 };
+            return (px + dx * t, py + dy * t, idx);
+        }
+        remaining -= seg;
+        px = wx;
+        py = wy;
+        idx += 1;
+    }
+
+    // Path exhausted: target the final waypoint center.
+    let (lx, ly) = (path[path.len() - 1][0] as f32 + 0.5, path[path.len() - 1][1] as f32 + 0.5);
+    (lx, ly, path.len())
 }
 
 /// Quantize a signed pitch angle (radians) to a pitch frame index in
@@ -228,6 +333,27 @@ impl Engine {
             (left - right).length() * tile_scale
         };
 
+        // Collision footprint for pathfinding: explicit def override, else
+        // auto-derived from the wheelbase/track — half the wheelbase
+        // (front-rear) along the heading axis and half the track (left-right)
+        // across it, rounded out.  This matches the vehicle's actual footprint
+        // in a single heading rather than the union of all 8 (which
+        // over-estimates on diagonal headings).
+        let footprint: Vec<(i32, i32)> = match &def.path_footprint {
+            Some(fp) => fp.clone(),
+            None => {
+                let half_x = ((wheelbase_px / tile_scale) * 0.5).ceil() as i32;
+                let half_y = ((track_px / tile_scale) * 0.5).ceil() as i32;
+                let mut fp = Vec::with_capacity(((half_x * 2 + 1) * (half_y * 2 + 1)) as usize);
+                for dy in -half_y..=half_y {
+                    for dx in -half_x..=half_x {
+                        fp.push((dx, dy));
+                    }
+                }
+                fp
+            }
+        };
+
         let wheel_names: [String; 4] = WHEEL_SUFFIXES.map(|s| format!("{entity_name}Wheel{s}"));
         let tilemap_name = "tilemap".to_string();
 
@@ -281,6 +407,9 @@ impl Engine {
             roll_levels: def.roll_levels,
             roll_max: def.roll_max_deg.to_radians(),
             track_px,
+            path_footprint: footprint,
+            turn_rate: def.turn_rate_deg_per_sec.to_radians(),
+            safe_fall_px: def.safe_fall_px,
             ..Default::default()
         };
         let be = self.world.spawn((
@@ -323,39 +452,55 @@ impl Engine {
         let write = {
             let Some(mut v) = self.world.get::<&mut IsoVehicle>(ve).ok() else { return };
 
-            // -- movement along the A* path ---------------------------------
+            // -- movement along the A* path (bounded-turn, forward-only) ----
             let mut x = body_x;
             let mut y = body_y;
-            if !v.path.is_empty() && v.path_idx < v.path.len() {
-                let tx = v.path[v.path_idx][0] as f32 + 0.5;
-                let ty = v.path[v.path_idx][1] as f32 + 0.5;
-                let dx = tx - x;
-                let dy = ty - y;
-                let mag = dx.abs() + dy.abs();
-                let step = v.speed * delta;
-                if mag <= step || mag <= 1e-4 {
-                    x = tx;
-                    y = ty;
-                    v.path_idx += 1;
+            if !v.path.is_empty() {
+                // Arrive once the final waypoint is within tolerance; snap to
+                // its center and stop.
+                let goal = (
+                    v.path[v.path.len() - 1][0] as f32 + 0.5,
+                    v.path[v.path.len() - 1][1] as f32 + 0.5,
+                );
+                let dx = goal.0 - x;
+                let dy = goal.1 - y;
+                if dx * dx + dy * dy <= GOAL_TOLERANCE * GOAL_TOLERANCE {
+                    x = goal.0;
+                    y = goal.1;
+                    v.path.clear();
+                    v.path_idx = 0;
                 } else {
-                    let f = step / mag;
-                    x += dx * f;
-                    y += dy * f;
-                }
-                let (ddx, ddy) = (dx.round() as i32, dy.round() as i32);
-                if ddx != 0 || ddy != 0 {
-                    v.direction = dir_index(ddx, ddy) as u32;
+                    // Pure-pursuit: lead the target by ~1.5× the minimum
+                    // turning radius (speed / turn_rate) so the vehicle arcs
+                    // through corners rather than orbiting a waypoint inside
+                    // its turning circle.
+                    let turn_radius = v.speed / v.turn_rate.max(1e-3);
+                    let lookahead_dist = (turn_radius * 1.5).max(1.0);
+                    let (gx, gy, next_idx) = lookahead(&v.path, v.path_idx, x, y, lookahead_dist);
+                    v.path_idx = next_idx;
+
+                    // Steer the heading toward the look-ahead target, bounded
+                    // by the max turn rate.
+                    let desired = (gy - y).atan2(gx - x);
+                    let err = wrap_pi(desired - v.heading);
+                    let max_turn = v.turn_rate * delta;
+                    v.heading = wrap_pi(v.heading + err.clamp(-max_turn, max_turn));
+
+                    // Advance forward only (a wheeled vehicle never reverses).
+                    let step = v.speed * delta;
+                    x += v.heading.cos() * step;
+                    y += v.heading.sin() * step;
                 }
             }
 
-            let direction = v.direction as usize;
+            // Quantize the continuous heading for the 8-way sprite sheets.
+            v.direction = heading_to_dir(v.heading);
 
             // -- wheel ground contacts --------------------------------------
             let mut wheel_xy = [[0.0f32; 2]; 4];
             let mut wheel_ground = [0.0f32; 4];
             for i in 0..4 {
-                let (ox, oy) =
-                    (v.wheel_tile_offsets[i][direction][0], v.wheel_tile_offsets[i][direction][1]);
+                let [ox, oy] = lerp_dir2(&v.wheel_tile_offsets[i], v.heading);
                 let wx = x + ox;
                 let wy = y + oy;
                 wheel_xy[i] = [wx, wy];
@@ -376,6 +521,7 @@ impl Engine {
                     v.vel_z = 0.0;
                 }
             }
+            v.airborne = airborne;
             let body_offset_y = -(v.altitude - body_terrain);
 
             // -- per-wheel suspension ---------------------------------------
@@ -396,7 +542,7 @@ impl Engine {
 
             let mut wheel_anchors = [[0.0f32; 2]; 4];
             for (i, a) in wheel_anchors.iter_mut().enumerate() {
-                *a = v.wheel_anchors[i][direction];
+                *a = lerp_dir2(&v.wheel_anchors[i], v.heading);
             }
 
             // -- body pitch (angular spring-damper) --------------------------
@@ -435,7 +581,7 @@ impl Engine {
             VehicleWrite {
                 body: [x, y, v.altitude],
                 body_offset_y,
-                body_anchor: v.body_anchors[direction],
+                body_anchor: lerp_dir2(&v.body_anchors, v.heading),
                 direction: v.direction,
                 body_frame,
                 wheel_xy,
@@ -493,6 +639,8 @@ impl Engine {
             let direction = v.direction as usize;
             v.altitude = terrain.height(x, y);
             v.vel_z = 0.0;
+            v.airborne = false;
+            v.heading = dir_to_heading(v.direction);
             v.path.clear();
             v.path_idx = 0;
 
@@ -546,12 +694,53 @@ impl Engine {
     }
 
     /// Set a vehicle's destination (integer tile coordinates).  The host runs
-    /// its own A* and stores the waypoints on the vehicle.
+    /// footprint-, slope- and jump-aware A* (see `Engine::find_vehicle_path`)
+    /// and stores the waypoints on the vehicle.
     pub fn vehicle_goto(&mut self, name: &str, tx: i32, ty: i32) -> bool {
-        let Some(&ve) = self.names.get(name) else { return false };
-        let Some(tf) = self.world.get::<&Transform>(ve).ok() else { return false };
-        let from = (tf.position.x.floor() as i32, tf.position.y.floor() as i32);
-        let Some(path) = self.find_path(from, (tx, ty)) else { return false };
+        let Some(&ve) = self.names.get(name) else {
+            classic_core::cl_info!(
+                classic_core::instrument::Chan::Path,
+                "vehicle_goto: no entity named {name}"
+            );
+            return false;
+        };
+        let (footprint, pitch_max, roll_max, wheelbase_px, track_px, safe_fall_px) = {
+            let Ok(v) = self.world.get::<&IsoVehicle>(ve) else { return false };
+            // Reject new paths while airborne: the vehicle keeps its current
+            // trajectory until its wheels touch down again (issue #40).
+            if v.airborne {
+                classic_core::cl_info!(
+                    classic_core::instrument::Chan::Path,
+                    "vehicle_goto {name}: airborne, rejecting"
+                );
+                return false;
+            }
+            (
+                v.path_footprint.clone(),
+                v.pitch_max,
+                v.roll_max,
+                v.wheelbase_px,
+                v.track_px,
+                v.safe_fall_px,
+            )
+        };
+        let from = {
+            let Some(tf) = self.world.get::<&Transform>(ve).ok() else { return false };
+            (tf.position.x.floor() as i32, tf.position.y.floor() as i32)
+        };
+        let Some(path) = self.find_vehicle_path(
+            from,
+            (tx, ty),
+            &footprint,
+            pitch_max,
+            roll_max,
+            wheelbase_px,
+            track_px,
+            safe_fall_px,
+            JUMP_COST,
+        ) else {
+            return false;
+        };
         let path: Vec<[i32; 2]> = path.into_iter().map(|(x, y)| [x, y]).collect();
         if let Ok(mut v) = self.world.get::<&mut IsoVehicle>(ve) {
             v.path = path;
@@ -577,21 +766,26 @@ mod tests {
     use super::*;
     use classic_core::components::{NavMesh, Role};
     use classic_core::math::iso_to_cartesian_4;
-    use classic_core::types::VehicleDef;
+    use classic_core::types::{VehicleDef, VehiclePartDef};
 
     fn test_tilemap() -> Tilemap {
+        flat_tilemap(3, 3)
+    }
+
+    /// A flat, fully-walkable-looking tilemap of arbitrary size (heights all 1).
+    fn flat_tilemap(size_x: i32, size_y: i32) -> Tilemap {
         Tilemap {
             position: Vec3::ZERO,
             scale: Vec3::new(45.0, 45.0, 1.0),
-            size_x: 3,
-            size_y: 3,
+            size_x,
+            size_y,
             tile_set: "tileset".into(),
             tile_pixel_size: [32, 32],
             max_tile: 16,
             tiles_grid: None,
             heights_grid: None,
-            data: vec![0; 9],
-            height_data: vec![1.0; 16],
+            data: vec![0; (size_x * size_y) as usize],
+            height_data: vec![1.0; ((size_x + 1) * (size_y + 1)) as usize],
             height_scale: 14.0,
             tile_set_pixel_size: [0, 0],
             tiles_per_row: 0,
@@ -724,6 +918,9 @@ mod tests {
             pitch_max_deg: 20.0,
             roll_levels: 1,
             roll_max_deg: 20.0,
+            path_footprint: Some(vec![(0, 0)]),
+            safe_fall_px: 0.0,
+            turn_rate_deg_per_sec: 720.0,
             parts: vec![
                 serde_json::from_value(serde_json::json!({
                     "name": "body", "texture": "lrvBody",
@@ -820,6 +1017,9 @@ mod tests {
             pitch_max_deg: 20.0,
             roll_levels: 3,
             roll_max_deg: 20.0,
+            path_footprint: Some(vec![(0, 0)]),
+            safe_fall_px: 0.0,
+            turn_rate_deg_per_sec: 720.0,
             parts: vec![
                 serde_json::from_value(serde_json::json!({
                     "name": "body", "texture": "lrvBody", "anchors": body
@@ -861,5 +1061,561 @@ mod tests {
         assert_eq!(veh.roll_levels, 3);
         assert!((veh.roll_max - 20.0f32.to_radians()).abs() < 1e-6);
         assert!(veh.track_px > 0.0);
+    }
+
+    #[test]
+    fn goto_rejected_while_airborne() {
+        let mut engine = Engine::new_for_test();
+        let tm = engine.world.spawn((test_tilemap(), Role::new(RoleKind::Tilemap)));
+        engine.names.insert("tilemap".into(), tm);
+        let nav = NavMesh {
+            position: Vec3::ZERO,
+            scale: Vec3::ONE,
+            map_entity: "tilemap".into(),
+            tile_set: "navTileset".into(),
+            data_grid: None,
+            data: vec![1; 9],
+            size_x: 3,
+            size_y: 3,
+        };
+        let nm = engine.world.spawn((nav, Role::new(RoleKind::NavMesh)));
+        engine.names.insert("navmesh".into(), nm);
+
+        let def = VehicleDef {
+            name: "lrv".into(),
+            directions: 8,
+            columns: 4,
+            rows: 2,
+            cell: [247.0, 247.0],
+            pitch_levels: 1,
+            pitch_max_deg: 20.0,
+            roll_levels: 1,
+            roll_max_deg: 20.0,
+            path_footprint: Some(vec![(0, 0)]),
+            safe_fall_px: 0.0,
+            turn_rate_deg_per_sec: 720.0,
+            parts: vec![
+                serde_json::from_value(serde_json::json!({
+                    "name": "body", "texture": "lrvBody",
+                    "anchors": [[0.5, 0.7352], [0.5, 0.7352], [0.5, 0.7352], [0.5, 0.7352],
+                                [0.5, 0.7352], [0.5, 0.7352], [0.5, 0.7352], [0.5, 0.7352]]
+                }))
+                .unwrap(),
+                serde_json::from_value(serde_json::json!({
+                    "name": "wheel_fl", "texture": "lrvWheelFl",
+                    "anchors": [[0.566, 0.618], [0.712, 0.676], [0.733, 0.768], [0.618, 0.841],
+                                [0.434, 0.852], [0.288, 0.794], [0.267, 0.702], [0.382, 0.629]]
+                }))
+                .unwrap(),
+                serde_json::from_value(serde_json::json!({
+                    "name": "wheel_fr", "texture": "lrvWheelFr",
+                    "anchors": [[0.734, 0.702], [0.712, 0.794], [0.566, 0.852], [0.382, 0.841],
+                                [0.266, 0.768], [0.288, 0.676], [0.434, 0.618], [0.618, 0.629]]
+                }))
+                .unwrap(),
+                serde_json::from_value(serde_json::json!({
+                    "name": "wheel_rl", "texture": "lrvWheelRl",
+                    "anchors": [[0.211, 0.796], [0.210, 0.676], [0.378, 0.591], [0.618, 0.590],
+                                [0.789, 0.674], [0.790, 0.794], [0.622, 0.880], [0.382, 0.880]]
+                }))
+                .unwrap(),
+                serde_json::from_value(serde_json::json!({
+                    "name": "wheel_rr", "texture": "lrvWheelRr",
+                    "anchors": [[0.379, 0.880], [0.210, 0.794], [0.211, 0.674], [0.382, 0.590],
+                                [0.621, 0.591], [0.790, 0.676], [0.789, 0.796], [0.618, 0.880]]
+                }))
+                .unwrap(),
+            ],
+        };
+        engine.vehicles.insert("lrv".into(), def);
+
+        assert!(engine.spawn_vehicle("lrv", "lrv", 1.0, 1.0));
+        let body = *engine.names.get("lrv").unwrap();
+
+        // Grounded: goto succeeds.
+        assert!(engine.vehicle_goto("lrv", 2, 1));
+        assert!(!engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
+        engine.vehicle_stop("lrv");
+
+        // Airborne: goto is rejected and the path stays empty.
+        engine.world.get::<&mut IsoVehicle>(body).unwrap().airborne = true;
+        assert!(!engine.vehicle_goto("lrv", 2, 1));
+        assert!(engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
+    }
+
+    #[test]
+    fn heading_and_dir_round_trip() {
+        for d in 0..8u32 {
+            assert_eq!(heading_to_dir(dir_to_heading(d)), d, "direction {d} round-trips");
+        }
+        // Negative and wrapped headings quantize to the expected frames.
+        assert_eq!(heading_to_dir(-std::f32::consts::FRAC_PI_4), 7);
+        assert_eq!(heading_to_dir(std::f32::consts::TAU), 0);
+        assert_eq!(heading_to_dir(std::f32::consts::FRAC_PI_2), 2);
+    }
+
+    #[test]
+    fn wrap_pi_bounds_angles() {
+        assert!(wrap_pi(0.0).abs() < 1e-6);
+        assert!((wrap_pi(0.5) - 0.5).abs() < 1e-6);
+        assert!((wrap_pi(std::f32::consts::PI) - std::f32::consts::PI).abs() < 1e-4);
+        assert!((wrap_pi(3.0 * std::f32::consts::PI) - std::f32::consts::PI).abs() < 1e-4);
+        assert!((wrap_pi(-3.0 * std::f32::consts::PI) + std::f32::consts::PI).abs() < 1e-4);
+    }
+
+    #[test]
+    fn lerp_dir2_interpolates_between_frames() {
+        let vals = [
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [10.0, 10.0],
+            [0.0, 10.0],
+            [-10.0, 10.0],
+            [-10.0, 0.0],
+            [-10.0, -10.0],
+            [0.0, -10.0],
+        ];
+        // Midway between East (0) and SouthEast (1) at heading π/8.
+        let mid = lerp_dir2(&vals, std::f32::consts::FRAC_PI_8);
+        assert!((mid[0] - 5.0).abs() < 1e-6 && mid[1].abs() < 1e-6);
+        // Exactly at a frame reproduces that frame's values.
+        let at_east = lerp_dir2(&vals, 0.0);
+        assert_eq!(at_east, [0.0, 0.0]);
+    }
+
+    #[test]
+    fn bounded_turn_steers_forward_only() {
+        // Start heading East, waypoint due South — the vehicle must arc forward
+        // (never reverse) and turn no faster than the configured rate.
+        let mut heading = 0.0f32;
+        let turn_rate = 45.0f32.to_radians();
+        let dt = 1.0 / 60.0;
+        let (tx, ty) = (1.5f32, 5.0f32);
+        let (mut x, mut y) = (1.0f32, 1.0f32);
+        let mut prev_heading = heading;
+
+        for _ in 0..120 {
+            let desired = (ty - y).atan2(tx - x);
+            let err = wrap_pi(desired - heading);
+            let max_turn = turn_rate * dt;
+            let dh = err.clamp(-max_turn, max_turn);
+            assert!(dh.abs() <= max_turn + 1e-6, "turn rate bounded");
+            heading = wrap_pi(heading + dh);
+            assert!(heading >= prev_heading - 1e-6, "no reverse — heading monotonic");
+            prev_heading = heading;
+
+            let step = 1.0 * dt;
+            x += heading.cos() * step;
+            y += heading.sin() * step;
+        }
+
+        assert!(
+            (heading - std::f32::consts::FRAC_PI_2).abs() < 0.4,
+            "heading should converge toward south: {heading}"
+        );
+    }
+
+    /// Build a minimal LRV vehicle definition (body + 4 wheels, flat anchors)
+    /// with a configurable turn rate for movement tests.
+    fn lrv_def(turn_rate_deg: f32) -> VehicleDef {
+        let part = |name: &str, texture: &str, anchors: [f32; 2]| VehiclePartDef {
+            name: name.into(),
+            texture: texture.into(),
+            anchors: vec![anchors],
+        };
+        VehicleDef {
+            name: "lrv".into(),
+            directions: 8,
+            columns: 4,
+            rows: 2,
+            cell: [247.0, 247.0],
+            pitch_levels: 1,
+            pitch_max_deg: 20.0,
+            roll_levels: 1,
+            roll_max_deg: 20.0,
+            path_footprint: None,
+            safe_fall_px: 0.0,
+            turn_rate_deg_per_sec: turn_rate_deg,
+            parts: vec![
+                part("body", "lrvBody", [0.5, 0.7352]),
+                part("wheel_fl", "lrvWheelFl", [0.566, 0.618]),
+                part("wheel_fr", "lrvWheelFr", [0.734, 0.702]),
+                part("wheel_rl", "lrvWheelRl", [0.211, 0.796]),
+                part("wheel_rr", "lrvWheelRr", [0.379, 0.880]),
+            ],
+        }
+    }
+
+    #[test]
+    fn spawn_vehicle_auto_derives_footprint() {
+        let mut engine = Engine::new_for_test();
+        let tm = engine.world.spawn((test_tilemap(), Role::new(RoleKind::Tilemap)));
+        engine.names.insert("tilemap".into(), tm);
+        engine.vehicles.insert("lrv".into(), lrv_def(90.0));
+
+        assert!(engine.spawn_vehicle("lrv", "lrv", 1.0, 1.0));
+        let body = *engine.names.get("lrv").unwrap();
+        let v = engine.world.get::<&IsoVehicle>(body).unwrap();
+
+        // Auto-derived footprint is a full rectangle covering the wheel extent
+        // plus a 1-tile margin.
+        assert!(!v.path_footprint.is_empty());
+        let half_x = v.path_footprint.iter().map(|p| p.0.abs()).max().unwrap();
+        let half_y = v.path_footprint.iter().map(|p| p.1.abs()).max().unwrap();
+        assert!(half_x >= 1 && half_y >= 1, "footprint should cover the wheel extent");
+        assert_eq!(
+            v.path_footprint.len() as i32,
+            (half_x * 2 + 1) * (half_y * 2 + 1),
+            "footprint must be a full rectangle"
+        );
+    }
+
+    #[test]
+    fn lookahead_targets_a_point_ahead() {
+        // Straight east path, vehicle at (1, 1): with lookahead 2 the target
+        // lands two tiles east of the vehicle on the first segment.
+        let path = [[1, 1], [5, 1], [9, 1]];
+        let (gx, gy, idx) = lookahead(&path, 1, 1.5, 1.5, 2.0);
+        assert_eq!(idx, 1);
+        assert!((gx - 3.5).abs() < 1e-4 && (gy - 1.5).abs() < 1e-4, "got ({gx}, {gy})");
+
+        // A longer look-ahead crosses into the next segment and advances idx.
+        let (gx, gy, idx) = lookahead(&path, 1, 1.5, 1.5, 6.0);
+        assert_eq!(idx, 2);
+        assert!((gx - 7.5).abs() < 1e-4 && (gy - 1.5).abs() < 1e-4, "got ({gx}, {gy})");
+
+        // Exhausting the path returns the final waypoint center.
+        let (gx, gy, idx) = lookahead(&path, 1, 1.5, 1.5, 100.0);
+        assert_eq!(idx, path.len());
+        assert!((gx - 9.5).abs() < 1e-4 && (gy - 1.5).abs() < 1e-4, "got ({gx}, {gy})");
+    }
+
+    #[test]
+    fn lookahead_skips_a_passed_waypoint() {
+        // Vehicle past the corner: path goes east then south, but the vehicle is
+        // already east of the corner.  It must skip the corner waypoint rather
+        // than target a point behind it.
+        let path = [[1, 1], [5, 1], [5, 5]];
+        let (gx, gy, idx) = lookahead(&path, 1, 5.5, 1.5, 2.0);
+        // The corner (5,1) is behind the vehicle; look-ahead continues south.
+        assert!(idx >= 2, "corner waypoint should be skipped, got idx {idx}");
+        assert!((gx - 5.5).abs() < 1e-4 && gy > 1.5, "got ({gx}, {gy})");
+    }
+
+    #[test]
+    fn pure_pursuit_reaches_goal_without_orbiting() {
+        let mut engine = Engine::new_for_test();
+        let size = 20i32;
+        let tm_e = engine.world.spawn((flat_tilemap(size, size), Role::new(RoleKind::Tilemap)));
+        engine.names.insert("tilemap".into(), tm_e);
+        engine.vehicles.insert("lrv".into(), lrv_def(90.0));
+
+        assert!(engine.spawn_vehicle("lrv", "lrv", 1.0, 1.0));
+        let body = *engine.names.get("lrv").unwrap();
+
+        // L-shaped path with a 90-degree corner: (1,1) -> (5,1) -> (5,5).
+        {
+            let mut v = engine.world.get::<&mut IsoVehicle>(body).unwrap();
+            v.path = vec![[1, 1], [5, 1], [5, 5]];
+            v.path_idx = 1;
+        }
+
+        let mut last_idx = 0usize;
+        let mut reached = false;
+        for _ in 0..600 {
+            engine.time.delta = 1.0 / 60.0;
+            engine.update_vehicles();
+            let v = engine.world.get::<&IsoVehicle>(body).unwrap();
+            if v.path.is_empty() {
+                reached = true;
+                break;
+            }
+            assert!(v.path_idx >= last_idx, "path_idx went backwards");
+            last_idx = v.path_idx;
+        }
+        assert!(reached, "vehicle never reached the goal after 600 frames");
+
+        let (gx, gy, _) = engine.get_pos("lrv").unwrap();
+        assert!(
+            (gx - 5.5).abs() < 0.01 && (gy - 5.5).abs() < 0.01,
+            "not snapped to goal: ({gx}, {gy})"
+        );
+    }
+
+    /// A rectangular footprint `[-hx..=hx] × [-hy..=hy]`.
+    fn rect_footprint(hx: i32, hy: i32) -> Vec<(i32, i32)> {
+        let mut fp = Vec::new();
+        for dy in -hy..=hy {
+            for dx in -hx..=hx {
+                fp.push((dx, dy));
+            }
+        }
+        fp
+    }
+
+    /// The real LRV sidecar anchors (8 directions per part) from `lrv.json`.
+    fn lrv_def_real() -> VehicleDef {
+        let part = |name: &str, texture: &str, anchors: Vec<[f32; 2]>| VehiclePartDef {
+            name: name.into(),
+            texture: texture.into(),
+            anchors,
+        };
+        VehicleDef {
+            name: "lrv".into(),
+            directions: 8,
+            columns: 4,
+            rows: 2,
+            cell: [331.0, 331.0],
+            pitch_levels: 5,
+            pitch_max_deg: 20.0,
+            roll_levels: 3,
+            roll_max_deg: 20.0,
+            path_footprint: None,
+            turn_rate_deg_per_sec: 90.0,
+            safe_fall_px: 96.0,
+            parts: vec![
+                part("body", "lrvBody", vec![[0.5, 0.6618]; 8]),
+                part(
+                    "wheel_fl",
+                    "lrvWheelFl",
+                    vec![
+                        [0.549373, 0.574673],
+                        [0.658127, 0.617648],
+                        [0.674253, 0.686486],
+                        [0.588304, 0.740864],
+                        [0.450627, 0.748927],
+                        [0.341873, 0.705952],
+                        [0.325747, 0.637114],
+                        [0.411696, 0.582736],
+                    ],
+                ),
+                part(
+                    "wheel_fr",
+                    "lrvWheelFr",
+                    vec![
+                        [0.674361, 0.637148],
+                        [0.658154, 0.706015],
+                        [0.549303, 0.74898],
+                        [0.411571, 0.740877],
+                        [0.325639, 0.686452],
+                        [0.341846, 0.617585],
+                        [0.450697, 0.57462],
+                        [0.588429, 0.582723],
+                    ],
+                ),
+                part(
+                    "wheel_rl",
+                    "lrvWheelRl",
+                    vec![
+                        [0.284399, 0.70716],
+                        [0.283399, 0.617648],
+                        [0.40928, 0.554],
+                        [0.588304, 0.553499],
+                        [0.715601, 0.61644],
+                        [0.716601, 0.705952],
+                        [0.59072, 0.7696],
+                        [0.411696, 0.770101],
+                    ],
+                ),
+                part(
+                    "wheel_rr",
+                    "lrvWheelRr",
+                    vec![
+                        [0.409349, 0.769654],
+                        [0.283371, 0.706014],
+                        [0.284292, 0.616474],
+                        [0.411571, 0.553486],
+                        [0.590651, 0.553946],
+                        [0.716629, 0.617586],
+                        [0.715708, 0.707126],
+                        [0.588429, 0.770114],
+                    ],
+                ),
+            ],
+        }
+    }
+
+    /// Build an engine with a 48×48 tilemap + all-walkable nav (the lrvtest
+    /// shape), spawn a vehicle with a 7×5 footprint + safe_fall, and assert a
+    /// flat click-to-move finds a path.
+    fn engine_with_lrvtest_like_map(heights: Option<Vec<f32>>) -> Engine {
+        let mut engine = Engine::new_for_test();
+        let size = 48;
+        let mut tm = flat_tilemap(size, size);
+        tm.height_scale = 32.0; // matches commit_terrain(32.0) in lrv-guest
+        if let Some(h) = heights {
+            tm.height_data = h;
+        }
+        let tm_e = engine.world.spawn((tm, Role::new(RoleKind::Tilemap)));
+        engine.names.insert("tilemap".into(), tm_e);
+
+        let nav = NavMesh {
+            position: Vec3::ZERO,
+            scale: Vec3::ONE,
+            map_entity: "tilemap".into(),
+            tile_set: "navTileset".into(),
+            data_grid: None,
+            data: vec![1; (size * size) as usize],
+            size_x: size,
+            size_y: size,
+        };
+        let nm = engine.world.spawn((nav, Role::new(RoleKind::NavMesh)));
+        engine.names.insert("navmesh".into(), nm);
+
+        let mut def = lrv_def(90.0);
+        def.path_footprint = Some(rect_footprint(3, 2)); // 7x5, matches auto-derive
+        def.safe_fall_px = 96.0;
+        engine.vehicles.insert("lrv".into(), def);
+
+        engine
+    }
+
+    #[test]
+    fn vehicle_goto_paths_across_flat_lrvtest_like_map() {
+        let mut engine = engine_with_lrvtest_like_map(None);
+        assert!(engine.spawn_vehicle("lrv", "lrv", 5.0, 5.0));
+        assert!(engine.vehicle_goto("lrv", 24, 24), "flat click-to-move should path");
+        let body = *engine.names.get("lrv").unwrap();
+        assert!(!engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
+    }
+
+    #[test]
+    fn vehicle_goto_paths_around_features() {
+        // A gentle ramp band (0.375 units/tile) and a steep curb (1.0 unit/tile)
+        // like the lrvtest map: the flat base and ramp faces must stay reachable.
+        let size = 48;
+        let n = (size + 1) as usize;
+        let mut heights = vec![1.0f32; n * n];
+        // East ramp: x in 33..=41, y in 20..=29, rise 3 units over 8 tiles.
+        for y in 20..=29 {
+            for x in 33..=41 {
+                heights[y * n + x] = heights[y * n + x].max(1.0 + 3.0 * (x - 33) as f32 / 8.0);
+            }
+        }
+        // Curb: x in 20..=36, y in 42..=47, +1 unit.
+        for x in 20..=36 {
+            for y in 42..=47 {
+                heights[y * n + x] = heights[y * n + x].max(2.0);
+            }
+        }
+
+        let mut engine = engine_with_lrvtest_like_map(Some(heights));
+        assert!(engine.spawn_vehicle("lrv", "lrv", 5.0, 5.0));
+        // Flat destination far from features.
+        assert!(engine.vehicle_goto("lrv", 10, 10), "flat destination should path");
+        // Ramp face (gentle) should be reachable.
+        assert!(engine.vehicle_goto("lrv", 33, 25), "gentle ramp face should path");
+    }
+
+    #[test]
+    fn real_lrv_def_auto_derives_and_paths() {
+        let mut engine = engine_with_lrvtest_like_map(None);
+        engine.vehicles.insert("lrv".into(), lrv_def_real());
+
+        assert!(engine.spawn_vehicle("lrv", "lrv", 5.0, 5.0));
+        let body = *engine.names.get("lrv").unwrap();
+        let (half_x, half_y) = {
+            let v = engine.world.get::<&IsoVehicle>(body).unwrap();
+            let half_x = v.path_footprint.iter().map(|p| p.0.abs()).max().unwrap();
+            let half_y = v.path_footprint.iter().map(|p| p.1.abs()).max().unwrap();
+            (half_x, half_y)
+        };
+        let footprint_len = {
+            let v = engine.world.get::<&IsoVehicle>(body).unwrap();
+            v.path_footprint.len() as i32
+        };
+        assert_eq!(footprint_len, (half_x * 2 + 1) * (half_y * 2 + 1));
+
+        assert!(engine.vehicle_goto("lrv", 24, 24), "goto with real def + auto footprint");
+    }
+
+    /// The full `lrvtest` ramp-course height field, mirroring
+    /// `gen_lrvtest_map` in classic-roms: base 1.0, a central hill, four
+    /// cardinal + four diagonal ramps, and a raised curb.
+    fn lrvtest_heights() -> Vec<f32> {
+        let size = 48usize;
+        let n = size + 1;
+        let mut h = vec![1.0f32; n * n];
+        let idx = |x: usize, y: usize| y * n + x;
+
+        // Central hill: +2 peak at (24,24), radius 5.
+        for y in 0..n {
+            for x in 0..n {
+                let dx = x as f32 - 24.0;
+                let dy = y as f32 - 24.0;
+                let d = (dx * dx + dy * dy).sqrt();
+                if d < 5.0 {
+                    let bump = 2.0 * (1.0 - d / 5.0);
+                    h[idx(x, y)] = h[idx(x, y)].max(1.0 + bump);
+                }
+            }
+        }
+        // Cardinal ramps.
+        for y in 20..=29 {
+            for x in 33..=41 {
+                h[idx(x, y)] = h[idx(x, y)].max(1.0 + 3.0 * (x - 33) as f32 / 8.0);
+            }
+            for x in 7..=15 {
+                h[idx(x, y)] = h[idx(x, y)].max(1.0 + 3.0 * (15 - x) as f32 / 8.0);
+            }
+        }
+        for x in 20..=29 {
+            for y in 33..=41 {
+                h[idx(x, y)] = h[idx(x, y)].max(1.0 + 3.0 * (y - 33) as f32 / 8.0);
+            }
+            for y in 7..=15 {
+                h[idx(x, y)] = h[idx(x, y)].max(1.0 + 3.0 * (15 - y) as f32 / 8.0);
+            }
+        }
+        // Diagonal ramps.
+        for x in 33..=41 {
+            for y in 33..=41 {
+                h[idx(x, y)] = h[idx(x, y)].max(1.0 + 3.0 * ((x + y) as f32 - 66.0) / 16.0);
+            }
+            for y in 7..=15 {
+                h[idx(x, y)] =
+                    h[idx(x, y)].max(1.0 + 3.0 * (x as f32 + (15.0 - y as f32) - 40.0) / 16.0);
+            }
+        }
+        for x in 7..=15 {
+            for y in 7..=15 {
+                h[idx(x, y)] = h[idx(x, y)].max(1.0 + 3.0 * (30.0 - (x + y) as f32) / 16.0);
+            }
+            for y in 33..=41 {
+                h[idx(x, y)] =
+                    h[idx(x, y)].max(1.0 + 3.0 * (15.0 - x as f32 + y as f32 - 40.0) / 16.0);
+            }
+        }
+        // Curb.
+        for x in 20..=36 {
+            for y in 42..=47 {
+                h[idx(x, y)] = h[idx(x, y)].max(2.0);
+            }
+        }
+        h
+    }
+
+    #[test]
+    fn vehicle_goto_paths_on_full_lrvtest_map() {
+        let mut engine = engine_with_lrvtest_like_map(Some(lrvtest_heights()));
+        engine.vehicles.insert("lrv".into(), lrv_def_real());
+
+        assert!(engine.spawn_vehicle("lrv", "lrv", 5.0, 5.0));
+
+        // Flat base, the ramp faces (gentle slopes), and the central hill must
+        // be reachable.
+        assert!(engine.vehicle_goto("lrv", 20, 20), "flat base should path");
+        assert!(engine.vehicle_goto("lrv", 11, 25), "west ramp face should path");
+        assert!(engine.vehicle_goto("lrv", 33, 25), "east ramp face should path");
+        assert!(engine.vehicle_goto("lrv", 24, 24), "central hill should path");
+        assert!(engine.vehicle_goto("lrv", 16, 29), "flat tile beside the ramp should path");
+        assert!(engine.vehicle_goto("lrv", 10, 10), "nw diagonal ramp face should path");
+        // The 1-unit curb is a ~14.5° pitch over the wheelbase — within the
+        // 20° limit, so the vehicle can drive over it.
+        assert!(engine.vehicle_goto("lrv", 28, 45), "1-unit curb should be traversable");
+
+        // The ramp's 3-unit cliff sides are a ~38° pitch over the wheelbase —
+        // beyond the 20° limit, so the vehicle can't stand on them.
+        assert!(!engine.vehicle_goto("lrv", 7, 29), "ramp cliff edge should not path");
     }
 }


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/lrv-vehicle-improvements
base: wkt/rom-releases
submitted:
  github: ___
-->

## Improve LRV vehicle pathing, turning, and cliff-jump

### Motivation

The wheeled `IsoVehicle` (LRV) demo could only path as a 1x1 point,
turned instantly, and had no notion of terrain slope or falls. Issues
#35, #39 and #40 ask for multi-tile pathing with a max rotation speed
and forward-only motion, debug path indicators, and no new paths while
airborne.

### Summary of changes

- Footprint-aware A* (`find_path_for_footprint`,
  `erode_for_footprint`) so a multi-tile vehicle paths by its wheel
  footprint instead of as a 1x1 point.
- Slope-aware nav (`derive_vehicle_slope_nav`) sampling terrain at the
  wheel positions in 8 headings, gated on the vehicle's pitch/roll
  range: gentle ramp faces stay drivable, 3-unit cliff sides don't.
- Downward cliff jumps (`find_path_for_footprint_with_jumps`) within a
  per-vehicle `safe_fall_px` suspension drop distance.
- A bounded-turn, forward-only pure-pursuit controller (`lookahead` +
  `GOAL_TOLERANCE`) replacing instant direction snapping.
- Reject `vehicle_goto` while airborne (issue #40) and auto-derive the
  pathing footprint from `wheelbase_px`/`track_px`.
- A `KeyV` debug overlay drawing each vehicle's planned A* path plus a
  target-waypoint diamond (issue #39).

### Future follow up

- [ ] Path smoothing / nonholonomic-aware A* (e.g. Theta*) to avoid
  90-degree corners and wide arcs on tight courses.
- [ ] Use the true iso tile distance in `wheelbase_px`/`track_px`
  instead of `tile_scale` as an isotropic px/tile approximation.

### Links

- https://github.com/guilledk/classic-wgl/issues/35
- https://github.com/guilledk/classic-wgl/issues/39
- https://github.com/guilledk/classic-wgl/issues/40

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
