### PR TITLE
Offload web guest worker to a browser `Worker`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ cargo clippy -p classic-core -p classic-gfx -p classic-engine -p classic-platfor
 # ROMs (must run once after checkout, and when the published ROMs bump)
 cargo xtask fetch-roms               # downloads the staged demo/lunar ROMs (and worker wasm) into roms/out/ (gitignored)
 
-# Web pathfinder module (must run before any --target wasm32 build/check, or trunk build)
+# Web pathfinder module (must run before any --target wasm32 build/check;
+# trunk serve/build do it automatically via the `pre_build` hook in `Trunk.toml`)
 cargo xtask build-pathfinder         # compiles crates/classic-pathfinder-wasm to pathfinder.wasm and stages it next to web.rs
 ```
 

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,0 +1,6 @@
+# classic-wgl web target. `classic-worker` embeds the compiled `pathfinder.wasm`
+# via `include_bytes!`, so build it before trunk compiles the wasm32 app.
+[[hooks]]
+stage = "pre_build"
+command = "cargo"
+command_arguments = ["xtask", "build-pathfinder"]

--- a/crates/classic-worker/src/guest_worker/guest_worker.js
+++ b/crates/classic-worker/src/guest_worker/guest_worker.js
@@ -1,0 +1,75 @@
+// classic-worker guest worker (web): instantiates a ROM's background guest
+// wasm module (Tier 3) and runs its pure entry points off the render thread.
+//
+// The reduced import surface surfaced here is `env.task_arg` / `env.task_return`
+// only — the two imports the shipped `lunar-worker` guest uses.  Its heavy
+// noise/field/kernel computation is compiled *into* the wasm, so nothing else
+// needs to cross the Worker boundary.  A worker guest that imports the wider
+// reduced surface (or any engine-mutating import) fails to instantiate with an
+// "unknown import" error rather than running against a silently-wrong host.
+//
+// Messages (from the main thread):
+//   { type: "init", wasm: Uint8Array }                 — instantiate the wasm
+//   { type: "run", id, entry, arg: Uint8Array }        — run a named export
+// Replies (to the main thread):
+//   { type: "result", id, result: Uint8Array }         — task_return payload
+//   { type: "error", id, message }                     — trapped/panicked
+
+var exports = null;
+var memory = null;
+var pending = [];
+var currentArg = null;
+var currentResult = null;
+
+function imports() {
+    return {
+        task_arg: function (outPtr, outCap) {
+            var n = currentArg ? currentArg.length : 0;
+            if (n > outCap) {
+                return -1;
+            }
+            if (n > 0) {
+                new Uint8Array(memory.buffer, outPtr, n).set(currentArg);
+            }
+            return n;
+        },
+        task_return: function (ptr, len) {
+            currentResult = new Uint8Array(memory.buffer, ptr, len).slice();
+        },
+    };
+}
+
+function handle(msg) {
+    currentArg = msg.arg;
+    currentResult = null;
+    try {
+        exports[msg.entry]();
+        self.postMessage({
+            type: "result",
+            id: msg.id,
+            result: currentResult || new Uint8Array(0),
+        });
+    } catch (err) {
+        var message = err && err.message ? err.message : String(err);
+        self.postMessage({ type: "error", id: msg.id, message: message });
+    }
+}
+
+self.onmessage = function (e) {
+    var msg = e.data;
+    if (msg.type === "init") {
+        WebAssembly.instantiate(msg.wasm, { env: imports() }).then(function (r) {
+            exports = r.instance.exports;
+            memory = exports.memory;
+            while (pending.length) {
+                handle(pending.shift());
+            }
+        });
+        return;
+    }
+    if (exports === null) {
+        pending.push(msg);
+        return;
+    }
+    handle(msg);
+};

--- a/crates/classic-worker/src/guest_worker/web.rs
+++ b/crates/classic-worker/src/guest_worker/web.rs
@@ -1,28 +1,46 @@
 //! Background guest worker (web backend): a second `.wasm` instance running
-//! pure guest entry points, backed by wasmi.
+//! pure guest entry points.
 //!
-//! The browser has no `std::thread`, and a real async `Worker`-bridged wasm
-//! runtime is not yet implemented.  For now the web
-//! backend runs entries **synchronously** on the render thread, so `spawn_task`
-//! runs the entry inline and `poll_task` returns the result immediately.  The
-//! reduced import surface (mutating imports trap) is identical to native.
+//! Two modes share one API:
+//! - **Worker** (default): the guest wasm runs in a dedicated `web_sys::Worker`
+//!   (`guest_worker.js`), so heavy entries (e.g. the lunar map generator)
+//!   execute off the render thread and on the browser's native wasm JIT.
+//! - **Sync**: the wasmi runtime stays on the render thread and each entry runs
+//!   inline at `spawn_task` time (the `synchronous_workers` fallback used by
+//!   the deterministic test/golden harness).
+//!
+//! The Worker surfaces only the `task_arg`/`task_return` imports the shipped
+//! `lunar-worker` guest uses; the wider reduced import surface (mutating
+//! imports trap) is provided by the sync `wasmi` backend and remains the
+//! fallback for any guest that needs it.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use classic_core::pathfinder::NavSnapshot;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use wasmi::{Caller, Config, Engine as WasmiEngine, Instance, Linker, Module, Store};
 
 use super::install_worker_imports;
 use super::{TaskId, WorkerHost};
+
+const WORKER_SRC: &str = include_str!("guest_worker.js");
 
 /// A completed task result (see the native backend).
 pub type TaskResult = Result<Vec<u8>, String>;
 
 /// The engine-facing handle to the background guest worker.
 pub struct GuestWorker {
-    runtime: Runtime,
-    results: HashMap<TaskId, TaskResult>,
+    mode: Mode,
+    results: Rc<RefCell<HashMap<TaskId, TaskResult>>>,
+}
+
+enum Mode {
+    Worker(web_sys::Worker),
+    Sync(Box<Runtime>),
 }
 
 /// The wasmi runtime pieces (owned here; web is single-threaded).
@@ -49,34 +67,136 @@ impl Runtime {
 }
 
 impl GuestWorker {
-    /// Compile and instantiate the worker guest.  The `synchronous` flag is
-    /// accepted for API parity with the native backend but ignored — the web
-    /// backend always runs entries inline (a real async web `Worker` is
-    /// not yet implemented).
-    pub fn new(wasm: &[u8], nav: Arc<NavSnapshot>, _synchronous: bool) -> Result<Self, String> {
-        let runtime = build_runtime(wasm, nav)?;
-        Ok(Self { runtime, results: HashMap::new() })
+    /// Compile and instantiate the worker guest.  When `synchronous` is true the
+    /// wasmi runtime runs entries inline on the render thread; otherwise the
+    /// guest wasm runs in a dedicated `Worker`.
+    pub fn new(wasm: &[u8], nav: Arc<NavSnapshot>, synchronous: bool) -> Result<Self, String> {
+        let results = Rc::new(RefCell::new(HashMap::new()));
+
+        if synchronous {
+            let runtime = build_runtime(wasm, nav)?;
+            return Ok(Self { mode: Mode::Sync(Box::new(runtime)), results });
+        }
+
+        // Build the worker from an inline source Blob (mirrors the pathfinder
+        // worker's approach).
+        let blob_parts = js_sys::Array::of1(&JsValue::from_str(WORKER_SRC));
+        let blob = web_sys::Blob::new_with_str_sequence(blob_parts.as_ref())
+            .map_err(|e| format!("failed to build guest worker blob: {e:?}"))?;
+        let url = web_sys::Url::create_object_url_with_blob(&blob)
+            .map_err(|e| format!("failed to create guest worker url: {e:?}"))?;
+        let worker = web_sys::Worker::new(&url)
+            .map_err(|e| format!("failed to spawn guest worker: {e:?}"))?;
+
+        // Install the result handler.  Uses `JsValue` for the event so no
+        // `MessageEvent` web-sys feature is required.
+        {
+            let results = results.clone();
+            let onmessage = Closure::wrap(Box::new(move |event: JsValue| {
+                let data = js_sys::Reflect::get(&event, &JsValue::from_str("data"))
+                    .unwrap_or(JsValue::NULL);
+                let id = js_sys::Reflect::get(&data, &JsValue::from_str("id"))
+                    .ok()
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0) as TaskId;
+                let kind = js_sys::Reflect::get(&data, &JsValue::from_str("type"))
+                    .ok()
+                    .and_then(|v| v.as_string());
+                let result = match kind.as_deref() {
+                    Some("result") => {
+                        let bytes = js_sys::Reflect::get(&data, &JsValue::from_str("result")).ok();
+                        match bytes {
+                            Some(b) if b.is_object() => Ok(js_sys::Uint8Array::new(&b).to_vec()),
+                            _ => Ok(Vec::new()),
+                        }
+                    }
+                    Some("error") => {
+                        let msg = js_sys::Reflect::get(&data, &JsValue::from_str("message"))
+                            .ok()
+                            .and_then(|v| v.as_string())
+                            .unwrap_or_else(|| "worker guest trapped".to_string());
+                        Err(msg)
+                    }
+                    _ => return,
+                };
+                results.borrow_mut().insert(id, result);
+            }) as Box<dyn FnMut(JsValue)>);
+            worker.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+            onmessage.forget();
+        }
+
+        // Hand the guest wasm bytes to the worker (it instantiates them and
+        // queues any run messages until ready).
+        {
+            let wasm = js_sys::Uint8Array::from(wasm);
+            let init = js_sys::Object::new();
+            let _ =
+                js_sys::Reflect::set(&init, &JsValue::from_str("type"), &JsValue::from_str("init"));
+            let _ = js_sys::Reflect::set(&init, &JsValue::from_str("wasm"), &wasm);
+            let _ = worker.post_message(&init);
+        }
+
+        Ok(Self { mode: Mode::Worker(worker), results })
     }
 
-    /// Replace the nav snapshot used by the worker.
+    /// Replace the nav snapshot used by the worker.  A no-op in Worker mode —
+    /// the reduced surface surfaced there (`task_arg`/`task_return`) does not
+    /// touch the nav snapshot.
     pub fn set_nav(&mut self, nav: Arc<NavSnapshot>) {
-        self.runtime.store.data_mut().set_nav(nav);
+        if let Mode::Sync(runtime) = &mut self.mode {
+            runtime.store.data_mut().set_nav(nav);
+        }
     }
 
-    /// Run a task synchronously and buffer its result.
+    /// Run a task and buffer its result.  Posts to the Worker (non-blocking) in
+    /// Worker mode; runs inline in sync mode.
     pub fn spawn_task(&mut self, id: TaskId, entry: &str, arg: Vec<u8>) {
-        let result = self.runtime.run(entry, arg);
-        self.results.insert(id, result);
+        match &mut self.mode {
+            Mode::Sync(runtime) => {
+                let result = runtime.run(entry, arg);
+                self.results.borrow_mut().insert(id, result);
+            }
+            Mode::Worker(worker) => {
+                let arg = js_sys::Uint8Array::from(arg.as_slice());
+                let msg = js_sys::Object::new();
+                let _ = js_sys::Reflect::set(
+                    &msg,
+                    &JsValue::from_str("type"),
+                    &JsValue::from_str("run"),
+                );
+                let _ = js_sys::Reflect::set(
+                    &msg,
+                    &JsValue::from_str("id"),
+                    &JsValue::from_f64(id as f64),
+                );
+                let _ = js_sys::Reflect::set(
+                    &msg,
+                    &JsValue::from_str("entry"),
+                    &JsValue::from_str(entry),
+                );
+                let _ = js_sys::Reflect::set(&msg, &JsValue::from_str("arg"), &arg);
+                let _ = worker.post_message(&msg);
+            }
+        }
     }
 
-    /// Poll a previously submitted task.  Synchronous on web, so the result is
-    /// always available immediately.
+    /// Poll a previously submitted task.  Non-blocking; `None` while the Worker
+    /// has not yet delivered a result.
     pub fn poll_task(&mut self, id: TaskId) -> Option<TaskResult> {
-        self.results.remove(&id)
+        self.results.borrow_mut().remove(&id)
     }
 
-    /// No-op on web (synchronous).
+    /// Web has no blocking join; determinism is handled by the synchronous
+    /// fallback (`synchronous_workers`), not this worker.
     pub fn join(&self) {}
+}
+
+impl Drop for GuestWorker {
+    fn drop(&mut self) {
+        if let Mode::Worker(worker) = &self.mode {
+            worker.terminate();
+        }
+    }
 }
 
 /// Produce the trap error for a mutating import.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -96,7 +96,10 @@ fn main() -> anyhow::Result<()> {
 /// wasm) and stage it next to `web.rs` so the web `Worker` can instantiate it.
 /// Must run before any `--target wasm32-unknown-unknown` build/check.
 fn build_pathfinder() -> anyhow::Result<()> {
-    let root = std::env::current_dir().context("current dir")?;
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .context("xtask manifest dir has a repo-root parent")?
+        .to_path_buf();
     let status = Command::new("cargo")
         .args([
             "build",


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/web_guest_worker_async
base: master
head_oid: 4704d92a919426fb95fee1486b5ab578e7985888
base_tip_oid: 019c94538f98cdc776c6d94f5e6f7b10689a27a1
merge_base_oid: 019c94538f98cdc776c6d94f5e6f7b10689a27a1
provider_diff_base_oid: unavailable
commit_range: 019c94538f98cdc776c6d94f5e6f7b10689a27a1..4704d92a919426fb95fee1486b5ab578e7985888
diff_range: 019c94538f98cdc776c6d94f5e6f7b10689a27a1...4704d92a919426fb95fee1486b5ab578e7985888
authority: local/prospective
submitted:
  github: ___
-->

## Offload web guest worker to a browser `Worker`

### Motivation

The lunar scene's 400x400 procedural map generation runs in the
Tier-3 background guest worker. On web that worker backend ran
entries inline on the render thread through the wasmi interpreter,
so booting `?rom=lunar` hung the whole page for seconds while it
generated the surface. demo and lrvtest ship no worker wasm, so
only lunar was affected.

### Summary of changes

- Run the web guest worker in a dedicated `web_sys::Worker`
  (`guest_worker.js`) that instantiates the guest wasm and runs
  its entry points off the render thread (and on the browser's
  native wasm JIT), so generation no longer blocks the page.
- Surface only the `env.task_arg` / `env.task_return` imports the
  `lunar-worker` module uses; keep the wasmi runtime as the
  synchronous fallback for the deterministic test/golden harness.

### Future follow up

- [ ] Widen the web worker import surface for richer guest modules
  `guest_worker.js` only provides `task_arg`/`task_return`; a
  future worker guest importing the wider reduced surface (noise
  fields, grid kernels, pathfinding) will fail to instantiate on
  web until those imports are bridged.

- [ ] Smooth the one-frame `commit_terrain` mesh build
  after the worker returns, the foreground guest bulk-uploads the
  grids and `commit_terrain` rebuilds the 400x400 tilemap mesh on
  the main thread once — a brief hitch vs the prior multi-second
  hang.

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
