### PR TITLE
Cap CI job runtimes and harden `apt-get` installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     lint:
         name: lint (fmt + clippy)
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
@@ -23,6 +24,7 @@ jobs:
     test:
         name: test
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
@@ -31,6 +33,7 @@ jobs:
     wasm-check:
         name: wasm check
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
@@ -39,6 +42,7 @@ jobs:
     golden:
         name: golden test (headless EGL)
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@v4
             # ROMs are built by the classic-roms repo and published to an R2
@@ -46,7 +50,13 @@ jobs:
             # building assets/guests from the private submodule.
             - uses: dtolnay/rust-toolchain@stable
             - run: cargo xtask fetch-roms
-            - run: sudo apt-get update -qq && sudo apt-get install -y -qq libegl1-mesa-dev libgl1-mesa-dri libgbm-dev libx11-dev
+            - name: Install Mesa/EGL system deps
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+              timeout-minutes: 5
+              run: |
+                  sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30
+                  sudo apt-get install -y -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 libegl1-mesa-dev libgl1-mesa-dri libgbm-dev libx11-dev
             - run: cargo build -p classic-desktop
             - name: demo scene (e2e assertions + golden trace)
               env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ result/
 apps/web/dist/
 
 # Worktree workspace (open-wkt)
+/wkts/
 .claude/wkts/
 claude_wkts
 


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/ci_timeouts
base: wkt/depth_mask_sprites_v2
head_oid: 0f3aa21ac8859f8e694decccf006fe9bb9a2a6b0
base_tip_oid: 260ce90f23a094ad1e9db5cd8884f22c4c3e601c
merge_base_oid: 260ce90f23a094ad1e9db5cd8884f22c4c3e601c
provider_diff_base_oid: unavailable
commit_range: 260ce90f23a094ad1e9db5cd8884f22c4c3e601c..0f3aa21ac8859f8e694decccf006fe9bb9a2a6b0
diff_range: 260ce90f23a094ad1e9db5cd8884f22c4c3e601c...0f3aa21ac8859f8e694decccf006fe9bb9a2a6b0
authority: forge-verified
submitted:
  github: 61
-->

## Cap CI job runtimes and harden `apt-get` installs

### Motivation

The headless-EGL `golden` job's apt step stalled for the full 6-hour
GitHub default on the spritesheet-packing PR: `apt-get` has no
per-step timeout and `-qq` hid the progress, so the job hung until
GitHub cancelled it. Every job in CI is un-capped and falls back to
that same 6-hour default.

This caps every job with an explicit `timeout-minutes` and hardens
the apt installs so a stuck step fails fast and visibly instead of
burning six hours of runner time.

---

### Summary of changes

- Cap every job with `timeout-minutes` (`lint` 15, `test` 20,
  `wasm-check` 15, `golden` 30, `deploy` 30) so a stuck step fails in
  minutes rather than the 6-hour default.

- Harden the apt steps with `DEBIAN_FRONTEND=noninteractive` and
  bounded `Acquire::Retries`/`Timeout` flags, drop `-qq` so a hang is
  visible in the log, and add a step-level 5-minute timeout.

- Ignore the `/wkts/` worktree dir in `.gitignore`.

---

### Links

- [classic-roms#4][roms-pr] — same timeout/apt hardening for the
  publish job.

---

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))

[roms-pr]: https://github.com/guilledk/classic-roms/pull/4
