### PR TITLE
Offload `vehicle_goto` and extract a shared `pathfinder` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   components: rustfmt, clippy
             - run: cargo fmt --all -- --check
-            - run: cargo clippy -p classic-core -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo --all-targets -- -D warnings
+            - run: cargo clippy -p classic-core -p classic-pathfinder -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo --all-targets -- -D warnings
 
     test:
         name: test
@@ -28,7 +28,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
-            - run: cargo test -p classic-core -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
+            - run: cargo test -p classic-core -p classic-pathfinder -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
 
     wasm-check:
         name: wasm check
@@ -37,7 +37,12 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
-            - run: cargo check --target wasm32-unknown-unknown -p classic-core -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
+              with:
+                  targets: wasm32-unknown-unknown
+            # The web Worker instantiates the compiled `pathfinder.wasm`, which
+            # `web.rs` embeds via `include_bytes!` — build it before checking.
+            - run: cargo xtask build-pathfinder
+            - run: cargo check --target wasm32-unknown-unknown -p classic-core -p classic-pathfinder -p classic-pathfinder-wasm -p classic-terrain -p classic-worker -p classic-gfx -p classic-engine -p classic-platform -p classic-rom -p classic-guest -p classic-demo
 
     golden:
         name: golden test (headless EGL)

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ result/
 /target/
 apps/web/dist/
 
+# generated pathfinder worker module (`cargo xtask build-pathfinder`)
+/crates/classic-worker/src/pathfinder_worker/pathfinder.wasm
+
 # Worktree workspace (open-wkt)
 /wkts/
 .claude/wkts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ cargo clippy -p classic-core -p classic-gfx -p classic-engine -p classic-platfor
 
 # ROMs (must run once after checkout, and when the published ROMs bump)
 cargo xtask fetch-roms               # downloads the staged demo/lunar ROMs (and worker wasm) into roms/out/ (gitignored)
+
+# Web pathfinder module (must run before any --target wasm32 build/check, or trunk build)
+cargo xtask build-pathfinder         # compiles crates/classic-pathfinder-wasm to pathfinder.wasm and stages it next to web.rs
 ```
 
 CI (`.github/workflows/ci.yml`) runs `cargo fmt` + `cargo clippy` + `cargo test` + `wasm check` +
@@ -52,9 +55,13 @@ submodule.
 ```
 Cargo.toml               workspace root (11 members)
 crates/
-  classic-core/           fundamental types, components, ECS registry, math, collision, pathfinder,
-                          tilemap, instrument (CLASSIC_LOG), GJK, quadtree, sdf_builder, plus the
-                          shared ABI marshalling (abi.rs) and field-buffer registry (fields.rs)
+  classic-core/           fundamental types, components, ECS registry, math, collision, tilemap,
+                          instrument (CLASSIC_LOG), GJK, quadtree, sdf_builder, plus the
+                          shared ABI marshalling (abi.rs) and field-buffer registry (fields.rs);
+                          re-exports `classic-pathfinder` as `pathfinder`
+  classic-pathfinder/     #![no_std] A* + footprint/slope/jump vehicle search (single source of
+                          truth for native + web; compiled to `pathfinder.wasm` for the web Worker)
+  classic-pathfinder-wasm/ thin `#[no_mangle]` wasm ABI over `classic-pathfinder` (cdylib)
   classic-worker/         background workers: generic native ThreadPool, PathfinderWorker (native
                           thread + web Worker), and the Tier-3 GuestWorker (a second .wasm instance
                           running pure guest entries against a reduced import surface)
@@ -126,9 +133,11 @@ plans/
   Colliders are synced via `add_collider_to_elem` → `PhysicsProvider` → `sync_colliders`.
   See `classic-ui` skill.
 - **Isometric/pathfinding**: `classic-core/src/tilemap.rs` builds the 3D tilemap mesh;
-  `classic-core/src/pathfinder.rs` implements A* over an immutable `NavSnapshot`
+  the A* + vehicle search lives in the standalone `classic-pathfinder` crate
+  (re-exported as `classic_core::pathfinder`), over an immutable `NavSnapshot`
   (`Arc`-shared).  The engine offloads searches to a host `PathfinderWorker`
-  (`classic-worker`, native thread / web `Worker`); guests drive it through the
+  (`classic-worker`, native thread / web `Worker` running the compiled
+  `pathfinder.wasm`); guests drive it through the
   async `request_path`/`poll_path` SDK imports (with a synchronous fallback for
   the deterministic harness).  See `classic-iso` and `classic-physics` skills.
 - **Wheeled vehicles**: `classic-engine/src/vehicle.rs` implements the `IsoVehicle`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
  "bytemuck",
+ "classic-pathfinder",
  "classic-terrain",
  "glam",
  "hecs",
@@ -434,6 +435,20 @@ dependencies = [
  "wasmtime",
  "wat",
  "web-sys",
+]
+
+[[package]]
+name = "classic-pathfinder"
+version = "0.1.0-alpha.0"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "classic-pathfinder-wasm"
+version = "0.1.0-alpha.0"
+dependencies = [
+ "classic-pathfinder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 resolver = "2"
 members = [
     "crates/classic-core",
+    "crates/classic-pathfinder",
+    "crates/classic-pathfinder-wasm",
     "crates/classic-worker",
     "crates/classic-terrain",
     "crates/classic-gfx",

--- a/crates/classic-core/Cargo.toml
+++ b/crates/classic-core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+classic-pathfinder = { path = "../classic-pathfinder" }
 classic-terrain = { path = "../classic-terrain" }
 glam.workspace = true
 hecs.workspace = true

--- a/crates/classic-core/src/lib.rs
+++ b/crates/classic-core/src/lib.rs
@@ -5,7 +5,6 @@ pub mod components;
 pub mod fields;
 pub mod instrument;
 pub mod math;
-pub mod pathfinder;
 pub mod registry;
 pub mod sdf_builder;
 pub mod terrain;
@@ -23,6 +22,11 @@ use components::{
 pub use camera::Camera;
 pub use components::{RoleKind, SpriteRender, Transform};
 pub use types::Rect;
+
+/// Pathfinding lives in the standalone `classic-pathfinder` crate (shared by
+/// the native host, the native worker thread, and the web `pathfinder.wasm`
+/// module).  Re-exported here so `classic_core::pathfinder::*` keeps resolving.
+pub use classic_pathfinder as pathfinder;
 
 /// Install all known component types into the registry.  Idempotent — the
 /// first call wins and later calls are no-ops.

--- a/crates/classic-core/src/tilemap.rs
+++ b/crates/classic-core/src/tilemap.rs
@@ -248,33 +248,11 @@ fn tri_normal(d1: (f32, f32, f32), d2: (f32, f32, f32)) -> [f32; 3] {
 /// Bilinear interpolation of height data at an iso-space position (px, py).
 ///
 /// `heights` has shape `(size_x + 1) × (size_y + 1)` (one sample per edge vertex).
-pub fn bilinear_height(heights: &[f32], size_x: i32, size_y: i32, px: f32, py: f32) -> f32 {
-    // A generated map has no height grid until its guest uploads one, so
-    // callers that sample terrain every frame must tolerate an empty (or
-    // not-yet-committed) grid.  Treat it as flat (height 0) rather than
-    // indexing out of bounds.
-    if heights.len() != (size_x as usize + 1) * (size_y as usize + 1) {
-        return 0.0;
-    }
-
-    let ftx = px.floor() as i32;
-    let fty = py.floor() as i32;
-    let fx = px - ftx as f32;
-    let fy = py - fty as f32;
-
-    let at = |tx: i32, ty: i32| -> f32 {
-        let tx = tx.clamp(0, size_x) as usize;
-        let ty = ty.clamp(0, size_y) as usize;
-        heights[ty * (size_x as usize + 1) + tx]
-    };
-
-    let h_nw = at(ftx, fty);
-    let h_ne = at(ftx + 1, fty);
-    let h_sw = at(ftx, fty + 1);
-    let h_se = at(ftx + 1, fty + 1);
-
-    h_nw + (h_ne - h_nw) * fx + (h_sw - h_nw) * fy + (h_nw - h_ne - h_sw + h_se) * fx * fy
-}
+///
+/// Re-exported from `classic-pathfinder` (the single source of truth shared
+/// with the wasm worker module) so callers keep using
+/// `classic_core::tilemap::bilinear_height`.
+pub use classic_pathfinder::bilinear_height;
 
 /// Horizontal depth divisor in the canonical iso-depth formula
 /// `iso_depth(tx, ty, z) = (tx - ty) / HORIZONTAL_DEPTH_SCALE + 0.5 + z / D`.

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -213,13 +213,23 @@ pub struct Engine {
     nav_version: u64,
     /// Force pathfinding to run synchronously (deterministic test harness).
     synchronous_workers: bool,
-    /// Next path-request id handed to a guest.
+    /// Next path-request id handed to a guest.  Shared by the humanoid
+    /// `request_path` and vehicle `vehicle_goto` (the worker's result map is a
+    /// single `PathId` namespace), starting at 1 so a vehicle id is always `> 0`
+    /// (the ABI's "airborne" code is `0`).
     next_path_id: u64,
     /// Synchronously-computed path results (synchronous_workers mode / web).
     sync_paths: HashMap<u64, pathfinder::PathPoll>,
     /// Pathfinding worker (spawned lazily on first async request; native
     /// thread or web `Worker` depending on target).
     pathfinder: Option<classic_worker::PathfinderWorker>,
+    /// Immutable vehicle nav snapshot (structural nav + heights) shared with
+    /// the pathfinding worker.
+    vehicle_nav_snapshot: Arc<pathfinder::VehicleNavSnapshot>,
+    /// Synchronously-computed vehicle path results (synchronous_workers mode).
+    sync_vehicle_paths: HashMap<u64, vehicle::VehicleGotoPoll>,
+    /// Vehicle entity for each in-flight vehicle path request id.
+    vehicle_path_entities: HashMap<u64, hecs::Entity>,
     /// Next background-task id handed to a guest.
     next_task_id: u64,
     /// Background guest worker (Tier 3): a second `.wasm` instance running pure
@@ -244,10 +254,6 @@ pub struct Engine {
     sdf_text_gpu: HashMap<hecs::Entity, SdfTextGpu>,
     last_vw: f32,
     last_vh: f32,
-    /// Cached slope-feasibility grid, keyed by `(nav_version, slope params)`.
-    /// Recomputed lazily on terrain rebuild / a different vehicle geometry.
-    /// Single-slot (the demo has one vehicle); extend to a map for many.
-    slope_nav_cache: Option<(u64, [u32; 4], Vec<i32>)>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -329,9 +335,19 @@ impl Engine {
             nav_snapshot: Arc::new(pathfinder::NavSnapshot::new(0, 0, Vec::new())),
             nav_version: 0,
             synchronous_workers: false,
-            next_path_id: 0,
+            next_path_id: 1,
             sync_paths: HashMap::new(),
             pathfinder: None,
+            vehicle_nav_snapshot: Arc::new(pathfinder::VehicleNavSnapshot::new(
+                0,
+                0,
+                Vec::new(),
+                Vec::new(),
+                0.0,
+                45.0,
+            )),
+            sync_vehicle_paths: HashMap::new(),
+            vehicle_path_entities: HashMap::new(),
             next_task_id: 0,
             guest_worker: None,
             fields: fields::FieldRegistry::default(),
@@ -350,7 +366,6 @@ impl Engine {
             sdf_text_gpu: HashMap::new(),
             last_vw: 0.0,
             last_vh: 0.0,
-            slope_nav_cache: None,
         }
     }
 
@@ -1205,17 +1220,13 @@ impl Engine {
         pathfinder::find_path_for_footprint(&nav_i32, nav.size_x, nav.size_y, from, to, footprint)
     }
 
-    /// Footprint-, slope- and jump-aware A* for a wheeled vehicle.
-    ///
-    /// Combines the structural nav (`NavMesh.data`) with a slope-feasibility
-    /// grid derived from the tilemap heights sampled at the vehicle's wheel
-    /// positions (`pitch_max`/`roll_max` limits over `wheelbase_px`/`track_px`),
-    /// then runs A* with downward jump edges: a drop within `safe_fall_px`
-    /// (suspension absorbs it) is routable even where the slope grid blocks, at
-    /// `jump_cost`× the normal cost.  `safe_fall_px <= 0` disables jumps.
+    /// Footprint-, slope- and jump-aware A* for a wheeled vehicle (the
+    /// synchronous fallback, used under `synchronous_workers`).  Builds the
+    /// vehicle nav snapshot and delegates to [`pathfinder::find_vehicle_path_snapshot`],
+    /// the same single code path the worker runs.
     #[allow(clippy::too_many_arguments)]
     pub fn find_vehicle_path(
-        &mut self,
+        &self,
         from: (i32, i32),
         to: (i32, i32),
         footprint: &[(i32, i32)],
@@ -1226,98 +1237,30 @@ impl Engine {
         safe_fall_px: f32,
         jump_cost: f32,
     ) -> Option<Vec<(i32, i32)>> {
-        // Extract everything out of the world up front so the slope cache can
-        // be mutated without holding a `World` borrow.
-        let (nav_data, nav_size_x, nav_size_y) = {
-            let nav_entity = self.entity_by_role(RoleKind::NavMesh)?;
-            let nav = self.world.get::<&NavMesh>(nav_entity).ok()?;
-            (nav.data.clone(), nav.size_x, nav.size_y)
-        };
-        let (heights, height_scale, tile_scale, size_x, size_y) = {
-            let tm_entity = self.entity_by_role(RoleKind::Tilemap)?;
-            let tm = self.world.get::<&Tilemap>(tm_entity).ok()?;
-            (tm.height_data.clone(), tm.height_scale, tm.scale.x, tm.size_x, tm.size_y)
-        };
-
-        let structural: Vec<i32> = nav_data.iter().map(|&v| v as i32).collect();
-        let slope = self.cached_slope_nav(
-            &heights,
-            size_x,
-            size_y,
-            height_scale,
-            tile_scale,
-            wheelbase_px,
-            track_px,
-            pitch_max,
-            roll_max,
-        );
-        let walkable: Vec<i32> =
-            structural.iter().zip(slope.iter()).map(|(&s, &w)| s & w).collect();
-
-        let result = pathfinder::find_path_for_footprint_with_jumps(
-            &walkable,
-            &structural,
-            &heights,
-            nav_size_x,
-            nav_size_y,
+        let snapshot = self.build_vehicle_nav_snapshot()?;
+        let result = pathfinder::find_vehicle_path_snapshot(
+            &snapshot,
             from,
             to,
             footprint,
-            height_scale,
+            pitch_max,
+            roll_max,
+            wheelbase_px,
+            track_px,
             safe_fall_px,
             jump_cost,
         );
         classic_core::cl_info!(
             classic_core::instrument::Chan::Path,
-            "find_vehicle_path {} -> {}: walkable={}/{}, footprint={} tiles, pitch={:.3}rad fall={}px, found={}",
+            "find_vehicle_path {} -> {}: footprint={} tiles, pitch={:.3}rad fall={}px, found={}",
             format!("{from:?}"),
             format!("{to:?}"),
-            walkable.iter().filter(|&&v| v == 1).count(),
-            walkable.len(),
             footprint.len(),
             pitch_max.min(roll_max),
             safe_fall_px,
             result.is_some(),
         );
         result
-    }
-
-    /// The slope-feasibility grid for a vehicle, cached per `nav_version` and
-    /// slope params (recomputed only when the terrain or the vehicle geometry
-    /// changes).
-    #[allow(clippy::too_many_arguments)]
-    fn cached_slope_nav(
-        &mut self,
-        heights: &[f32],
-        size_x: i32,
-        size_y: i32,
-        height_scale: f32,
-        tile_scale: f32,
-        wheelbase_px: f32,
-        track_px: f32,
-        pitch_max: f32,
-        roll_max: f32,
-    ) -> Vec<i32> {
-        let key =
-            [pitch_max.to_bits(), roll_max.to_bits(), wheelbase_px.to_bits(), track_px.to_bits()];
-        if let Some((ver, k, grid)) = &self.slope_nav_cache {
-            if *ver == self.nav_version && *k == key {
-                return grid.clone();
-            }
-        }
-        let grid = pathfinder::derive_vehicle_slope_nav(
-            heights,
-            size_x,
-            size_y,
-            height_scale,
-            tile_scale,
-            wheelbase_px,
-            track_px,
-            pitch_max,
-            roll_max,
-        );
-        self.slope_nav_cache = Some((self.nav_version, key, grid.clone()));
-        grid
     }
 
     /// Rebuild the shared nav snapshot from the live `NavMesh` component and
@@ -1337,8 +1280,40 @@ impl Engine {
             worker.set_snapshot(Arc::clone(&snapshot));
         }
         self.nav_snapshot = snapshot;
+
+        // Rebuild + push the vehicle nav snapshot (structural nav + heights +
+        // height/tile scale) so the worker can run vehicle A* off-thread too.
+        if let Some(vehicle_snapshot) = self.build_vehicle_nav_snapshot() {
+            if let Some(worker) = self.pathfinder.as_mut() {
+                worker.set_vehicle_snapshot(Arc::clone(&vehicle_snapshot));
+            }
+            self.vehicle_nav_snapshot = vehicle_snapshot;
+        }
+
         self.refresh_guest_worker_nav();
         self.nav_version = self.nav_version.wrapping_add(1);
+    }
+
+    /// Build the [`pathfinder::VehicleNavSnapshot`] the worker uses for vehicle
+    /// A*, from the live `NavMesh` (structural nav) and `Tilemap` (heights +
+    /// scales).  Returns `None` when either component is missing.
+    fn build_vehicle_nav_snapshot(&self) -> Option<Arc<pathfinder::VehicleNavSnapshot>> {
+        let nav_entity = self.entity_by_role(RoleKind::NavMesh)?;
+        let nav = self.world.get::<&NavMesh>(nav_entity).ok()?;
+        let structural: Vec<i32> = nav.data.iter().map(|&v| v as i32).collect();
+        let size_x = nav.size_x;
+        let size_y = nav.size_y;
+
+        let tm_entity = self.entity_by_role(RoleKind::Tilemap)?;
+        let tm = self.world.get::<&Tilemap>(tm_entity).ok()?;
+        Some(Arc::new(pathfinder::VehicleNavSnapshot::new(
+            size_x,
+            size_y,
+            structural,
+            tm.height_data.clone(),
+            tm.height_scale,
+            tm.scale.x,
+        )))
     }
 
     /// Force pathfinding to run synchronously on the render thread (the
@@ -1406,11 +1381,12 @@ impl Engine {
     }
 
     /// Spawn the pathfinding worker on first use, sharing the current nav
-    /// snapshot.
+    /// snapshot and vehicle nav snapshot.
     fn ensure_pathfinder(&mut self) {
         if self.pathfinder.is_none() {
-            self.pathfinder =
-                Some(classic_worker::PathfinderWorker::new(Arc::clone(&self.nav_snapshot)));
+            let mut worker = classic_worker::PathfinderWorker::new(Arc::clone(&self.nav_snapshot));
+            worker.set_vehicle_snapshot(Arc::clone(&self.vehicle_nav_snapshot));
+            self.pathfinder = Some(worker);
         }
     }
 

--- a/crates/classic-engine/src/vehicle.rs
+++ b/crates/classic-engine/src/vehicle.rs
@@ -10,6 +10,7 @@
 
 use classic_core::components::{DebugName, IsoSprite, IsoVehicle, RoleKind, Tilemap, Transform};
 use classic_core::math::cartesian_to_iso_4;
+use classic_core::pathfinder::PathPoll;
 use classic_core::tilemap::sample_height_mesh;
 use glam::{Vec2, Vec3};
 
@@ -54,6 +55,26 @@ const GOAL_TOLERANCE: f32 = 0.5;
 /// penalty makes the vehicle prefer flat routes but take a jump when it
 /// clearly shortens the path.
 const JUMP_COST: f32 = 1.3;
+
+/// The outcome of submitting a vehicle path request via [`Engine::vehicle_goto`].
+pub enum VehicleGotoSubmit {
+    /// Vehicle is airborne; the guest should re-issue next frame.
+    Airborne,
+    /// No entity with that name (drop the request).
+    NoVehicle,
+    /// Request submitted; poll with [`Engine::vehicle_goto_poll`].
+    Submitted(u64),
+}
+
+/// The outcome of polling a vehicle path request via [`Engine::vehicle_goto_poll`].
+pub enum VehicleGotoPoll {
+    /// The search is still running.
+    Pending,
+    /// A route was found; carries the waypoints to install on the vehicle.
+    Accepted(Vec<[i32; 2]>),
+    /// No route exists (drop the request).
+    NoPath,
+}
 
 /// A terrain-height sampler snapshot, cloned once per frame so the mutation
 /// pass can sample heights without re-borrowing the world.
@@ -717,19 +738,22 @@ impl Engine {
         true
     }
 
-    /// Set a vehicle's destination (integer tile coordinates).  The host runs
-    /// footprint-, slope- and jump-aware A* (see `Engine::find_vehicle_path`)
-    /// and stores the waypoints on the vehicle.
-    pub fn vehicle_goto(&mut self, name: &str, tx: i32, ty: i32) -> bool {
+    /// Set a vehicle's destination (integer tile coordinates).  Submits a
+    /// footprint-, slope- and jump-aware A* request off-thread (or computes it
+    /// inline under `synchronous_workers`) and returns a request id to poll
+    /// with [`Engine::vehicle_goto_poll`].
+    pub fn vehicle_goto(&mut self, name: &str, tx: i32, ty: i32) -> VehicleGotoSubmit {
         let Some(&ve) = self.names.get(name) else {
             classic_core::cl_info!(
                 classic_core::instrument::Chan::Path,
                 "vehicle_goto: no entity named {name}"
             );
-            return false;
+            return VehicleGotoSubmit::NoVehicle;
         };
         let (footprint, pitch_max, roll_max, wheelbase_px, track_px, safe_fall_px) = {
-            let Ok(v) = self.world.get::<&IsoVehicle>(ve) else { return false };
+            let Ok(v) = self.world.get::<&IsoVehicle>(ve) else {
+                return VehicleGotoSubmit::NoVehicle;
+            };
             // Reject new paths while airborne: the vehicle keeps its current
             // trajectory until its wheels touch down again (issue #40).
             if v.airborne {
@@ -737,7 +761,7 @@ impl Engine {
                     classic_core::instrument::Chan::Path,
                     "vehicle_goto {name}: airborne, rejecting"
                 );
-                return false;
+                return VehicleGotoSubmit::Airborne;
             }
             (
                 v.path_footprint.clone(),
@@ -749,28 +773,92 @@ impl Engine {
             )
         };
         let from = {
-            let Some(tf) = self.world.get::<&Transform>(ve).ok() else { return false };
+            let Ok(tf) = self.world.get::<&Transform>(ve) else {
+                return VehicleGotoSubmit::NoVehicle;
+            };
             (tf.position.x.floor() as i32, tf.position.y.floor() as i32)
         };
-        let Some(path) = self.find_vehicle_path(
-            from,
-            (tx, ty),
-            &footprint,
-            pitch_max,
-            roll_max,
-            wheelbase_px,
-            track_px,
-            safe_fall_px,
-            JUMP_COST,
-        ) else {
-            return false;
-        };
-        let path: Vec<[i32; 2]> = path.into_iter().map(|(x, y)| [x, y]).collect();
-        if let Ok(mut v) = self.world.get::<&mut IsoVehicle>(ve) {
-            v.path = path;
-            v.path_idx = if v.path.len() > 1 { 1 } else { 0 };
+
+        // Allocate a request id.  Shares the `next_path_id` counter with the
+        // humanoid `request_path` so ids stay unique in the worker's result map.
+        let id = self.next_path_id;
+        self.next_path_id = self.next_path_id.wrapping_add(1);
+
+        if !self.synchronous_workers {
+            self.ensure_pathfinder();
+            if let Some(worker) = self.pathfinder.as_mut() {
+                worker.request_vehicle_path(
+                    id,
+                    from,
+                    (tx, ty),
+                    footprint,
+                    pitch_max,
+                    roll_max,
+                    wheelbase_px,
+                    track_px,
+                    safe_fall_px,
+                    JUMP_COST,
+                );
+            }
+        } else {
+            let poll = match self.find_vehicle_path(
+                from,
+                (tx, ty),
+                &footprint,
+                pitch_max,
+                roll_max,
+                wheelbase_px,
+                track_px,
+                safe_fall_px,
+                JUMP_COST,
+            ) {
+                Some(path) => {
+                    VehicleGotoPoll::Accepted(path.into_iter().map(|(x, y)| [x, y]).collect())
+                }
+                None => VehicleGotoPoll::NoPath,
+            };
+            self.sync_vehicle_paths.insert(id, poll);
         }
-        true
+
+        self.vehicle_path_entities.insert(id, ve);
+        VehicleGotoSubmit::Submitted(id)
+    }
+
+    /// Poll a previously submitted vehicle path request (non-blocking).  On
+    /// acceptance, the route is installed on the vehicle (`v.path` /
+    /// `v.path_idx`) here — the single mutation point shared by the sync and
+    /// async paths.
+    pub fn vehicle_goto_poll(&mut self, id: u64) -> VehicleGotoPoll {
+        let poll = if let Some(poll) = self.sync_vehicle_paths.remove(&id) {
+            poll
+        } else if let Some(worker) = self.pathfinder.as_mut() {
+            match worker.poll_vehicle_path(id) {
+                PathPoll::Pending => VehicleGotoPoll::Pending,
+                PathPoll::NoPath => VehicleGotoPoll::NoPath,
+                PathPoll::Path(cells) => {
+                    VehicleGotoPoll::Accepted(cells.into_iter().map(|(x, y)| [x, y]).collect())
+                }
+            }
+        } else {
+            VehicleGotoPoll::Pending
+        };
+
+        match &poll {
+            VehicleGotoPoll::Accepted(path) => {
+                if let Some(ve) = self.vehicle_path_entities.remove(&id) {
+                    if let Ok(mut v) = self.world.get::<&mut IsoVehicle>(ve) {
+                        v.path = path.clone();
+                        v.path_idx = if v.path.len() > 1 { 1 } else { 0 };
+                    }
+                }
+            }
+            VehicleGotoPoll::NoPath => {
+                self.vehicle_path_entities.remove(&id);
+            }
+            VehicleGotoPoll::Pending => {}
+        }
+
+        poll
     }
 
     /// Stop a vehicle, clearing its movement path.
@@ -817,6 +905,20 @@ mod tests {
             selection_iso_begin: Vec3::new(-1.0, -1.0, -1.0),
             selection_iso_end: Vec3::new(-1.0, -1.0, -1.0),
         }
+    }
+
+    /// Submit a vehicle goto under `synchronous_workers` (inline search) and
+    /// return the poll outcome immediately, mirroring the guest's submit/poll
+    /// idiom.  Airborne / unknown-vehicle submissions resolve to `NoPath`.
+    fn goto_sync(engine: &mut Engine, name: &str, tx: i32, ty: i32) -> VehicleGotoPoll {
+        engine.set_synchronous_workers(true);
+        let id = match engine.vehicle_goto(name, tx, ty) {
+            VehicleGotoSubmit::Submitted(id) => id,
+            VehicleGotoSubmit::Airborne | VehicleGotoSubmit::NoVehicle => {
+                return VehicleGotoPoll::NoPath;
+            }
+        };
+        engine.vehicle_goto_poll(id)
     }
 
     #[test]
@@ -1011,7 +1113,7 @@ mod tests {
         let nm = engine.world.spawn((nav, Role::new(RoleKind::NavMesh)));
         engine.names.insert("navmesh".into(), nm);
 
-        assert!(engine.vehicle_goto("lrv", 2, 1));
+        assert!(matches!(goto_sync(&mut engine, "lrv", 2, 1), VehicleGotoPoll::Accepted(_)));
         assert!(!engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
         assert!(engine.vehicle_stop("lrv"));
         assert!(engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
@@ -1191,13 +1293,13 @@ mod tests {
         let body = *engine.names.get("lrv").unwrap();
 
         // Grounded: goto succeeds.
-        assert!(engine.vehicle_goto("lrv", 2, 1));
+        assert!(matches!(goto_sync(&mut engine, "lrv", 2, 1), VehicleGotoPoll::Accepted(_)));
         assert!(!engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
         engine.vehicle_stop("lrv");
 
         // Airborne: goto is rejected and the path stays empty.
         engine.world.get::<&mut IsoVehicle>(body).unwrap().airborne = true;
-        assert!(!engine.vehicle_goto("lrv", 2, 1));
+        assert!(matches!(goto_sync(&mut engine, "lrv", 2, 1), VehicleGotoPoll::NoPath));
         assert!(engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
     }
 
@@ -1532,7 +1634,10 @@ mod tests {
     fn vehicle_goto_paths_across_flat_lrvtest_like_map() {
         let mut engine = engine_with_lrvtest_like_map(None);
         assert!(engine.spawn_vehicle("lrv", "lrv", 5.0, 5.0));
-        assert!(engine.vehicle_goto("lrv", 24, 24), "flat click-to-move should path");
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 24, 24), VehicleGotoPoll::Accepted(_)),
+            "flat click-to-move should path"
+        );
         let body = *engine.names.get("lrv").unwrap();
         assert!(!engine.world.get::<&IsoVehicle>(body).unwrap().path.is_empty());
     }
@@ -1560,9 +1665,15 @@ mod tests {
         let mut engine = engine_with_lrvtest_like_map(Some(heights));
         assert!(engine.spawn_vehicle("lrv", "lrv", 5.0, 5.0));
         // Flat destination far from features.
-        assert!(engine.vehicle_goto("lrv", 10, 10), "flat destination should path");
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 10, 10), VehicleGotoPoll::Accepted(_)),
+            "flat destination should path"
+        );
         // Ramp face (gentle) should be reachable.
-        assert!(engine.vehicle_goto("lrv", 33, 25), "gentle ramp face should path");
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 33, 25), VehicleGotoPoll::Accepted(_)),
+            "gentle ramp face should path"
+        );
     }
 
     #[test]
@@ -1584,7 +1695,10 @@ mod tests {
         };
         assert_eq!(footprint_len, (half_x * 2 + 1) * (half_y * 2 + 1));
 
-        assert!(engine.vehicle_goto("lrv", 24, 24), "goto with real def + auto footprint");
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 24, 24), VehicleGotoPoll::Accepted(_)),
+            "goto with real def + auto footprint"
+        );
     }
 
     /// The full `lrvtest` ramp-course height field, mirroring
@@ -1662,18 +1776,42 @@ mod tests {
 
         // Flat base, the ramp faces (gentle slopes), and the central hill must
         // be reachable.
-        assert!(engine.vehicle_goto("lrv", 20, 20), "flat base should path");
-        assert!(engine.vehicle_goto("lrv", 11, 25), "west ramp face should path");
-        assert!(engine.vehicle_goto("lrv", 33, 25), "east ramp face should path");
-        assert!(engine.vehicle_goto("lrv", 24, 24), "central hill should path");
-        assert!(engine.vehicle_goto("lrv", 16, 29), "flat tile beside the ramp should path");
-        assert!(engine.vehicle_goto("lrv", 10, 10), "nw diagonal ramp face should path");
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 20, 20), VehicleGotoPoll::Accepted(_)),
+            "flat base should path"
+        );
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 11, 25), VehicleGotoPoll::Accepted(_)),
+            "west ramp face should path"
+        );
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 33, 25), VehicleGotoPoll::Accepted(_)),
+            "east ramp face should path"
+        );
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 24, 24), VehicleGotoPoll::Accepted(_)),
+            "central hill should path"
+        );
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 16, 29), VehicleGotoPoll::Accepted(_)),
+            "flat tile beside the ramp should path"
+        );
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 10, 10), VehicleGotoPoll::Accepted(_)),
+            "nw diagonal ramp face should path"
+        );
         // The 1-unit curb is a ~14.5° pitch over the wheelbase — within the
         // 20° limit, so the vehicle can drive over it.
-        assert!(engine.vehicle_goto("lrv", 28, 45), "1-unit curb should be traversable");
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 28, 45), VehicleGotoPoll::Accepted(_)),
+            "1-unit curb should be traversable"
+        );
 
         // The ramp's 3-unit cliff sides are a ~38° pitch over the wheelbase —
         // beyond the 20° limit, so the vehicle can't stand on them.
-        assert!(!engine.vehicle_goto("lrv", 7, 29), "ramp cliff edge should not path");
+        assert!(
+            matches!(goto_sync(&mut engine, "lrv", 7, 29), VehicleGotoPoll::NoPath),
+            "ramp cliff edge should not path"
+        );
     }
 }

--- a/crates/classic-guest/src/imports.rs
+++ b/crates/classic-guest/src/imports.rs
@@ -314,6 +314,14 @@ macro_rules! install_host_imports {
 
         $linker.func_wrap(
             m,
+            "vehicle_goto_poll",
+            |mut caller: Caller<'_, $host>, id: i32| -> i32 {
+                caller.data_mut().guest_mut().vehicle_goto_poll(id)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
             "vehicle_stop",
             |mut caller: Caller<'_, $host>, ptr: i32, len: i32| -> i32 {
                 let name = $read_str(&mut caller, ptr, len);

--- a/crates/classic-guest/src/runtime_web.rs
+++ b/crates/classic-guest/src/runtime_web.rs
@@ -919,6 +919,16 @@ impl WebWasmRuntime {
             );
         }
 
+        // vehicle_goto_poll
+        {
+            let host = host.clone();
+            set_import!(
+                "vehicle_goto_poll",
+                Box::new(move |id: i32| -> i32 { host.borrow_mut().vehicle_goto_poll(id) })
+                    as Box<dyn FnMut(i32) -> i32>
+            );
+        }
+
         // vehicle_stop
         {
             let host = host.clone();

--- a/crates/classic-guest/src/sdk.rs
+++ b/crates/classic-guest/src/sdk.rs
@@ -11,6 +11,7 @@ use classic_core::fields::FieldDtype;
 use classic_core::instrument::Chan;
 use classic_core::pathfinder::PathPoll;
 use classic_core::terrain::kernels::{FieldOp, Reduce};
+use classic_engine::vehicle::{VehicleGotoPoll, VehicleGotoSubmit};
 use classic_engine::Engine;
 
 /// Map an integer to a [`UiAnchor`] (0..=8, TopLeft → BotRight).
@@ -248,10 +249,26 @@ impl GuestHost {
         self.engine_mut().spawn_vehicle(def, name, x as f32, y as f32) as i32
     }
 
-    /// Set a wheeled vehicle's destination (integer tile coordinates).  The
-    /// host runs its own A* and stores the waypoints on the vehicle.
+    /// Set a wheeled vehicle's destination (integer tile coordinates).  Returns
+    /// `> 0` (a request id to poll with [`Self::vehicle_goto_poll`]), `0` when
+    /// the vehicle is airborne (re-issue next frame), or `-1` for an unknown
+    /// vehicle.
     pub fn vehicle_goto(&mut self, name: &str, tx: i32, ty: i32) -> i32 {
-        self.engine_mut().vehicle_goto(name, tx, ty) as i32
+        match self.engine_mut().vehicle_goto(name, tx, ty) {
+            VehicleGotoSubmit::Airborne => 0,
+            VehicleGotoSubmit::NoVehicle => -1,
+            VehicleGotoSubmit::Submitted(id) => id as i32,
+        }
+    }
+
+    /// Poll a vehicle path request by id: `0` pending, `1` accepted (path
+    /// installed), `-1` no path.
+    pub fn vehicle_goto_poll(&mut self, id: i32) -> i32 {
+        match self.engine_mut().vehicle_goto_poll(id as u64) {
+            VehicleGotoPoll::Pending => 0,
+            VehicleGotoPoll::Accepted(_) => 1,
+            VehicleGotoPoll::NoPath => -1,
+        }
     }
 
     /// Stop a wheeled vehicle, clearing its movement path.

--- a/crates/classic-guest/tests/guest.rs
+++ b/crates/classic-guest/tests/guest.rs
@@ -225,16 +225,18 @@ fn guest_vehicle_imports_are_wired() {
         r#"(module
             (import "env" "vehicle_teleport" (func $t (param i32 i32 f64 f64) (result i32)))
             (import "env" "vehicle_goto" (func $g (param i32 i32 i32 i32) (result i32)))
+            (import "env" "vehicle_goto_poll" (func $gp (param i32) (result i32)))
             (import "env" "vehicle_stop" (func $s (param i32 i32) (result i32)))
             (import "env" "vehicle_spawn" (func $sp (param i32 i32 i32 i32 f64 f64) (result i32)))
             (memory (export "memory") 1)
             (data (i32.const 0) "lrv")
             (data (i32.const 16) "rover")
-            (func (export "update") (param f64)
+            (func (export "update") (param f64) (local $id i32)
                 (drop (call $sp (i32.const 0) (i32.const 3) (i32.const 16) (i32.const 5)
                     (f64.const 1.0) (f64.const 1.0)))
                 (drop (call $t (i32.const 16) (i32.const 5) (f64.const 1.0) (f64.const 1.0)))
-                (drop (call $g (i32.const 16) (i32.const 5) (i32.const 2) (i32.const 0)))
+                (local.set $id (call $g (i32.const 16) (i32.const 5) (i32.const 2) (i32.const 0)))
+                (drop (call $gp (local.get $id)))
                 (drop (call $s (i32.const 16) (i32.const 5)))))"#,
         &GuestLimits::default(),
         |rt| {

--- a/crates/classic-pathfinder-wasm/Cargo.toml
+++ b/crates/classic-pathfinder-wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "classic-pathfinder-wasm"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+classic-pathfinder = { path = "../classic-pathfinder" }

--- a/crates/classic-pathfinder-wasm/src/lib.rs
+++ b/crates/classic-pathfinder-wasm/src/lib.rs
@@ -1,0 +1,146 @@
+//! Thin `#[no_mangle]` wasm ABI over `classic_pathfinder::PathfinderState`.
+//!
+//! Built to `pathfinder.wasm` (`cargo xtask build-pathfinder`) and instantiated
+//! by the web `Worker` shim in `classic-worker`.  It is the *same* Rust
+//! pathfinder the native worker thread runs, so native and web routes are
+//! identical by construction.
+//!
+//! The module is stateful and single-threaded (a `Worker` is single-threaded):
+//! `set_snapshot` / `set_vehicle_snapshot` upload a grid copy, `find` /
+//! `find_vehicle` run the search and leave the result in an internal buffer,
+//! and `result_ptr` exposes that buffer to the shim.  `alloc` returns a
+//! caller-writable scratch buffer for uploading input grids.
+
+use std::sync::{Mutex, MutexGuard};
+
+use classic_pathfinder::{GridCell, NavSnapshot, PathfinderState, VehicleNavSnapshot};
+
+struct WState {
+    pathfinder: PathfinderState,
+    result: Vec<i32>,
+}
+
+static STATE: Mutex<Option<WState>> = Mutex::new(None);
+
+fn state() -> MutexGuard<'static, Option<WState>> {
+    STATE.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Allocate a caller-writable scratch buffer of `len` bytes.  Leaked (inputs are
+/// uploaded rarely — once per terrain commit, or a tiny footprint per request).
+#[no_mangle]
+pub extern "C" fn alloc(len: i32) -> *mut u8 {
+    let len = len.max(0) as usize;
+    let mut v = Vec::<u8>::with_capacity(len);
+    let p = v.as_mut_ptr();
+    core::mem::forget(v);
+    p
+}
+
+#[no_mangle]
+pub extern "C" fn set_snapshot(size_x: i32, size_y: i32, ptr: *const i32, len: i32) {
+    let data = unsafe { core::slice::from_raw_parts(ptr, len.max(0) as usize) }.to_vec();
+    let nav = NavSnapshot::new(size_x, size_y, data);
+    let mut st = state();
+    match st.as_mut() {
+        Some(st) => st.pathfinder.set_nav(nav),
+        None => *st = Some(WState { pathfinder: PathfinderState::new(nav), result: Vec::new() }),
+    }
+}
+
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn set_vehicle_snapshot(
+    size_x: i32,
+    size_y: i32,
+    structural: *const i32,
+    structural_len: i32,
+    heights: *const f32,
+    heights_len: i32,
+    height_scale: f32,
+    tile_scale: f32,
+) {
+    let structural =
+        unsafe { core::slice::from_raw_parts(structural, structural_len.max(0) as usize) }.to_vec();
+    let heights =
+        unsafe { core::slice::from_raw_parts(heights, heights_len.max(0) as usize) }.to_vec();
+    let snap =
+        VehicleNavSnapshot::new(size_x, size_y, structural, heights, height_scale, tile_scale);
+    let mut st = state();
+    match st.as_mut() {
+        Some(st) => st.pathfinder.set_vehicle(snap),
+        None => {
+            let mut pf = PathfinderState::new(NavSnapshot::new(0, 0, Vec::new()));
+            pf.set_vehicle(snap);
+            *st = Some(WState { pathfinder: pf, result: Vec::new() });
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn find(from_x: i32, from_y: i32, to_x: i32, to_y: i32) -> i32 {
+    let mut st = state();
+    let Some(st) = st.as_mut() else { return -1 };
+    match st.pathfinder.find((from_x, from_y), (to_x, to_y)) {
+        Some(path) => write_result(&mut st.result, path),
+        None => -1,
+    }
+}
+
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn find_vehicle(
+    from_x: i32,
+    from_y: i32,
+    to_x: i32,
+    to_y: i32,
+    footprint: *const i32,
+    footprint_len: i32,
+    pitch_max: f32,
+    roll_max: f32,
+    wheelbase_px: f32,
+    track_px: f32,
+    safe_fall_px: f32,
+    jump_cost: f32,
+) -> i32 {
+    let fp_len = footprint_len.max(0) as usize;
+    let footprint: Vec<GridCell> = unsafe { core::slice::from_raw_parts(footprint, fp_len * 2) }
+        .chunks_exact(2)
+        .map(|c| (c[0], c[1]))
+        .collect();
+    let mut st = state();
+    let Some(st) = st.as_mut() else { return -1 };
+    match st.pathfinder.find_vehicle(
+        (from_x, from_y),
+        (to_x, to_y),
+        &footprint,
+        pitch_max,
+        roll_max,
+        wheelbase_px,
+        track_px,
+        safe_fall_px,
+        jump_cost,
+    ) {
+        Some(path) => write_result(&mut st.result, path),
+        None => -1,
+    }
+}
+
+/// Pointer to the internal result buffer (flat `[x0, y0, x1, y1, …]`), valid
+/// until the next `find` / `find_vehicle`.
+#[no_mangle]
+pub extern "C" fn result_ptr() -> *const i32 {
+    match state().as_ref() {
+        Some(st) if !st.result.is_empty() => st.result.as_ptr(),
+        _ => core::ptr::null(),
+    }
+}
+
+fn write_result(result: &mut Vec<i32>, path: Vec<GridCell>) -> i32 {
+    result.clear();
+    for (x, y) in path {
+        result.push(x);
+        result.push(y);
+    }
+    result.len() as i32 / 2
+}

--- a/crates/classic-pathfinder/Cargo.toml
+++ b/crates/classic-pathfinder/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "classic-pathfinder"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+libm = "0.2"

--- a/crates/classic-pathfinder/src/lib.rs
+++ b/crates/classic-pathfinder/src/lib.rs
@@ -1,14 +1,22 @@
-//! # Skill: `classic-physics`
+//! A* pathfinding over a 2D grid of walkable/blocked cells, plus the
+//! footprint-, slope- and jump-aware vehicle search.
 //!
-//! **Read `.claude/skills/classic-physics/SKILL.md` before working on this module.**
+//! `#![no_std]` (with `alloc`) so the same code compiles into the host
+//! (`classic-core` re-exports this as `pathfinder`), the native worker thread,
+//! and the web `pathfinder.wasm` worker module — a single source of truth for
+//! native + web routes.  Transcendental functions use `libm` so results are
+//! reproducible across targets (the same rationale as `classic-terrain`).
 //!
-//! A* pathfinding over a 2D grid of walkable/blocked cells.
-//!
-//! Port of the algorithm from `src/classic/pathfinder.ts` (web worker),
-//! running in-thread.  The nav mesh is a flat `[i32]` where `1` = walkable,
-//! `0` = blocked.
+//! Port of the algorithm from `src/classic/pathfinder.ts` (web worker).  The
+//! nav mesh is a flat `[i32]` where `1` = walkable, `0` = blocked.
 
-use std::collections::BinaryHeap;
+#![no_std]
+
+extern crate alloc;
+
+use alloc::collections::BinaryHeap;
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// Ordered float for priority queue keys.
 #[derive(Copy, Clone, PartialEq)]
@@ -19,12 +27,12 @@ struct Key {
 
 impl Eq for Key {}
 impl PartialOrd for Key {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 impl Ord for Key {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         // Reverse: lower cost = higher priority.
         other.cost.total_cmp(&self.cost).then_with(|| self.cell.cmp(&other.cell))
     }
@@ -134,7 +142,7 @@ pub fn find_path(
             return None;
         }
         Some(if neighbour.0 != current.0 && neighbour.1 != current.1 {
-            (2.0_f32).sqrt()
+            libm::sqrtf(2.0)
         } else {
             1.0
         })
@@ -206,6 +214,37 @@ pub fn find_path_for_footprint(
     find_path(&eroded, size_x, size_y, from, to)
 }
 
+/// Bilinear interpolation of height data at an iso-space position (px, py).
+///
+/// `heights` has shape `(size_x + 1) × (size_y + 1)` (one sample per edge vertex).
+pub fn bilinear_height(heights: &[f32], size_x: i32, size_y: i32, px: f32, py: f32) -> f32 {
+    // A generated map has no height grid until its guest uploads one, so
+    // callers that sample terrain every frame must tolerate an empty (or
+    // not-yet-committed) grid.  Treat it as flat (height 0) rather than
+    // indexing out of bounds.
+    if heights.len() != (size_x as usize + 1) * (size_y as usize + 1) {
+        return 0.0;
+    }
+
+    let ftx = libm::floorf(px) as i32;
+    let fty = libm::floorf(py) as i32;
+    let fx = px - ftx as f32;
+    let fy = py - fty as f32;
+
+    let at = |tx: i32, ty: i32| -> f32 {
+        let tx = tx.clamp(0, size_x) as usize;
+        let ty = ty.clamp(0, size_y) as usize;
+        heights[ty * (size_x as usize + 1) + tx]
+    };
+
+    let h_nw = at(ftx, fty);
+    let h_ne = at(ftx + 1, fty);
+    let h_sw = at(ftx, fty + 1);
+    let h_se = at(ftx + 1, fty + 1);
+
+    h_nw + (h_ne - h_nw) * fx + (h_sw - h_nw) * fy + (h_nw - h_ne - h_sw + h_se) * fx * fy
+}
+
 /// Derive a vehicle-specific slope-feasibility walkability grid from a vertex
 /// height grid: `1` where the vehicle can stand (i.e. *some* heading keeps its
 /// pitch/roll within limits), `0` otherwise.
@@ -234,8 +273,8 @@ pub fn derive_vehicle_slope_nav(
     }
     let half_wb = (wheelbase_px / tile_scale.max(1e-6)) * 0.5;
     let half_tr = (track_px / tile_scale.max(1e-6)) * 0.5;
-    let max_pitch_tan = max_pitch.tan();
-    let max_roll_tan = max_roll.tan();
+    let max_pitch_tan = libm::tanf(max_pitch);
+    let max_roll_tan = libm::tanf(max_roll);
 
     for y in 0..size_y {
         for x in 0..size_x {
@@ -243,37 +282,17 @@ pub fn derive_vehicle_slope_nav(
             let cy = y as f32 + 0.5;
             let mut walkable = false;
             for d in 0..8 {
-                let angle = d as f32 * std::f32::consts::FRAC_PI_4;
-                let (hx, hy) = (angle.cos(), angle.sin());
+                let angle = d as f32 * core::f32::consts::FRAC_PI_4;
+                let (hx, hy) = (libm::cosf(angle), libm::sinf(angle));
                 let (lx, ly) = (-hy, hx);
-                let front = crate::tilemap::bilinear_height(
-                    heights,
-                    size_x,
-                    size_y,
-                    cx + hx * half_wb,
-                    cy + hy * half_wb,
-                );
-                let rear = crate::tilemap::bilinear_height(
-                    heights,
-                    size_x,
-                    size_y,
-                    cx - hx * half_wb,
-                    cy - hy * half_wb,
-                );
-                let left = crate::tilemap::bilinear_height(
-                    heights,
-                    size_x,
-                    size_y,
-                    cx + lx * half_tr,
-                    cy + ly * half_tr,
-                );
-                let right = crate::tilemap::bilinear_height(
-                    heights,
-                    size_x,
-                    size_y,
-                    cx - lx * half_tr,
-                    cy - ly * half_tr,
-                );
+                let front =
+                    bilinear_height(heights, size_x, size_y, cx + hx * half_wb, cy + hy * half_wb);
+                let rear =
+                    bilinear_height(heights, size_x, size_y, cx - hx * half_wb, cy - hy * half_wb);
+                let left =
+                    bilinear_height(heights, size_x, size_y, cx + lx * half_tr, cy + ly * half_tr);
+                let right =
+                    bilinear_height(heights, size_x, size_y, cx - lx * half_tr, cy - ly * half_tr);
                 let pitch = (front - rear).abs() * height_scale / wheelbase_px;
                 let roll = (left - right).abs() * height_scale / track_px;
                 if pitch <= max_pitch_tan && roll <= max_roll_tan {
@@ -334,7 +353,7 @@ pub fn find_path_for_footprint_with_jumps(
     a_star(size_x, size_y, from, to, |current, neighbour| {
         let idx = (neighbour.0 + neighbour.1 * size_x) as usize;
         let diagonal = neighbour.0 != current.0 && neighbour.1 != current.1;
-        let base = if diagonal { (2.0_f32).sqrt() } else { 1.0 };
+        let base = if diagonal { libm::sqrtf(2.0) } else { 1.0 };
 
         if walk_eroded[idx] == 1 {
             return Some(base);
@@ -350,12 +369,107 @@ pub fn find_path_for_footprint_with_jumps(
     })
 }
 
+/// A snapshot of the terrain the vehicle pathfinder needs: the structural nav
+/// grid (obstacle-free walkability) plus the vertex height grid it derives the
+/// slope-feasibility grid from.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VehicleNavSnapshot {
+    pub size_x: i32,
+    pub size_y: i32,
+    /// Obstacle-free walkability (`1` = open, `0` = blocked), row-major.
+    pub structural: Vec<i32>,
+    /// Vertex height grid `(size_x + 1) × (size_y + 1)`, row-major.
+    pub heights: Vec<f32>,
+    /// Vertical world units per height unit (the tilemap `height_scale`).
+    pub height_scale: f32,
+    /// World size of a tile edge (the tilemap `scale.x`), used to convert the
+    /// pixel wheelbase/track back into tile units for slope sampling.
+    pub tile_scale: f32,
+}
+
+impl VehicleNavSnapshot {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        size_x: i32,
+        size_y: i32,
+        structural: Vec<i32>,
+        heights: Vec<f32>,
+        height_scale: f32,
+        tile_scale: f32,
+    ) -> Self {
+        Self { size_x, size_y, structural, heights, height_scale, tile_scale }
+    }
+}
+
+/// Footprint-, slope- and jump-aware vehicle A* over a [`VehicleNavSnapshot`].
+///
+/// Derives the slope-feasibility grid from `snapshot.heights`, combines it with
+/// `snapshot.structural`, and runs [`find_path_for_footprint_with_jumps`].  The
+/// worker-callable equivalent of `Engine::find_vehicle_path` (see
+/// `classic-engine`), so native + web produce identical routes.
+#[allow(clippy::too_many_arguments)]
+pub fn find_vehicle_path_snapshot(
+    snapshot: &VehicleNavSnapshot,
+    from: GridCell,
+    to: GridCell,
+    footprint: &[GridCell],
+    pitch_max: f32,
+    roll_max: f32,
+    wheelbase_px: f32,
+    track_px: f32,
+    safe_fall_px: f32,
+    jump_cost: f32,
+) -> Option<Vec<GridCell>> {
+    let slope = derive_vehicle_slope_nav(
+        &snapshot.heights,
+        snapshot.size_x,
+        snapshot.size_y,
+        snapshot.height_scale,
+        snapshot.tile_scale,
+        wheelbase_px,
+        track_px,
+        pitch_max,
+        roll_max,
+    );
+    find_vehicle_path_with_slope(snapshot, &slope, from, to, footprint, safe_fall_px, jump_cost)
+}
+
+/// Vehicle A* reusing a pre-derived slope-feasibility grid (`slope`, the output
+/// of [`derive_vehicle_slope_nav`]).  The worker caches `slope` per
+/// `(pitch, roll, wheelbase, track)` to avoid re-deriving it per request.
+#[allow(clippy::too_many_arguments)]
+pub fn find_vehicle_path_with_slope(
+    snapshot: &VehicleNavSnapshot,
+    slope: &[i32],
+    from: GridCell,
+    to: GridCell,
+    footprint: &[GridCell],
+    safe_fall_px: f32,
+    jump_cost: f32,
+) -> Option<Vec<GridCell>> {
+    let walkable: Vec<i32> =
+        snapshot.structural.iter().zip(slope.iter()).map(|(&s, &w)| s & w).collect();
+    find_path_for_footprint_with_jumps(
+        &walkable,
+        &snapshot.structural,
+        &snapshot.heights,
+        snapshot.size_x,
+        snapshot.size_y,
+        from,
+        to,
+        footprint,
+        snapshot.height_scale,
+        safe_fall_px,
+        jump_cost,
+    )
+}
+
 /// Chebyshev-approximation heuristic (admissible for 8-directional grid).
 /// Returns the estimate of cost from `a` to `b`.
 fn heuristic(a: GridCell, b: GridCell) -> f32 {
     let dx = (a.0 - b.0).abs() as f32;
     let dy = (a.1 - b.1).abs() as f32;
-    dx + dy + (2.0_f32.sqrt() - 2.0) * dx.min(dy)
+    dx + dy + (libm::sqrtf(2.0) - 2.0) * dx.min(dy)
 }
 
 /// Walk backwards from `to` through `came_from` to rebuild the path.
@@ -426,6 +540,82 @@ impl NavSnapshot {
             return None;
         }
         find_path(&self.data, self.size_x, self.size_y, from, to)
+    }
+}
+
+/// A stateful pathfinder: the nav + vehicle snapshots plus the cached derived
+/// slope grid.  Shared by the native worker thread and the wasm worker module so
+/// both run identical searches with identical caching and invalidation.
+pub struct PathfinderState {
+    nav: NavSnapshot,
+    vehicle: Option<VehicleNavSnapshot>,
+    vehicle_slope_cache: Option<([u32; 4], Vec<i32>)>,
+}
+
+impl PathfinderState {
+    pub fn new(nav: NavSnapshot) -> Self {
+        Self { nav, vehicle: None, vehicle_slope_cache: None }
+    }
+
+    /// Replace the nav snapshot searched by [`Self::find`].
+    pub fn set_nav(&mut self, nav: NavSnapshot) {
+        self.nav = nav;
+    }
+
+    /// Replace the vehicle snapshot; clears the cached slope grid (the terrain
+    /// changed).
+    pub fn set_vehicle(&mut self, vehicle: VehicleNavSnapshot) {
+        self.vehicle = Some(vehicle);
+        self.vehicle_slope_cache = None;
+    }
+
+    /// Run plain humanoid A* over the current nav snapshot.
+    pub fn find(&self, from: GridCell, to: GridCell) -> Option<Vec<GridCell>> {
+        self.nav.find_path(from, to)
+    }
+
+    /// Run footprint-, slope- and jump-aware vehicle A* over the current vehicle
+    /// snapshot, caching the derived slope grid per `(pitch, roll, wheelbase,
+    /// track)`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn find_vehicle(
+        &mut self,
+        from: GridCell,
+        to: GridCell,
+        footprint: &[GridCell],
+        pitch_max: f32,
+        roll_max: f32,
+        wheelbase_px: f32,
+        track_px: f32,
+        safe_fall_px: f32,
+        jump_cost: f32,
+    ) -> Option<Vec<GridCell>> {
+        let snap = self.vehicle.as_ref()?;
+        let key =
+            [pitch_max.to_bits(), roll_max.to_bits(), wheelbase_px.to_bits(), track_px.to_bits()];
+        let slope: Vec<i32> = match self
+            .vehicle_slope_cache
+            .as_ref()
+            .and_then(|(k, grid)| (*k == key).then(|| grid.clone()))
+        {
+            Some(grid) => grid,
+            None => {
+                let grid = derive_vehicle_slope_nav(
+                    &snap.heights,
+                    snap.size_x,
+                    snap.size_y,
+                    snap.height_scale,
+                    snap.tile_scale,
+                    wheelbase_px,
+                    track_px,
+                    pitch_max,
+                    roll_max,
+                );
+                self.vehicle_slope_cache = Some((key, grid.clone()));
+                grid
+            }
+        };
+        find_vehicle_path_with_slope(snap, &slope, from, to, footprint, safe_fall_px, jump_cost)
     }
 }
 
@@ -580,7 +770,8 @@ mod tests {
     /// Slope-nav params for a vehicle with ~2-tile wheelbase, 1-tile track,
     /// 20° pitch/roll limits (matching the LRV tuning).
     fn slope_params() -> (f32, f32, f32, f32) {
-        (45.0 * 2.0, 45.0 * 1.0, 20.0f32.to_radians(), 20.0f32.to_radians())
+        let twenty_deg = 20.0 * core::f32::consts::PI / 180.0;
+        (45.0 * 2.0, 45.0 * 1.0, twenty_deg, twenty_deg)
     }
 
     #[test]
@@ -728,5 +919,145 @@ mod tests {
             1.3,
         );
         assert!(path.is_none(), "cannot jump uphill");
+    }
+
+    #[test]
+    fn vehicle_nav_snapshot_roundtrip() {
+        let (w, h) = (4, 4);
+        let structural = vec![1_i32; (w * h) as usize];
+        let heights = vec![1.0f32; ((w + 1) * (h + 1)) as usize];
+        let snap = VehicleNavSnapshot::new(w, h, structural.clone(), heights.clone(), 32.0, 45.0);
+        assert_eq!(snap.size_x, w);
+        assert_eq!(snap.size_y, h);
+        assert_eq!(snap.structural, structural);
+        assert_eq!(snap.heights, heights);
+        assert_eq!(snap.height_scale, 32.0);
+        assert_eq!(snap.tile_scale, 45.0);
+    }
+
+    #[test]
+    fn vehicle_path_snapshot_matches_manual_pipeline() {
+        let size = 16;
+        let structural = vec![1_i32; (size * size) as usize];
+        let heights = ramp_heights(size, 0.375);
+        let (wb, tr, pitch, roll) = slope_params();
+        let snap =
+            VehicleNavSnapshot::new(size, size, structural.clone(), heights.clone(), 32.0, 45.0);
+
+        let via_snapshot = find_vehicle_path_snapshot(
+            &snap,
+            (0, 0),
+            (15, 15),
+            &[(0, 0)],
+            pitch,
+            roll,
+            wb,
+            tr,
+            64.0,
+            1.3,
+        );
+
+        let slope = derive_vehicle_slope_nav(&heights, size, size, 32.0, 45.0, wb, tr, pitch, roll);
+        let walkable: Vec<i32> =
+            structural.iter().zip(slope.iter()).map(|(&s, &w)| s & w).collect();
+        let manual = find_path_for_footprint_with_jumps(
+            &walkable,
+            &structural,
+            &heights,
+            size,
+            size,
+            (0, 0),
+            (15, 15),
+            &[(0, 0)],
+            32.0,
+            64.0,
+            1.3,
+        );
+        assert_eq!(via_snapshot, manual);
+    }
+
+    #[test]
+    fn vehicle_path_snapshot_flat_is_routable() {
+        let size = 16;
+        let structural = vec![1_i32; (size * size) as usize];
+        let heights = vec![1.0f32; ((size + 1) * (size + 1)) as usize];
+        let snap = VehicleNavSnapshot::new(size, size, structural, heights, 32.0, 45.0);
+        let (wb, tr, pitch, roll) = slope_params();
+        let path = find_vehicle_path_snapshot(
+            &snap,
+            (0, 0),
+            (15, 15),
+            &[(0, 0)],
+            pitch,
+            roll,
+            wb,
+            tr,
+            0.0,
+            1.3,
+        );
+        assert!(path.is_some(), "flat ground should route");
+    }
+
+    #[test]
+    fn vehicle_path_snapshot_blocks_steep_ramp() {
+        let size = 16;
+        let structural = vec![1_i32; (size * size) as usize];
+        let heights = ramp_heights(size, 1.0); // exceeds the 20° pitch limit
+        let snap = VehicleNavSnapshot::new(size, size, structural, heights, 32.0, 45.0);
+        let (wb, tr, pitch, roll) = slope_params();
+        let path = find_vehicle_path_snapshot(
+            &snap,
+            (0, 8),
+            (15, 8),
+            &[(0, 0)],
+            pitch,
+            roll,
+            wb,
+            tr,
+            0.0,
+            1.3,
+        );
+        assert!(path.is_none(), "a 1.0/tile ramp exceeds the pitch limit");
+    }
+
+    #[test]
+    fn pathfinder_state_caches_and_invalidates_slope() {
+        let size = 8;
+        let n = (size + 1) as usize;
+        let mut state =
+            PathfinderState::new(NavSnapshot::new(size, size, vec![1; (size * size) as usize]));
+        let (wb, tr, pitch, roll) = slope_params();
+
+        // Flat terrain: straight diagonal.
+        state.set_vehicle(VehicleNavSnapshot::new(
+            size,
+            size,
+            vec![1; (size * size) as usize],
+            vec![1.0; n * n],
+            32.0,
+            45.0,
+        ));
+        assert!(state
+            .find_vehicle((0, 0), (7, 7), &[(0, 0)], pitch, roll, wb, tr, 0.0, 1.3)
+            .is_some());
+
+        // Steep terrain (1.0/tile): no path — the slope grid was re-derived.
+        let mut steep = vec![0.0f32; n * n];
+        for y in 0..n {
+            for x in 0..n {
+                steep[y * n + x] = x as f32;
+            }
+        }
+        state.set_vehicle(VehicleNavSnapshot::new(
+            size,
+            size,
+            vec![1; (size * size) as usize],
+            steep,
+            32.0,
+            45.0,
+        ));
+        assert!(state
+            .find_vehicle((0, 0), (7, 7), &[(0, 0)], pitch, roll, wb, tr, 0.0, 1.3)
+            .is_none());
     }
 }

--- a/crates/classic-worker/src/pathfinder_worker/native.rs
+++ b/crates/classic-worker/src/pathfinder_worker/native.rs
@@ -11,13 +11,32 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
 
-use classic_core::pathfinder::{GridCell, NavSnapshot, PathPoll};
+use classic_core::pathfinder::{
+    GridCell, NavSnapshot, PathPoll, PathfinderState, VehicleNavSnapshot,
+};
 
 use super::PathId;
 
 enum Command {
-    Find { id: PathId, from: GridCell, to: GridCell },
+    Find {
+        id: PathId,
+        from: GridCell,
+        to: GridCell,
+    },
     SetSnapshot(Arc<NavSnapshot>),
+    SetVehicleSnapshot(Arc<VehicleNavSnapshot>),
+    FindVehicle {
+        id: PathId,
+        from: GridCell,
+        to: GridCell,
+        footprint: Vec<GridCell>,
+        pitch_max: f32,
+        roll_max: f32,
+        wheelbase_px: f32,
+        track_px: f32,
+        safe_fall_px: f32,
+        jump_cost: f32,
+    },
     Flush(mpsc::Sender<()>),
     Shutdown,
 }
@@ -38,14 +57,40 @@ impl PathfinderWorker {
         let worker_snapshot = Arc::clone(&snapshot);
 
         thread::spawn(move || {
-            let mut snapshot = worker_snapshot;
+            let mut state = PathfinderState::new((*worker_snapshot).clone());
             while let Ok(command) = worker_rx.recv() {
                 match command {
                     Command::Find { id, from, to } => {
-                        let result = snapshot.find_path(from, to);
+                        let result = state.find(from, to);
                         let _ = worker_tx.send((id, result));
                     }
-                    Command::SetSnapshot(next) => snapshot = next,
+                    Command::SetSnapshot(next) => state.set_nav((*next).clone()),
+                    Command::SetVehicleSnapshot(next) => state.set_vehicle((*next).clone()),
+                    Command::FindVehicle {
+                        id,
+                        from,
+                        to,
+                        footprint,
+                        pitch_max,
+                        roll_max,
+                        wheelbase_px,
+                        track_px,
+                        safe_fall_px,
+                        jump_cost,
+                    } => {
+                        let result = state.find_vehicle(
+                            from,
+                            to,
+                            &footprint,
+                            pitch_max,
+                            roll_max,
+                            wheelbase_px,
+                            track_px,
+                            safe_fall_px,
+                            jump_cost,
+                        );
+                        let _ = worker_tx.send((id, result));
+                    }
                     Command::Flush(ack) => {
                         let _ = ack.send(());
                     }
@@ -79,6 +124,48 @@ impl PathfinderWorker {
     pub fn poll_path(&mut self, id: PathId) -> PathPoll {
         self.drain_results();
         self.results.remove(&id).unwrap_or(PathPoll::Pending)
+    }
+
+    /// Replace the vehicle nav snapshot the worker derives the slope grid from.
+    /// Also clears the cached slope grid (the terrain changed).
+    pub fn set_vehicle_snapshot(&mut self, snapshot: Arc<VehicleNavSnapshot>) {
+        let _ = self.tx.send(Command::SetVehicleSnapshot(snapshot));
+    }
+
+    /// Submit a vehicle path request under a caller-chosen `id`.  Non-blocking.
+    #[allow(clippy::too_many_arguments)]
+    pub fn request_vehicle_path(
+        &mut self,
+        id: PathId,
+        from: GridCell,
+        to: GridCell,
+        footprint: Vec<GridCell>,
+        pitch_max: f32,
+        roll_max: f32,
+        wheelbase_px: f32,
+        track_px: f32,
+        safe_fall_px: f32,
+        jump_cost: f32,
+    ) {
+        let _ = self.tx.send(Command::FindVehicle {
+            id,
+            from,
+            to,
+            footprint,
+            pitch_max,
+            roll_max,
+            wheelbase_px,
+            track_px,
+            safe_fall_px,
+            jump_cost,
+        });
+    }
+
+    /// Poll a previously submitted vehicle request (non-blocking).  Shares the
+    /// same result channel/map as [`PathfinderWorker::poll_path`], so ids must
+    /// be unique across both request kinds.
+    pub fn poll_vehicle_path(&mut self, id: PathId) -> PathPoll {
+        self.poll_path(id)
     }
 
     /// Synchronous fallback: run A* inline against the latest snapshot.
@@ -197,5 +284,92 @@ mod tests {
         worker.join();
         // After the barrier, the result must already be buffered (no Pending).
         assert_ne!(worker.poll_path(0), PathPoll::Pending);
+    }
+
+    fn open_vehicle_snapshot(w: i32, h: i32) -> Arc<VehicleNavSnapshot> {
+        Arc::new(VehicleNavSnapshot::new(
+            w,
+            h,
+            vec![1; (w * h) as usize],
+            vec![1.0; ((w + 1) * (h + 1)) as usize],
+            32.0,
+            45.0,
+        ))
+    }
+
+    fn steep_vehicle_snapshot(w: i32, h: i32) -> Arc<VehicleNavSnapshot> {
+        let n = (w + 1) as usize;
+        let mut heights = vec![0.0f32; n * n];
+        for y in 0..n {
+            for x in 0..n {
+                heights[y * n + x] = x as f32; // 1.0 unit/tile ramp
+            }
+        }
+        Arc::new(VehicleNavSnapshot::new(w, h, vec![1; (w * h) as usize], heights, 32.0, 45.0))
+    }
+
+    fn vehicle_params() -> (f32, f32, f32, f32) {
+        let pitch = 20.0f32.to_radians();
+        let roll = 20.0f32.to_radians();
+        (pitch, roll, 90.0, 45.0)
+    }
+
+    #[test]
+    fn finds_a_vehicle_path_async() {
+        let mut worker = PathfinderWorker::new(open_snapshot(8, 8));
+        worker.set_vehicle_snapshot(open_vehicle_snapshot(8, 8));
+        let (pitch, roll, wb, tr) = vehicle_params();
+        worker.request_vehicle_path(0, (0, 0), (7, 7), vec![(0, 0)], pitch, roll, wb, tr, 0.0, 1.3);
+        match poll_until(&mut worker, 0) {
+            PathPoll::Path(path) => {
+                assert_eq!(path.first(), Some(&(0, 0)));
+                assert_eq!(path.last(), Some(&(7, 7)));
+            }
+            other => panic!("expected a vehicle path, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vehicle_snapshot_update_repins_search() {
+        let mut worker = PathfinderWorker::new(open_snapshot(8, 8));
+        let (pitch, roll, wb, tr) = vehicle_params();
+
+        // Flat terrain: straight diagonal route.
+        worker.set_vehicle_snapshot(open_vehicle_snapshot(8, 8));
+        worker.request_vehicle_path(1, (0, 0), (7, 7), vec![(0, 0)], pitch, roll, wb, tr, 0.0, 1.3);
+        match poll_until(&mut worker, 1) {
+            PathPoll::Path(path) => {
+                assert_eq!(path.first(), Some(&(0, 0)));
+                assert_eq!(path.last(), Some(&(7, 7)));
+            }
+            other => panic!("expected a path on flat terrain, got {other:?}"),
+        }
+
+        // Push a steep snapshot (1.0/tile exceeds the 20° pitch limit): the same
+        // query must now find no path — the slope grid was re-derived.
+        worker.set_vehicle_snapshot(steep_vehicle_snapshot(8, 8));
+        worker.request_vehicle_path(2, (0, 0), (7, 7), vec![(0, 0)], pitch, roll, wb, tr, 0.0, 1.3);
+        assert_eq!(poll_until(&mut worker, 2), PathPoll::NoPath);
+    }
+
+    #[test]
+    fn join_barrier_waits_for_vehicle_inflight() {
+        let mut worker = PathfinderWorker::new(open_snapshot(64, 64));
+        worker.set_vehicle_snapshot(open_vehicle_snapshot(64, 64));
+        let (pitch, roll, wb, tr) = vehicle_params();
+        worker.request_vehicle_path(
+            0,
+            (0, 0),
+            (63, 63),
+            vec![(0, 0)],
+            pitch,
+            roll,
+            wb,
+            tr,
+            0.0,
+            1.3,
+        );
+        worker.join();
+        assert_ne!(worker.poll_vehicle_path(0), PathPoll::Pending);
     }
 }

--- a/crates/classic-worker/src/pathfinder_worker/web.rs
+++ b/crates/classic-worker/src/pathfinder_worker/web.rs
@@ -1,10 +1,11 @@
 //! Host-owned A* pathfinding worker (web backend).
 //!
-//! Spawns a dedicated `Worker` running the A* algorithm in JavaScript (see
-//! `worker.js`, a mirror of the retired TypeScript `pathfinder.ts`).  The
-//! render thread posts a `snapshot` message when the nav grid changes and a
-//! `find` message per request; results arrive via `onmessage` and are buffered
-//! until [`PathfinderWorker::poll_path`] drains them.  A synchronous fallback
+//! Spawns a dedicated `Worker` running the compiled `pathfinder.wasm` module
+//! (the same Rust pathfinder the native worker thread runs — see `worker.js`,
+//! which only instantiates the wasm and forwards messages).  The render thread
+//! posts a `snapshot` message when the nav grid changes and a `find` message
+//! per request; results arrive via `onmessage` and are buffered until
+//! [`PathfinderWorker::poll_path`] drains them.  A synchronous fallback
 //! ([`PathfinderWorker::find_path_sync`]) runs the same search inline for the
 //! deterministic test harness.
 
@@ -13,13 +14,14 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use classic_core::pathfinder::{GridCell, NavSnapshot, PathPoll};
+use classic_core::pathfinder::{GridCell, NavSnapshot, PathPoll, VehicleNavSnapshot};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 use super::PathId;
 
 const WORKER_SRC: &str = include_str!("worker.js");
+const PATHFINDER_WASM: &[u8] = include_bytes!("pathfinder.wasm");
 
 /// Web pathfinding worker: a `Worker` running JS A* + a main-thread result map.
 pub struct PathfinderWorker {
@@ -69,6 +71,17 @@ impl PathfinderWorker {
             }) as Box<dyn FnMut(JsValue)>);
             worker.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
             onmessage.forget();
+        }
+
+        // Hand the compiled pathfinder.wasm bytes to the worker (it instantiates
+        // them and queues any snapshot/find messages until ready).
+        {
+            let wasm = js_sys::Uint8Array::from(PATHFINDER_WASM);
+            let init = js_sys::Object::new();
+            let _ =
+                js_sys::Reflect::set(&init, &JsValue::from_str("type"), &JsValue::from_str("init"));
+            let _ = js_sys::Reflect::set(&init, &JsValue::from_str("wasm"), &wasm);
+            let _ = worker.post_message(&init);
         }
 
         let worker_handle = Self { worker, results, snapshot };
@@ -128,6 +141,122 @@ impl PathfinderWorker {
     /// [`PathPoll::Pending`] until the worker has delivered a result.
     pub fn poll_path(&mut self, id: PathId) -> PathPoll {
         self.results.borrow_mut().remove(&id).unwrap_or(PathPoll::Pending)
+    }
+
+    /// Post the current vehicle snapshot to the worker (message ordering
+    /// guarantees the worker holds it before any subsequent `findVehicle`).
+    fn push_vehicle_snapshot(&self, snapshot: &Arc<VehicleNavSnapshot>) {
+        let structural = js_sys::Int32Array::new_with_length(snapshot.structural.len() as u32);
+        structural.copy_from(&snapshot.structural);
+        let heights = js_sys::Float32Array::new_with_length(snapshot.heights.len() as u32);
+        heights.copy_from(&snapshot.heights);
+
+        let msg = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("type"),
+            &JsValue::from_str("vehicleSnapshot"),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("sizeX"),
+            &JsValue::from_f64(snapshot.size_x as f64),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("sizeY"),
+            &JsValue::from_f64(snapshot.size_y as f64),
+        );
+        let _ = js_sys::Reflect::set(&msg, &JsValue::from_str("structural"), &structural);
+        let _ = js_sys::Reflect::set(&msg, &JsValue::from_str("heights"), &heights);
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("heightScale"),
+            &JsValue::from_f64(snapshot.height_scale as f64),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("tileScale"),
+            &JsValue::from_f64(snapshot.tile_scale as f64),
+        );
+        let _ = self.worker.post_message(&msg);
+    }
+
+    /// Replace the vehicle nav snapshot the worker derives the slope grid from.
+    pub fn set_vehicle_snapshot(&mut self, snapshot: Arc<VehicleNavSnapshot>) {
+        self.push_vehicle_snapshot(&snapshot);
+    }
+
+    /// Submit a vehicle path request under a caller-chosen `id`.  Non-blocking.
+    #[allow(clippy::too_many_arguments)]
+    pub fn request_vehicle_path(
+        &mut self,
+        id: PathId,
+        from: GridCell,
+        to: GridCell,
+        footprint: Vec<GridCell>,
+        pitch_max: f32,
+        roll_max: f32,
+        wheelbase_px: f32,
+        track_px: f32,
+        safe_fall_px: f32,
+        jump_cost: f32,
+    ) {
+        let from = js_sys::Array::of2(&JsValue::from(from.0), &JsValue::from(from.1));
+        let to = js_sys::Array::of2(&JsValue::from(to.0), &JsValue::from(to.1));
+        let fp = js_sys::Array::new();
+        for (dx, dy) in footprint {
+            fp.push(&js_sys::Array::of2(&JsValue::from(dx), &JsValue::from(dy)));
+        }
+
+        let msg = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("type"),
+            &JsValue::from_str("findVehicle"),
+        );
+        let _ = js_sys::Reflect::set(&msg, &JsValue::from_str("id"), &JsValue::from_f64(id as f64));
+        let _ = js_sys::Reflect::set(&msg, &JsValue::from_str("from"), &from);
+        let _ = js_sys::Reflect::set(&msg, &JsValue::from_str("to"), &to);
+        let _ = js_sys::Reflect::set(&msg, &JsValue::from_str("footprint"), &fp);
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("pitchMax"),
+            &JsValue::from_f64(pitch_max as f64),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("rollMax"),
+            &JsValue::from_f64(roll_max as f64),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("wheelbasePx"),
+            &JsValue::from_f64(wheelbase_px as f64),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("trackPx"),
+            &JsValue::from_f64(track_px as f64),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("safeFallPx"),
+            &JsValue::from_f64(safe_fall_px as f64),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("jumpCost"),
+            &JsValue::from_f64(jump_cost as f64),
+        );
+        let _ = self.worker.post_message(&msg);
+    }
+
+    /// Poll a previously submitted vehicle request (non-blocking).  Shares the
+    /// same result map as [`PathfinderWorker::poll_path`], so ids must be
+    /// unique across both request kinds.
+    pub fn poll_vehicle_path(&mut self, id: PathId) -> PathPoll {
+        self.poll_path(id)
     }
 
     /// Synchronous fallback: run A* inline against the latest snapshot.

--- a/crates/classic-worker/src/pathfinder_worker/worker.js
+++ b/crates/classic-worker/src/pathfinder_worker/worker.js
@@ -1,173 +1,93 @@
-// classic-worker pathfinder worker (web): runs A* over a shared nav snapshot.
+// classic-worker pathfinder worker (web): instantiates the compiled
+// `pathfinder.wasm` (the same Rust pathfinder the native worker thread runs)
+// and forwards messages.  No pathfinding algorithm lives here.
 //
-// A faithful mirror of `classic_core::pathfinder::find_path` (itself a port of
-// the retired TypeScript `pathfinder.ts`), so native and web agree on routes.
 // Messages (from the main thread):
-//   { type: "snapshot", sizeX, sizeY, data: Int32Array }  — replace the grid
-//   { type: "find", id, from: [x, y], to: [x, y] }         — run a search
+//   { type: "init", wasm: Uint8Array }                        — instantiate wasm
+//   { type: "snapshot", sizeX, sizeY, data: Int32Array }      — replace nav grid
+//   { type: "find", id, from: [x, y], to: [x, y] }            — run a search
+//   { type: "vehicleSnapshot", sizeX, sizeY, structural: Int32Array,
+//     heights: Float32Array, heightScale, tileScale }         — replace vehicle nav
+//   { type: "findVehicle", id, from: [x, y], to: [x, y],
+//     footprint: [[dx, dy], …], pitchMax, rollMax, wheelbasePx, trackPx,
+//     safeFallPx, jumpCost }                                  — run a vehicle search
 // Replies (to the main thread):
-//   { type: "result", id, path: Int32Array | null }        — flat [x0,y0,…]
+//   { type: "result", id, path: Int32Array | null }           — flat [x0,y0,…]
 //      where `path` is null when no route exists.
 
-var nav = null;
-var SQRT2 = Math.SQRT2;
+var exports = null;
+var memory = null;
+var pending = [];
 
-// Max-heap keyed by `before` (higher priority pops first), mirroring the Rust
-// `BinaryHeap<Key>` ordering: lowest f first, then largest (x, then y).
-function before(a, b) {
-    if (a.f !== b.f) return a.f < b.f;
-    if (a.x !== b.x) return a.x > b.x;
-    return a.y > b.y;
+function copyInto(arr) {
+    var ptr = exports.alloc(arr.length * 4);
+    var u8 = new Uint8Array(memory.buffer, ptr, arr.length * 4);
+    u8.set(new Uint8Array(arr.buffer, arr.byteOffset, arr.length * 4));
+    return ptr;
 }
 
-function makeHeap() {
-    var items = [];
-    return {
-        push: function (item) {
-            items.push(item);
-            var i = items.length - 1;
-            while (i > 0) {
-                var p = (i - 1) >> 1;
-                if (before(items[i], items[p])) {
-                    var t = items[i];
-                    items[i] = items[p];
-                    items[p] = t;
-                    i = p;
-                } else {
-                    break;
-                }
-            }
-        },
-        pop: function () {
-            if (items.length === 0) return null;
-            var top = items[0];
-            var last = items.pop();
-            if (items.length > 0) {
-                items[0] = last;
-                var i = 0;
-                for (;;) {
-                    var l = i * 2 + 1;
-                    var r = l + 1;
-                    var best = i;
-                    if (l < items.length && before(items[l], items[best])) best = l;
-                    if (r < items.length && before(items[r], items[best])) best = r;
-                    if (best === i) break;
-                    var t = items[i];
-                    items[i] = items[best];
-                    items[best] = t;
-                    i = best;
-                }
-            }
-            return top;
-        },
-    };
+function readResult(n) {
+    return new Int32Array(memory.buffer, exports.result_ptr(), n * 2);
 }
 
-function heuristic(ax, ay, bx, by) {
-    var dx = Math.abs(ax - bx);
-    var dy = Math.abs(ay - by);
-    return dx + dy + (SQRT2 - 2) * Math.min(dx, dy);
-}
-
-function findPath(sizeX, sizeY, data, fromX, fromY, toX, toY) {
-    fromX = Math.max(0, Math.min(sizeX - 1, fromX));
-    fromY = Math.max(0, Math.min(sizeY - 1, fromY));
-    toX = Math.max(0, Math.min(sizeX - 1, toX));
-    toY = Math.max(0, Math.min(sizeY - 1, toY));
-
-    function flatten(x, y) {
-        return x + y * sizeX;
-    }
-
-    if (fromX === toX && fromY === toY) {
-        return [fromX, fromY, toX, toY];
-    }
-
-    var total = sizeX * sizeY;
-    var INF = Infinity;
-    var gCost = new Float64Array(total).fill(INF);
-    var fCost = new Float64Array(total).fill(INF);
-    var cameFrom = new Int32Array(total).fill(-1);
-    var inOpen = new Uint8Array(total);
-
-    var fromIdx = flatten(fromX, fromY);
-    gCost[fromIdx] = 0;
-    fCost[fromIdx] = heuristic(fromX, fromY, toX, toY);
-
-    var open = makeHeap();
-    open.push({ f: fCost[fromIdx], x: fromX, y: fromY });
-
-    var neighbours = [
-        [-1, -1], [0, -1], [1, -1],
-        [-1, 0], [1, 0],
-        [-1, 1], [0, 1], [1, 1],
-    ];
-
-    var toIdx = flatten(toX, toY);
-
-    for (;;) {
-        var current = open.pop();
-        if (current === null) return null;
-        var cx = current.x;
-        var cy = current.y;
-        var curIdx = flatten(cx, cy);
-
-        if (cx === toX && cy === toY) {
-            var path = [toX, toY];
-            var cur = toIdx;
-            while (cur !== fromIdx) {
-                var prev = cameFrom[cur];
-                if (prev < 0) break;
-                path.push(prev % sizeX, Math.floor(prev / sizeX));
-                cur = prev;
-            }
-            path.reverse();
-            return path;
+function handle(msg) {
+    if (msg.type === "snapshot") {
+        var ptr = copyInto(msg.data);
+        exports.set_snapshot(msg.sizeX, msg.sizeY, ptr, msg.data.length);
+    } else if (msg.type === "find") {
+        var n = exports.find(msg.from[0], msg.from[1], msg.to[0], msg.to[1]);
+        self.postMessage({ type: "result", id: msg.id, path: n < 0 ? null : readResult(n) });
+    } else if (msg.type === "vehicleSnapshot") {
+        var sp = copyInto(msg.structural);
+        var hp = copyInto(msg.heights);
+        exports.set_vehicle_snapshot(
+            msg.sizeX,
+            msg.sizeY,
+            sp,
+            msg.structural.length,
+            hp,
+            msg.heights.length,
+            msg.heightScale,
+            msg.tileScale,
+        );
+    } else if (msg.type === "findVehicle") {
+        var fp = new Int32Array(msg.footprint.length * 2);
+        for (var i = 0; i < msg.footprint.length; i++) {
+            fp[i * 2] = msg.footprint[i][0];
+            fp[i * 2 + 1] = msg.footprint[i][1];
         }
-
-        inOpen[curIdx] = 0;
-
-        for (var n = 0; n < 8; n++) {
-            var nx = cx + neighbours[n][0];
-            var ny = cy + neighbours[n][1];
-            if (nx < 0 || nx >= sizeX || ny < 0 || ny >= sizeY) continue;
-            var nIdx = flatten(nx, ny);
-            if (data[nIdx] === 0) continue;
-
-            var stepCost = neighbours[n][0] !== 0 && neighbours[n][1] !== 0 ? SQRT2 : 1;
-            var tentativeG = gCost[curIdx] + stepCost;
-
-            if (tentativeG < gCost[nIdx]) {
-                cameFrom[nIdx] = curIdx;
-                gCost[nIdx] = tentativeG;
-                fCost[nIdx] = tentativeG + heuristic(nx, ny, toX, toY);
-                if (!inOpen[nIdx]) {
-                    open.push({ f: fCost[nIdx], x: nx, y: ny });
-                    inOpen[nIdx] = 1;
-                }
-            }
-        }
+        var fpp = copyInto(fp);
+        var n = exports.find_vehicle(
+            msg.from[0],
+            msg.from[1],
+            msg.to[0],
+            msg.to[1],
+            fpp,
+            msg.footprint.length,
+            msg.pitchMax,
+            msg.rollMax,
+            msg.wheelbasePx,
+            msg.trackPx,
+            msg.safeFallPx,
+            msg.jumpCost,
+        );
+        self.postMessage({ type: "result", id: msg.id, path: n < 0 ? null : readResult(n) });
     }
 }
 
 self.onmessage = function (e) {
     var msg = e.data;
-    if (msg.type === "snapshot") {
-        nav = { sizeX: msg.sizeX, sizeY: msg.sizeY, data: msg.data };
-    } else if (msg.type === "find") {
-        if (nav === null) {
-            self.postMessage({ type: "result", id: msg.id, path: null });
-            return;
-        }
-        var path = findPath(
-            nav.sizeX,
-            nav.sizeY,
-            nav.data,
-            msg.from[0],
-            msg.from[1],
-            msg.to[0],
-            msg.to[1],
-        );
-        self.postMessage({ type: "result", id: msg.id, path: path });
+    if (msg.type === "init") {
+        WebAssembly.instantiate(msg.wasm, {}).then(function (r) {
+            exports = r.instance.exports;
+            memory = exports.memory;
+            while (pending.length) handle(pending.shift());
+        });
+        return;
     }
+    if (exports === null) {
+        pending.push(msg);
+        return;
+    }
+    handle(msg);
 };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,10 +10,12 @@
 //!   cargo xtask fetch-roms --url <rom-base>    # override the ROM base URL
 //!   cargo xtask fetch-roms --skip-verify       # proceed without a roms.json index
 //!   cargo xtask                                # alias for fetch-roms
+//!   cargo xtask build-pathfinder               # compile + stage pathfinder.wasm
 
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
+use std::process::Command;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -31,6 +33,10 @@ const ROMS: &[(&str, &str)] =
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.first().map(String::as_str) == Some("build-pathfinder") {
+        return build_pathfinder();
+    }
+
     let mut url = DEFAULT_ROM_BASE.to_string();
     let mut skip_verify = false;
     let mut i = 0;
@@ -83,6 +89,34 @@ fn main() -> anyhow::Result<()> {
     }
 
     println!("roms ready under roms/out/; boot with CLASSIC_ROM=rom:demo (etc.)");
+    Ok(())
+}
+
+/// Build the web `pathfinder.wasm` module (the Rust pathfinder compiled to
+/// wasm) and stage it next to `web.rs` so the web `Worker` can instantiate it.
+/// Must run before any `--target wasm32-unknown-unknown` build/check.
+fn build_pathfinder() -> anyhow::Result<()> {
+    let root = std::env::current_dir().context("current dir")?;
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "--target",
+            "wasm32-unknown-unknown",
+            "-p",
+            "classic-pathfinder-wasm",
+            "--release",
+        ])
+        .current_dir(&root)
+        .status()
+        .context("build classic-pathfinder-wasm")?;
+    if !status.success() {
+        anyhow::bail!("classic-pathfinder-wasm build failed");
+    }
+    let wasm = root.join("target/wasm32-unknown-unknown/release/classic_pathfinder_wasm.wasm");
+    let dst = root.join("crates/classic-worker/src/pathfinder_worker/pathfinder.wasm");
+    fs::copy(&wasm, &dst)
+        .with_context(|| format!("copy {} -> {}", wasm.display(), dst.display()))?;
+    println!("staged {}", dst.display());
     Ok(())
 }
 


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/lrv_goto_offload
base: master
head_oid: 489c91df79c17bea64d047f1d64b52c5ba99c662
base_tip_oid: 50182ff1f46ee136c5bfa60172d78071b3d8ce6d
merge_base_oid: 50182ff1f46ee136c5bfa60172d78071b3d8ce6d
provider_diff_base_oid: unavailable
commit_range: 50182ff1f46ee136c5bfa60172d78071b3d8ce6d..489c91df79c17bea64d047f1d64b52c5ba99c662
diff_range: 50182ff1f46ee136c5bfa60172d78071b3d8ce6d...489c91df79c17bea64d047f1d64b52c5ba99c662
authority: local/prospective
submitted:
  github: ___
-->

## Offload `vehicle_goto` and extract a shared `pathfinder` crate

### Motivation

Click-to-move for the LRV runs the full vehicle A* synchronously on
the render thread.  The lunar/lrvtest guests re-issue `vehicle_goto`
every frame until it returns true, but the old bool return conflated
"airborne" (a cheap early-out) with "no path", so a click on an
unreachable tile re-ran the ~160k-cell search every frame and dropped
FPS from 60 to ~10 (issue #40).

Separately, the web pathfinding worker was a hand-written JS port of
the Rust A*, so native and web routes could drift (f32 vs f64 in the
slope/jump math, heap tie-breaking, bilinear sampling).

### Summary of changes

- Split `vehicle_goto` into a tri-state submit/poll pair
  (`VehicleGotoSubmit` / `VehicleGotoPoll`) and offload the search to
  the worker (native thread / web worker), so the render thread never
  blocks on it.  The sync fallback delegates to the shared
  `find_vehicle_path_snapshot`.
- Extract the A* + footprint/slope/jump search into a `#![no_std]`
  `classic-pathfinder` crate compiled to `pathfinder.wasm`; the web
  worker instantiates it, dropping the JS algorithm mirror so native
  and web match by construction.
- Add the `vehicle_goto_poll` host import (native + web runtimes) and
  re-map `vehicle_goto` to the submit codes.

### Scopes changed

- `classic_core::pathfinder` -> `classic_pathfinder` (re-exported as
  `classic_core::pathfinder`, so call sites are unchanged).
- `classic_core::tilemap::bilinear_height` ->
  `classic_pathfinder::bilinear_height` (re-exported).

### Future follow up

- [ ] Rebuild + republish the lunar/lrvtest ROMs (classic-roms) so
  the new `vehicle_goto_poll` ABI ships, then regenerate the lunar
  golden trace.

### Links

- https://github.com/guilledk/classic-wgl/issues/40

---

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
