### PR TITLE
fix iso depth clipping and mouse-iso debug overlay

### DIFF
--- a/crates/classic-core/src/tilemap.rs
+++ b/crates/classic-core/src/tilemap.rs
@@ -257,7 +257,24 @@ pub use classic_pathfinder::bilinear_height;
 /// Horizontal depth divisor in the canonical iso-depth formula
 /// `iso_depth(tx, ty, z) = (tx - ty) / HORIZONTAL_DEPTH_SCALE + 0.5 + z / D`.
 /// One unit of `tx - ty` spans this many iso-depth steps.
+///
+/// Legacy fixed value (== [`horizontal_depth_scale`] for a 200×200 map).
+/// Prefer [`horizontal_depth_scale`] so larger maps are not clipped at the
+/// NE/SW corners.
 pub const HORIZONTAL_DEPTH_SCALE: f32 = 400.0;
+
+/// Horizontal depth divisor for a tilemap of `size_x × size_y`, in the
+/// canonical iso-depth formula
+/// `iso_depth(tx, ty, z) = (tx - ty) / scale + 0.5 + z / D`.
+///
+/// `tx - ty` spans `[-size_y, size_x]`, so `scale = 2 · max(size_x, size_y)`
+/// keeps the horizontal term within `[-0.5, +0.5]` (window depth `[0, 1]`)
+/// for every tile.  A fixed scale smaller than this clips the NE (`tx - ty` at
+/// its maximum) and SW (`tx - ty` at its minimum) corners, since window depth
+/// outside `[0, 1]` maps to clip-z outside `[-1, 1]`.
+pub fn horizontal_depth_scale(size_x: i32, size_y: i32) -> f32 {
+    2.0 * size_x.max(size_y).max(1) as f32
+}
 
 /// Height depth divisor in the canonical iso-depth formula, for `z` in
 /// **tileset pixels** (`height_data · height_scale`).

--- a/crates/classic-core/tests/tilemap_math.rs
+++ b/crates/classic-core/tests/tilemap_math.rs
@@ -1,4 +1,25 @@
-use classic_core::tilemap::{bilinear_height, sample_height_mesh};
+use classic_core::tilemap::{bilinear_height, horizontal_depth_scale, sample_height_mesh};
+
+#[test]
+fn horizontal_depth_scale_covers_map_diagonal() {
+    // 200×200 (the demo) matches the legacy fixed constant exactly.
+    assert_eq!(horizontal_depth_scale(200, 200), 400.0);
+    // 400×400 (the lunar scene) doubles it so the NE/SW corners are not clipped.
+    assert_eq!(horizontal_depth_scale(400, 400), 800.0);
+
+    // The full tile diagonal must stay within window depth [0, 1]:
+    //   iso_depth(tx, ty, z) = (tx - ty) / scale + 0.5 + z / HEIGHT_DEPTH_SCALE_PX
+    for &(sx, sy) in &[(200, 200), (400, 400), (600, 600), (400, 200)] {
+        let scale = horizontal_depth_scale(sx, sy);
+        let ne = (sx as f32) / scale + 0.5;
+        let sw = -(sy as f32) / scale + 0.5;
+        assert!(ne <= 1.0, "NE depth {ne} clipped (scale {scale})");
+        assert!(sw >= 0.0, "SW depth {sw} clipped (scale {scale})");
+    }
+
+    // Degenerate maps must not divide by zero.
+    assert!(horizontal_depth_scale(0, 0) > 0.0);
+}
 
 #[test]
 fn bilinear_height_flat_uniform() {

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -2011,17 +2011,22 @@ impl Engine {
         for f in pre.iter_mut() {
             f(self);
         }
+        pre.append(&mut self.pre_update_hooks);
         self.pre_update_hooks = pre;
 
         // Take-restore dance: closures fire with &mut Engine, but the Vec
         // is owned by Engine. Taking means closures can call on_update()
         // without borrow conflicts. Restoring preserves them for next frame.
+        // Closures registered *during* the loop (e.g. the tilemap's mouse-iso
+        // solve, installed lazily by `commit_terrain`) land in the emptied
+        // `self.update_fns`; append them before restoring so they survive.
         // Handlers use iter_mut(), NOT std::mem::take — they must survive
         // across frames (click, enter, exit, selection).
         let mut fns = std::mem::take(&mut self.update_fns);
         for f in fns.iter_mut() {
             f(self);
         }
+        fns.append(&mut self.update_fns);
         self.update_fns = fns;
 
         // Wheeled-vehicle simulation runs after the guest update closures

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -34,8 +34,8 @@ use classic_core::math::{cartesian_to_iso_4, iso_to_cartesian_4};
 use classic_core::pathfinder;
 use classic_core::sdf_builder::build_sdf_glyph_buffer;
 use classic_core::tilemap::{
-    bilinear_height, build_mesh, build_tile_texture, sample_height_mesh, HEIGHT_DEPTH_SCALE_PX,
-    HORIZONTAL_DEPTH_SCALE,
+    bilinear_height, build_mesh, build_tile_texture, horizontal_depth_scale, sample_height_mesh,
+    HEIGHT_DEPTH_SCALE_PX, HORIZONTAL_DEPTH_SCALE,
 };
 use classic_core::types::AnimationData;
 use classic_core::types::FrameTable;
@@ -2289,7 +2289,9 @@ impl Engine {
                 tex_dim,
                 anchor_px,
             );
-            let depth_corners = Self::compute_iso_depth_corners(tf.position, &iso_sprite.footprint);
+            let h_depth = horizontal_depth_scale(tilemap.size_x, tilemap.size_y);
+            let depth_corners =
+                Self::compute_iso_depth_corners(tf.position, &iso_sprite.footprint, h_depth);
             // Per-sheet normal/depth companions (from the resolved frame's
             // sheet) win; fall back to the per-texture `entry.normal`/`depth`
             // manifest fields for assets not on a shared atlas.
@@ -2312,7 +2314,7 @@ impl Engine {
                 uv,
                 depth_corners,
                 depth_map,
-                depth_base: Self::compute_iso_base_depth(tf.position),
+                depth_base: Self::compute_iso_base_depth(tf.position, h_depth),
                 normal_map,
                 ghost_group: iso_sprite.ghost_group,
             });
@@ -2375,7 +2377,10 @@ impl Engine {
                                 ambient: self.light_ambient,
                                 light_dir: self.light_dir,
                                 light_color: self.light_color,
-                                depth_scale: [HORIZONTAL_DEPTH_SCALE, HEIGHT_DEPTH_SCALE_PX],
+                                depth_scale: [
+                                    horizontal_depth_scale(nav.size_x, nav.size_y),
+                                    HEIGHT_DEPTH_SCALE_PX,
+                                ],
                                 normal_matrix,
                             },
                             false,
@@ -2443,7 +2448,10 @@ impl Engine {
                         ambient: self.light_ambient,
                         light_dir: self.light_dir,
                         light_color: self.light_color,
-                        depth_scale: [HORIZONTAL_DEPTH_SCALE, HEIGHT_DEPTH_SCALE_PX],
+                        depth_scale: [
+                            horizontal_depth_scale(tm.size_x, tm.size_y),
+                            HEIGHT_DEPTH_SCALE_PX,
+                        ],
                         normal_matrix,
                     },
                     self.show_grid,
@@ -3424,14 +3432,18 @@ impl Engine {
     /// Compute the anchor-plane iso depth for a sprite position (the depth a
     /// depth map's 0.5 grayscale corresponds to), in **window space** `[0, 1]`.
     /// Matches the `base_depth` term in [`Self::compute_iso_depth_corners`].
-    fn compute_iso_base_depth(pos: Vec3) -> f32 {
-        (pos.x - pos.y) / HORIZONTAL_DEPTH_SCALE + 0.5 + pos.z / HEIGHT_DEPTH_SCALE_PX
+    /// `h_depth` is the tilemap's horizontal depth scale (see
+    /// [`classic_core::tilemap::horizontal_depth_scale`]).
+    fn compute_iso_base_depth(pos: Vec3, h_depth: f32) -> f32 {
+        (pos.x - pos.y) / h_depth + 0.5 + pos.z / HEIGHT_DEPTH_SCALE_PX
     }
 
     /// Compute iso depth corners for the footprint (matches TS `IsoSprite.rawDraw()`),
-    /// in **window space** `[0, 1]`.
-    fn compute_iso_depth_corners(pos: Vec3, footprint: &[glam::Vec2]) -> [f32; 4] {
-        let base_depth = Self::compute_iso_base_depth(pos);
+    /// in **window space** `[0, 1]`.  `h_depth` is the tilemap's horizontal depth
+    /// scale, kept identical to the terrain's `depth_scale.x` uniform so sprite
+    /// occlusion matches the tilemap.
+    fn compute_iso_depth_corners(pos: Vec3, footprint: &[glam::Vec2], h_depth: f32) -> [f32; 4] {
+        let base_depth = Self::compute_iso_base_depth(pos, h_depth);
         let default_footprint = [
             glam::Vec2::new(0.5, -0.5),
             glam::Vec2::new(0.5, 0.5),
@@ -3443,9 +3455,7 @@ impl Engine {
         let mut raw_depths = [0.0f32; 4];
         for i in 0..4 {
             let pt = &footprint[i];
-            let d = (pos.x + pt.x - pos.y - pt.y) / HORIZONTAL_DEPTH_SCALE
-                + 0.5
-                + pos.z / HEIGHT_DEPTH_SCALE_PX;
+            let d = (pos.x + pt.x - pos.y - pt.y) / h_depth + 0.5 + pos.z / HEIGHT_DEPTH_SCALE_PX;
             raw_depths[i] = d.min(base_depth);
         }
 
@@ -3600,6 +3610,8 @@ mod tests {
     fn compute_iso_base_depth_matches_anchor_plane_formula() {
         let pos = glam::Vec3::new(100.0, 20.0, 64.0);
         let expected = (100.0 - 20.0) / HORIZONTAL_DEPTH_SCALE + 0.5 + 64.0 / HEIGHT_DEPTH_SCALE_PX;
-        assert!((Engine::compute_iso_base_depth(pos) - expected).abs() < 1e-9);
+        assert!(
+            (Engine::compute_iso_base_depth(pos, HORIZONTAL_DEPTH_SCALE) - expected).abs() < 1e-9
+        );
     }
 }


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/fix_iso_depth_clip_mouse_iso
base: master
head_oid: fc9339589cad2c530cf3b10ed35ff2049022e334
base_tip_oid: 019c94538f98cdc776c6d94f5e6f7b10689a27a1
merge_base_oid: 019c94538f98cdc776c6d94f5e6f7b10689a27a1
provider_diff_base_oid: unavailable
commit_range: 019c94538f98cdc776c6d94f5e6f7b10689a27a1..fc9339589cad2c530cf3b10ed35ff2049022e334
diff_range: 019c94538f98cdc776c6d94f5e6f7b10689a27a1...fc9339589cad2c530cf3b10ed35ff2049022e334
authority: local/prospective
submitted:
  github: ___
-->

## fix iso depth clipping and mouse-iso debug overlay

### Motivation

The canonical iso depth formula divides `tx - ty` by a fixed
`HORIZONTAL_DEPTH_SCALE = 400.0`.  Once the old `clamp(0, 1)` was
removed from `iso_tilemap.vert`, out-of-range window depth clips at
the fixed function, and `400.0` is only large enough for the 200x200
demo.  The 400x400 lunar map spans `tx - ty` in [-400, 400], so its
NE and SW corners fell outside `[0, 1]` and were not rendered.

Separately, `Engine::frame` drops any `on_update` closure registered
mid-loop.  The lunar guest generates its map on a background worker
and calls `commit_terrain` during a frame, so the mouse-iso solve it
installs was silently discarded and the XYZ debug overlay stayed at
`0`.

### Summary of changes

- Derive the horizontal iso depth scale from the map size
  (`horizontal_depth_scale(size_x, size_y)`) and use it for the
  tilemap, nav mesh, and sprite iso depth, replacing the fixed
  `HORIZONTAL_DEPTH_SCALE`.  The demo still resolves to 400, so its
  goldens are unchanged.
- Preserve `on_update`/`on_pre_update` closures registered during
  the frame loop by appending them before the take-restore, so the
  lazily-installed mouse-iso solve survives and the overlay updates.

---

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
