### PR TITLE
Fix headless EGL teardown segfault and CI coverage gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
     push:
-        branches: [master, rust-port]
+        branches: [master]
     pull_request:
-        branches: [master, rust-port]
 
 env:
     CARGO_TERM_COLOR: always
@@ -19,7 +18,7 @@ jobs:
               with:
                   components: rustfmt, clippy
             - run: cargo fmt --all -- --check
-            - run: cargo clippy -p classic-core -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo --all-targets -- -D warnings
+            - run: cargo clippy -p classic-core -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo --all-targets -- -D warnings
 
     test:
         name: test
@@ -27,7 +26,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
-            - run: cargo test -p classic-core -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
+            - run: cargo test -p classic-core -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
 
     wasm-check:
         name: wasm check
@@ -35,7 +34,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
-            - run: cargo check --target wasm32-unknown-unknown -p classic-core -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
+            - run: cargo check --target wasm32-unknown-unknown -p classic-core -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
 
     golden:
         name: golden test (headless EGL)

--- a/crates/classic-platform/src/headless.rs
+++ b/crates/classic-platform/src/headless.rs
@@ -23,7 +23,6 @@ type EGLContext = *mut c_void;
 type EGLSurface = *mut c_void;
 
 const EGL_DEFAULT_DISPLAY: EGLDisplay = 0 as EGLDisplay;
-#[allow(dead_code)]
 const EGL_NO_SURFACE: EGLSurface = 0 as EGLSurface;
 const EGL_NO_CONTEXT: EGLContext = 0 as EGLContext;
 
@@ -51,6 +50,16 @@ macro_rules! load_fn {
             .get::<VoidFn>($name)
             .map_err(|e| format!("{}: {e}", std::str::from_utf8($name).unwrap_or("?")))?;
         std::mem::transmute::<VoidFn, unsafe extern "C" fn($($arg),*) -> $ret>(*sym)
+    }};
+}
+
+/// [`load_fn!`] but returning `Option` instead of `Result`, for teardown paths
+/// (e.g. `Drop`) that cannot propagate errors.
+macro_rules! load_fn_opt {
+    ($lib:expr, $name:expr, $ret:ty, $($arg:ty),*) => {{
+        $lib.get::<VoidFn>($name).ok().map(|sym| {
+            std::mem::transmute::<VoidFn, unsafe extern "C" fn($($arg),*) -> $ret>(*sym)
+        })
     }};
 }
 
@@ -227,6 +236,46 @@ impl HeadlessPlatform {
                 _context: context,
                 _surface: surface,
             })
+        }
+    }
+}
+
+impl Drop for HeadlessPlatform {
+    fn drop(&mut self) {
+        // Tear down the EGL context, surface, and display while libEGL is still
+        // loaded.  Without this the context stays current at process exit, and
+        // its thread-local destructor runs against the already-dlclose'd library,
+        // segfaulting at shutdown (issue #47).  The engine's glow context is
+        // dropped first (it lives in the run_loop closure), so no GL call runs
+        // after this teardown.
+        unsafe {
+            let make_current = load_fn_opt!(
+                self._egl_lib,
+                b"eglMakeCurrent\x00",
+                i32,
+                EGLDisplay,
+                EGLSurface,
+                EGLSurface,
+                EGLContext
+            );
+            let destroy_context =
+                load_fn_opt!(self._egl_lib, b"eglDestroyContext\x00", i32, EGLDisplay, EGLContext);
+            let destroy_surface =
+                load_fn_opt!(self._egl_lib, b"eglDestroySurface\x00", i32, EGLDisplay, EGLSurface);
+            let terminate = load_fn_opt!(self._egl_lib, b"eglTerminate\x00", i32, EGLDisplay);
+
+            if let (
+                Some(make_current),
+                Some(destroy_context),
+                Some(destroy_surface),
+                Some(terminate),
+            ) = (make_current, destroy_context, destroy_surface, terminate)
+            {
+                make_current(self._display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+                destroy_context(self._display, self._context);
+                destroy_surface(self._display, self._surface);
+                terminate(self._display);
+            }
         }
     }
 }


### PR DESCRIPTION
## Fix headless EGL teardown segfault + CI coverage

### Headless EGL shutdown segfault (fixes #47)

The `golden test (headless EGL)` job segfaulted (exit 139) at process
teardown *after* every assertion passed.  `HeadlessPlatform` never tore down
EGL: it `dlopen`'d `libEGL.so.1`, stored the display/context/surface as raw
pointers, and dropped `_egl_lib` (dlclose) while the context was still
current.  The current-context thread-local destructor then ran at exit
against the unloaded library.

Add a `Drop` impl that, while libEGL is still loaded, unbinds then destroys
context/surface/display (`eglMakeCurrent(NO_CONTEXT)` → `eglDestroyContext`
→ `eglDestroySurface` → `eglTerminate`).  The engine's glow context is
dropped first (it lives in the `run_loop` closure), so no GL call runs after
teardown.

Verified locally (headless EGL): demo golden `12/12 assertions` + trace
match, lunar golden trace match, both exit 0 (previously 139).

### CI coverage (fixes #48, #50)

- Run CI on every PR (drop the `pull_request.branches: [master, rust-port]`
  filter), and drop the dead `rust-port` push branch.
- Add `classic-terrain` and `classic-worker` to the `clippy`, `test`, and
  `wasm-check` crate lists — their `#[cfg(test)]` suites were previously never
  run in CI.
