### PR TITLE
Let vehicle pathing climb by pitch/roll, not the walk grid

### DIFF
--- a/.claude/skills/classic-ecs/SKILL.md
+++ b/.claude/skills/classic-ecs/SKILL.md
@@ -130,8 +130,11 @@ categories:
   `size_x`, `size_y`.  Rendered on top of the tilemap at z-order 19999.
 
 - **`IsoSprite`** — billboard in iso space.  Fields: `position`, `scale`,
-  `texture`, `tilemap` (entity name), `frame`, `tile_set_size`, `anchor`,
-  `footprint: Vec<Vec2>` (four corner vertices in iso tile coords).
+  `texture`, `tilemap` (entity name), `frame`, `frame_name` (packed-atlas
+  frame resolution), `tile_set_size`, `anchor`, `footprint: Vec<Vec2>` (four
+  corner vertices in iso tile coords), `ghost_group` (stencil id so grouped
+  sprites never ghost through each other), `color: [f32; 4]` (per-sprite tint
+  multiplied onto the albedo by `sheet.frag` before the Lambertian term).
   Drawn via `draw_iso_sprite`.
 
 - **`IsoAgent`** — pathfinding sprite.  Subsumes `IsoSprite` (i.e. the

--- a/.claude/skills/classic-guest/SKILL.md
+++ b/.claude/skills/classic-guest/SKILL.md
@@ -73,6 +73,9 @@ both the wasmi and wasmtime backends) are the SDK surface:
 | `names` | `(out_ptr, out_cap) -> i32` | JSON array of names |
 | `set_pos` | `(name_ptr, name_len, x: f64, y: f64, z: f64) -> i32` | write 3D position |
 | `get_pos` | `(name_ptr, name_len, out_ptr) -> i32` | writes `[x, y, z]` as three f64 |
+| `set_sprite_frame` | `(name_ptr, name_len, frame: f64) -> i32` | set a named entity's `IsoSprite` frame index (resolves `frame_name` for packed-atlas textures) |
+| `set_sprite_color` | `(name_ptr, name_len, r: f64, g: f64, b: f64, a: f64) -> i32` | set a named entity's `IsoSprite` tint colour (RGBA `0..=1`) |
+| `spawn_sprite_clone` | `(template_ptr, template_len, name_ptr, name_len) -> i32` | spawn a new `IsoSprite` entity cloned from a template entity's `IsoSprite` + `Transform` |
 | `mouse` | `(out_ptr) -> i32` | screen mouse pos `[x, y]` |
 | `mouse_iso` | `(out_ptr) -> i32` | iso tile coords under cursor `[x, y]` |
 | `iso_to_screen` | `(x: f64, y: f64, out_ptr) -> i32` | project an iso tile coord to screen space `[sx, sy]` (two f64; `0` if no Tilemap) |

--- a/.claude/skills/classic-iso/SKILL.md
+++ b/.claude/skills/classic-iso/SKILL.md
@@ -111,10 +111,23 @@ The canonical formula (one definition, in `classic-core::tilemap`):
 
 ```
 iso_depth(tx, ty, z) = (tx - ty) / horizontal_depth_scale + 0.5 + (z / PPM_TARGET) / HEIGHT_DEPTH_SCALE_M
-  horizontal_depth_scale  = 2 · max(size_x, size_y)  (tiles per 1.0 iso-depth)
-  HEIGHT_DEPTH_SCALE_M    = 344.46  (z in metres; the metre-space height divisor)
-  PPM_TARGET              = 64.0    (px/m; converts the px mesh/sprite z back to metres)
+  horizontal_depth_scale  = max(HORIZONTAL_DEPTH_SCALE, 2 · max(size_x, size_y))
+                            (tiles per 1.0 iso-depth)
+  HORIZONTAL_DEPTH_SCALE  = 400.0 (legacy fixed divisor; == horizontal_depth_scale for a 200×200 map)
+  HEIGHT_DEPTH_SCALE_M    = 344.46 (z in metres; the metre-space height divisor)
+  PPM_TARGET              = 64.0   (px/m; converts the px mesh/sprite z back to metres)
 ```
+
+**`horizontal_depth_scale` must never fall below 400.**  Depth-mapped sprites
+bake their per-pixel grayscale with the legacy fixed `HORIZONTAL_DEPTH_SCALE`
+(400) horizontal divisor — `classic-assets` `render/materials.py::proxy_axis`
+uses `1/(tile_m · 400)` — so a smaller divisor (e.g. `2·48 = 96` on the
+container/lrvtest maps) makes the sprite's horizontal depth component
+`400/smaller` × too small relative to the terrain: the near (front) corners read
+as *deeper* than the terrain (ghosted) and the far corners read as *nearer*
+(solid) — inverted corner occlusion.  Keep `2·max(size)` only when it exceeds
+400 (large maps whose `tx−ty` span would clip the NE/SW corners, e.g. the lunar
+400×400 → 800).  This is the bug the `shipping-container-cargo` session fixed.
 
 The height term is **`+ z / D`**: the camera basis `back.z = +0.5` means taller
 terrain is *farther* (larger depth).  An earlier sign error (`- z / D`) made
@@ -473,20 +486,32 @@ float cornerDepth = mix(topDepth, bottomDepth, vertexPos.y);
 gl_Position.z = cornerDepth * 2.0 - 1.0;
 ```
 
-### Ghost pass (`draw_iso_sprite`)
+### Two-pass draw (`draw_iso_sprite`, engine order: all normals, then all ghosts)
 
-IsoSprites are drawn with two draw calls:
+The engine drives isometric sprites in **two phases** (all `Normal` passes first,
+then all `Ghost` passes) so sprite-vs-sprite occlusion is resolved by the depth
+buffer, not draw order:
 
-1. **Ghost pass:** `ghostAlpha = 0.4`, `depthFunc(ALWAYS)`, `depthMask(false)`.
-   Renders a translucent silhouette that is visible through occluding terrain.
-   This lets the player see units behind walls.
-
-2. **Normal pass:** `ghostAlpha = 0.0`, `depthFunc(LEQUAL)`, `depthMask(false)`.
+1. **Normal pass:** `ghostAlpha = 0.0`, `depthFunc(LEQUAL)`,
+   `depthMask(depth_map.is_some())` (depth-mapped sprites **write** depth),
+   stencil `ALWAYS` / `REPLACE ghost_group`, `stencilMask(0xFF)`.
    Renders the full-colour sprite on top of terrain, respecting depth occlusion.
 
-Both passes leave `depthMask(false)` to avoid writing to the depth buffer and
-interfering with subsequent draw calls.  `DEPTH_TEST` is enabled only for the
-scope of these two passes, then disabled before returning.
+2. **Ghost pass:** `ghostAlpha = 0.4`, `depthFunc(GREATER)`, `depthMask(false)`,
+   stencil `NOTEQUAL ghost_group` (`ALWAYS` when `ghost_group == 0`),
+   `stencilMask(0x00)`.  Draws the 40%-alpha silhouette **only where the sprite
+   is behind the depth buffer** (occluded by terrain or another sprite), letting
+   the player see units through walls.  The stencil skips pixels the sprite's
+   own group already occluded (a vehicle's body + wheels share a `ghost_group`
+   id so they never ghost through each other).
+
+Both passes restore `depthMask(true)` + `depthFunc(LEQUAL)` and disable
+`DEPTH_TEST`/`STENCIL_TEST` on exit.  The stencil buffer records the per-instance
+`ghost_group` id during the normal pass (`REPLACE`); the ghost pass reads it
+(`NOTEQUAL`).  Sprites with no depth map (`depth_map == None`) do **not** write
+depth in the normal pass (`depthMask(false)`) — occlusion is then draw-order
+only, and the ghost pass uses the same `GREATER` test against whatever the
+terrain/other sprites wrote.
 
 ### Sheet fragment shader (`sheet.frag`)
 
@@ -762,6 +787,14 @@ other (stencil `NOTEQUAL`).  Depth maps are emitted by the Blender exporter
 (gray `0.5` == the ground anchor == `depth_base`), and packed by the ROM
 `xtask`.  All depth maps share one global `DEPTH_RANGE` (classic-assets
 `presets.DEPTH_RANGE`) so several assets can pack into a single depth sheet.
+
+**The depth map's horizontal component is baked with the fixed
+`HORIZONTAL_DEPTH_SCALE` = 400** (`proxy_axis` returns `1/(tile_m · 400)` for
+x/y), so the engine's `horizontal_depth_scale(map)` must be ≥ 400 (see §3) or
+the sprite's near/far corner occlusion inverts.  `gray = 0.5 − dot/0.05`, where
+`dot = axis · (position − anchor)` equals the iso-depth offset of the pixel
+relative to the anchor; the shader decodes
+`gl_FragDepth = depth_base + (0.5 − gray) · depth_range`.
 
 ### Per-pixel normal maps (per-sheet)
 

--- a/.claude/skills/classic-testing/SKILL.md
+++ b/.claude/skills/classic-testing/SKILL.md
@@ -49,8 +49,8 @@ Key lifecycle properties:
 
 ## 2. Test Actions
 
-Each `TestStep` carries a `Vec<TestAction>`.  All nine actions are mapped in
-`run_test_frame` and directly modify `Engine` input/editor state:
+Each `TestStep` carries a `Vec<TestAction>`.  All actions are mapped in
+`run_test_frame` and directly modify `Engine` input/editor/entity state:
 
 | Action | JSON key | Description |
 |---|---|---|
@@ -64,6 +64,9 @@ Each `TestStep` carries a `Vec<TestAction>`.  All nine actions are mapped in
 | `Wheel` | `wheel` | Sets `input.mouse_wheel`. The engine's wheel-decay logic runs after the test frame, so wheel values may need to be set immediately before assertions that depend on them. |
 | `Wait` | `wait` | No-op; only useful as a sentinel in the JSON. Frame-based waiting is achieved by scheduling a step on a later frame. |
 | `SetCameraIso` | `setCameraIso` | Centers the camera on iso tile `(tx, ty)` at the given `scale` (via `Engine::iso_to_screen` + `set_camera`). Useful for framing a sprite for pixel assertions. |
+| `SetMouseIso` | `setMouseIso` | Sets `input.mouse_pos` to the screen position of iso tile `(tx, ty)` via `render_order::iso_to_screen_px`. Note: in a native (winit) window the OS cursor overwrites `input.mouse_pos` every `CursorMoved`, so this action is only reliable headless — prefer `setEntityPos` for deterministic native placement. |
+| `SetEntityPos` | `setEntityPos` | Sets a named entity's `Transform.position` to `(x, y, z)` **and arms a persistent per-frame override** (`runner.pos_override`), so a mouse-following guest (which re-writes the position every frame) can't steal the placement. `z` is in px (metres × `PPM_TARGET`). |
+| `SetSpriteFrame` | `setSpriteFrame` | Calls `Engine::set_sprite_frame(name, frame)` **and arms a persistent per-frame override** (`runner.frame_override`), keeping a packed-atlas sprite on a chosen pitch/roll frame even though the guest recomputes it from the terrain each frame. |
 
 Drag simulation detail: the drag is processed by `run_test_frame`'s drag state
 machine.  On frame `start+0` it sets `selection_iso_begin=mouse_iso_pos=from`
@@ -88,7 +91,7 @@ tile coordinates for spatial assertions; its meaning varies by assertion kind.
 | `CameraAt` | `cameraAt` | `region = (ex, ey, ez, expected_scale)`.  Checks `camera.position` against `(ex, ey, ez)` with default tolerance 1.0 in position and 0.01 in scale.  `expected` overrides the tolerance if > 0.  If `region.3 == 0`, scale defaults to 1.0. |
 | `EntityVisible` | `entityVisible` | Uses `log` as the entity name lookup key in `Engine::names`.  Checks `is_disabled` matches `expected != 0.0`. |
 | `EntityPos` | `entityPos` | Uses `log` as the entity name.  `region = (ex, ey, ...)`.  Checks `Transform::position.x/y` within tolerance (default 1.0) of `(ex, ey)`.  `expected` overrides tolerance if > 0. |
-| `PixelAtEntity` | `pixelAtEntity` | **GPU-only.** Uses `log` as the entity name; projects its iso position to screen pixels (`render_order::iso_to_screen_px`) and reads the framebuffer pixel (`Gfx::read_pixel_rgba`). With `color` set, checks all 4 channels within `expected` tolerance; with `color` absent/null, checks alpha `>= expected`. |
+| `PixelAtEntity` | `pixelAtEntity` | **GPU-only.** Uses `log` as the entity name; projects its iso position (plus an optional tile-space `offset: [dx, dy]`) to screen pixels (`render_order::iso_to_screen_px`) and reads the framebuffer pixel (`Gfx::read_pixel_rgba`). With `color` set, checks all 4 channels within `expected` tolerance; with `color` absent/null, checks alpha `>= expected`. The `offset` lets a test sample a sprite's footprint corner (e.g. `[-1.735, 1.735]` = front-bottom) rather than only its ground anchor — this is how the shipping-container corner-ghost regression was pinned down. |
 
 `PixelAtEntity` is the render-order / depth-occlusion assertion (per-texture
 depth maps, ghost pass).  It reads the previous frame's framebuffer (the test
@@ -155,6 +158,11 @@ complete).
 - `expected`: `f32`.  Used as the target value for height/tile assertions,
   tolerance for `UiTextCentered`/`CameraAt`/`EntityPos`, or boolean intent
   for `UiEnabled`/`EntityVisible`.
+- `color`: `[r, g, b, a]` (optional) — expected RGBA for `PixelAtEntity`;
+  absent/null = opacity-only (alpha `>= expected`).
+- `offset`: `[dx, dy]` (optional, default `[0,0]`) — tile-space offset added to
+  the entity's position for `PixelAtEntity`, so a test can sample a footprint
+  corner instead of the ground anchor.
 - `log`: free-form description, emitted on pass/fail.
 
 ## 5. Scenario Authoring Workflow

--- a/crates/classic-core/src/components/mod.rs
+++ b/crates/classic-core/src/components/mod.rs
@@ -235,10 +235,24 @@ pub struct IsoSprite {
     /// declaratively in `state.json`; `spawn_vehicle` assigns it imperatively.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub ghost_group: u32,
+    /// Per-sprite tint (RGBA) multiplied onto the sprite's albedo by the sheet
+    /// shader before the Lambertian term.  Defaults to white (a no-op).
+    /// Tintable assets (e.g. the grayscale shipping container cargo) set this
+    /// at spawn to render the same sheet in different colours.
+    #[serde(default = "default_white", skip_serializing_if = "is_white")]
+    pub color: [f32; 4],
 }
 
 fn is_zero(v: &u32) -> bool {
     *v == 0
+}
+
+fn default_white() -> [f32; 4] {
+    [1.0, 1.0, 1.0, 1.0]
+}
+
+fn is_white(c: &[f32; 4]) -> bool {
+    *c == default_white()
 }
 
 fn default_footprint() -> Vec<Vec2> {

--- a/crates/classic-core/src/lib.rs
+++ b/crates/classic-core/src/lib.rs
@@ -99,6 +99,7 @@ pub fn register_all_components() {
                     frame_offset: a.frame_offset,
                     footprint: a.footprint.clone(),
                     ghost_group: 0,
+                    color: [1.0, 1.0, 1.0, 1.0],
                 });
                 b.add(a);
                 Ok(())

--- a/crates/classic-core/src/tilemap.rs
+++ b/crates/classic-core/src/tilemap.rs
@@ -271,7 +271,13 @@ pub const HORIZONTAL_DEPTH_SCALE: f32 = 400.0;
 /// its maximum) and SW (`tx - ty` at its minimum) corners, since window depth
 /// outside `[0, 1]` maps to clip-z outside `[-1, 1]`.
 pub fn horizontal_depth_scale(size_x: i32, size_y: i32) -> f32 {
-    2.0 * size_x.max(size_y).max(1) as f32
+    // Depth-mapped sprites bake their per-pixel grayscale with the legacy
+    // `HORIZONTAL_DEPTH_SCALE` (400) horizontal divisor, so the divisor must
+    // never fall *below* 400 or a small map's sprite depth map misaligns with
+    // the terrain (front corners ghost, rear corners read as nearer).  Keep
+    // `2·max(size)` only when it exceeds 400 (large maps whose `tx−ty` span
+    // would otherwise clip the NE/SW corners).
+    (2.0 * size_x.max(size_y).max(1) as f32).max(HORIZONTAL_DEPTH_SCALE)
 }
 
 /// Pixels per metre: the fixed conversion the render/depth space uses between

--- a/crates/classic-core/tests/dumpers.rs
+++ b/crates/classic-core/tests/dumpers.rs
@@ -113,6 +113,7 @@ fn isoagent_subsume_skips_transform_and_isosprite() {
             frame_offset: glam::Vec3::ZERO,
             footprint: agent.footprint.clone(),
             ghost_group: 0,
+            color: [1.0, 1.0, 1.0, 1.0],
         },
         agent.clone(),
     ));

--- a/crates/classic-core/tests/tilemap_math.rs
+++ b/crates/classic-core/tests/tilemap_math.rs
@@ -6,6 +6,10 @@ fn horizontal_depth_scale_covers_map_diagonal() {
     assert_eq!(horizontal_depth_scale(200, 200), 400.0);
     // 400×400 (the lunar scene) doubles it so the NE/SW corners are not clipped.
     assert_eq!(horizontal_depth_scale(400, 400), 800.0);
+    // Small maps (48×48 container/lrvtest) must NOT fall below 400: the depth
+    // maps are baked with the legacy 400 divisor, so a smaller divisor
+    // misaligns sprite depth maps with the terrain (front corners ghost).
+    assert_eq!(horizontal_depth_scale(48, 48), 400.0);
 
     // The full tile diagonal must stay within window depth [0, 1]:
     //   iso_depth(tx, ty, z) = (tx - ty) / scale + 0.5 + (z / PPM_TARGET) / HEIGHT_DEPTH_SCALE_M

--- a/crates/classic-demo/src/render_order.rs
+++ b/crates/classic-demo/src/render_order.rs
@@ -44,7 +44,11 @@ pub fn read_pixel_rgba(engine: &Engine, sx: f32, sy: f32) -> Option<[f32; 4]> {
     gfx.read_pixel_rgba(sx as i32, sy as i32)
 }
 
-/// Assert a pixel at an entity's iso position.
+/// Assert a pixel at an entity's iso position, optionally offset in tile units.
+///
+/// `offset` is a tile-space `(dx, dy)` added to the entity's `(x, y)` before
+/// projecting to screen pixels, so callers can sample a sprite corner rather
+/// than only its ground anchor.
 ///
 /// When `expected` is `Some(rgba)`, every channel must match within `tol`.
 /// When `expected` is `None`, the pixel is checked for opacity (alpha must be
@@ -56,6 +60,7 @@ pub fn assert_pixel_at_entity(
     name: &str,
     expected: Option<[f32; 4]>,
     tol: f32,
+    offset: (f32, f32),
 ) -> bool {
     let Some(&entity) = engine.names.get(name) else {
         classic_core::cl_info!(
@@ -71,7 +76,9 @@ pub fn assert_pixel_at_entity(
         );
         return false;
     };
-    let Some((sx, sy)) = iso_to_screen_px(engine, tf.position.x, tf.position.y) else {
+    let Some((sx, sy)) =
+        iso_to_screen_px(engine, tf.position.x + offset.0, tf.position.y + offset.1)
+    else {
         classic_core::cl_info!(
             classic_core::instrument::Chan::Test,
             "  [Pixel] no tilemap for '{name}'"
@@ -92,7 +99,7 @@ pub fn assert_pixel_at_entity(
     if !ok {
         classic_core::cl_info!(
             classic_core::instrument::Chan::Test,
-            "  [Pixel] '{name}' @ ({sx:.1},{sy:.1}) actual={:?} expected={:?} tol={tol}",
+            "  [Pixel] '{name}' @ ({sx:.1},{sy:.1}) offset={offset:?} actual={:?} expected={:?} tol={tol}",
             actual,
             expected
         );

--- a/crates/classic-demo/src/testing.rs
+++ b/crates/classic-demo/src/testing.rs
@@ -53,6 +53,12 @@ pub enum TestAction {
     Wait { frames: u64 },
     #[serde(rename = "setCameraIso")]
     SetCameraIso { tx: f32, ty: f32, scale: f32 },
+    #[serde(rename = "setMouseIso")]
+    SetMouseIso { tx: f32, ty: f32 },
+    #[serde(rename = "setEntityPos")]
+    SetEntityPos { name: String, x: f32, y: f32, z: f32 },
+    #[serde(rename = "setSpriteFrame")]
+    SetSpriteFrame { name: String, frame: f32 },
 }
 
 /// Kinds of assertions the test runner supports.
@@ -86,6 +92,9 @@ pub struct TileAssertion {
     /// Expected RGBA (normalized `[0, 1]`) for `PixelAtEntity`.
     #[serde(default)]
     pub color: Option<[f32; 4]>,
+    /// Tile-space `(dx, dy)` offset from the entity anchor for `PixelAtEntity`.
+    #[serde(default)]
+    pub offset: (f32, f32),
 }
 
 /// A scheduled test step: at the given frame, execute actions then run assertions.
@@ -105,6 +114,8 @@ struct TestRunner {
     drag_state: Option<(glam::Vec2, glam::Vec2, u64, u64)>,
     editor_state: Option<(String, i32, String, u32)>,
     complete_reported: bool,
+    pos_override: Option<(String, glam::Vec3)>,
+    frame_override: Option<(String, f32)>,
 }
 
 /// Register the CLASSIC_TEST runner on the engine's test hook (no-op unless
@@ -150,6 +161,21 @@ fn run_frame(
     steps: &[TestStep],
 ) {
     let frame = engine.frame_number();
+
+    // Re-apply any persistent entity-position override (a `setEntityPos`
+    // action) before step processing, so the entity stays put even though the
+    // guest's update closure (which runs earlier in the frame) follows the
+    // mouse every frame.
+    if let Some((ref name, pos)) = runner.pos_override {
+        if let Some(&e) = engine.names.get(name) {
+            if let Ok(mut tf) = engine.world.get::<&mut Transform>(e) {
+                tf.position = pos;
+            }
+        }
+    }
+    if let Some((ref name, frame)) = runner.frame_override {
+        engine.set_sprite_frame(name, frame);
+    }
 
     // Re-apply editor state before step processing so assertions
     // on this frame see the corrected state (tool_buttons on_update
@@ -241,6 +267,34 @@ fn run_frame(
                     if let Some((cx, cy)) = engine.iso_to_screen(*tx, *ty) {
                         engine.set_camera(cx, cy, *scale);
                     }
+                }
+                TestAction::SetMouseIso { tx, ty } => {
+                    if let Some((sx, sy)) = crate::render_order::iso_to_screen_px(engine, *tx, *ty)
+                    {
+                        let (vw, vh) = engine.viewport_size();
+                        engine.input.mouse_pos = glam::Vec2::new(sx, sy);
+                        engine.input.mouse_axis.x = ((sx / vw) - 0.5) * 2.0;
+                        engine.input.mouse_axis.y = ((sy / vh) - 0.5) * 2.0;
+                    }
+                }
+                TestAction::SetEntityPos { name, x, y, z } => {
+                    runner.pos_override = Some((name.clone(), glam::Vec3::new(*x, *y, *z)));
+                    let ok = engine
+                        .names
+                        .get(name)
+                        .and_then(|&e| engine.world.get::<&mut Transform>(e).ok())
+                        .map(|mut tf| {
+                            tf.position = glam::Vec3::new(*x, *y, *z);
+                            true
+                        })
+                        .unwrap_or(false);
+                    if !ok {
+                        classic_core::cl_info!(Chan::Test, "  [SetEntityPos] no entity '{name}'");
+                    }
+                }
+                TestAction::SetSpriteFrame { name, frame } => {
+                    runner.frame_override = Some((name.clone(), *frame));
+                    engine.set_sprite_frame(name, *frame);
                 }
             }
         }
@@ -345,7 +399,9 @@ fn run_frame(
                 AssertKind::PixelAtEntity => {
                     let name = if a.log.is_empty() { "entity" } else { &a.log };
                     let tol = if a.expected <= 0.0 { 0.02 } else { a.expected };
-                    crate::render_order::assert_pixel_at_entity(engine, name, a.color, tol)
+                    crate::render_order::assert_pixel_at_entity(
+                        engine, name, a.color, tol, a.offset,
+                    )
                 }
             };
             let result = format!(

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -989,6 +989,56 @@ impl Engine {
         }
     }
 
+    /// Set a named entity's `IsoSprite` frame index.  When the sprite's texture
+    /// has a packed-atlas frame table, the matching `frame_name` is resolved so
+    /// the packed path is used; otherwise the uniform-grid path takes over.
+    pub fn set_sprite_frame(&mut self, name: &str, frame: f32) -> bool {
+        let Some(&entity) = self.names.get(name) else { return false };
+        let Ok(mut sprite) = self.world.get::<&mut IsoSprite>(entity) else { return false };
+        sprite.frame = frame;
+        sprite.frame_name = if self.frame_tables.contains_key(&sprite.texture) {
+            Some(format!("{}_{}", sprite.texture, frame as u32))
+        } else {
+            None
+        };
+        true
+    }
+
+    /// Set a named entity's `IsoSprite` tint colour (RGBA).
+    pub fn set_sprite_color(&mut self, name: &str, color: [f32; 4]) -> bool {
+        let Some(&entity) = self.names.get(name) else { return false };
+        let Ok(mut sprite) = self.world.get::<&mut IsoSprite>(entity) else { return false };
+        sprite.color = color;
+        true
+    }
+
+    /// Spawn a new `IsoSprite` entity cloned from a template entity (e.g. a
+    /// mouse-follow placement ghost), so a guest can drop copies at runtime.
+    /// Copies the template's `IsoSprite` and `Transform` (the latter carries the
+    /// live position written by `set_pos`); the caller then adjusts the clone
+    /// with `set_pos`/`set_sprite_frame`/`set_sprite_color` as usual.  Returns
+    /// `false` when the name is taken, the template is unknown, or the template
+    /// has no `IsoSprite`.
+    pub fn spawn_sprite_clone(&mut self, template: &str, name: &str) -> bool {
+        if self.names.contains_key(name) {
+            return false;
+        }
+        let Some(&template_entity) = self.names.get(template) else { return false };
+        let sprite = match self.world.get::<&IsoSprite>(template_entity) {
+            Ok(s) => (*s).clone(),
+            Err(_) => return false,
+        };
+        let transform = self
+            .world
+            .get::<&Transform>(template_entity)
+            .ok()
+            .map(|t| (*t).clone())
+            .unwrap_or_else(|| Transform::new(sprite.position, sprite.scale));
+        let entity = self.world.spawn((sprite, transform));
+        self.register_named_entity(name, entity);
+        true
+    }
+
     /// The iso tile coordinates under the mouse cursor (from the tilemap).
     pub fn mouse_iso(&self) -> Option<(f32, f32)> {
         let tm_entity = self.entity_by_role(RoleKind::Tilemap)?;

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -1357,9 +1357,15 @@ impl Engine {
     fn build_vehicle_nav_snapshot(&self) -> Option<Arc<pathfinder::VehicleNavSnapshot>> {
         let nav_entity = self.entity_by_role(RoleKind::NavMesh)?;
         let nav = self.world.get::<&NavMesh>(nav_entity).ok()?;
-        let structural: Vec<i32> = nav.data.iter().map(|&v| v as i32).collect();
         let size_x = nav.size_x;
         let size_y = nav.size_y;
+        // The terrain nav grid encodes slope-limited *human* walkability, not
+        // obstacles.  A vehicle derives climbability from its own per-request
+        // pitch/roll tolerance, so the shared snapshot's `structural` grid only
+        // needs to gate hard obstacles.  No current vehicle scene (lunar,
+        // lrvtest, container) has any, so treat it as fully open and let
+        // pitch/roll be the sole slope gate.
+        let structural: Vec<i32> = vec![1; (size_x * size_y) as usize];
 
         let tm_entity = self.entity_by_role(RoleKind::Tilemap)?;
         let tm = self.world.get::<&Tilemap>(tm_entity).ok()?;

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -94,6 +94,7 @@ struct IsoDraw {
     depth_base: f32,
     normal_map: Option<String>,
     ghost_group: u32,
+    color: [f32; 4],
 }
 
 impl IsoDraw {
@@ -2323,6 +2324,7 @@ impl Engine {
                 depth_base: Self::compute_iso_base_depth(tf.position, h_depth),
                 normal_map,
                 ghost_group: iso_sprite.ghost_group,
+                color: iso_sprite.color,
             });
         }
 
@@ -2509,6 +2511,7 @@ impl Engine {
                 draw.depth_map.as_ref().map(|(t, r)| (t.as_str(), *r)),
                 draw.depth_base,
                 draw.normal_map.as_deref(),
+                &[draw.color[0], draw.color[1], draw.color[2]],
                 &sprite_settings,
                 draw.ghost_group,
                 IsoSpritePass::Normal,
@@ -2527,6 +2530,7 @@ impl Engine {
                 draw.depth_map.as_ref().map(|(t, r)| (t.as_str(), *r)),
                 draw.depth_base,
                 draw.normal_map.as_deref(),
+                &[draw.color[0], draw.color[1], draw.color[2]],
                 &sprite_settings,
                 draw.ghost_group,
                 IsoSpritePass::Ghost,

--- a/crates/classic-engine/src/vehicle.rs
+++ b/crates/classic-engine/src/vehicle.rs
@@ -485,6 +485,7 @@ impl Engine {
                 frame_offset: Vec3::ZERO,
                 footprint: vec![],
                 ghost_group,
+                color: [1.0, 1.0, 1.0, 1.0],
             };
             let we = self.world.spawn((sprite, Transform::new(Vec3::new(x, y, 0.0), Vec3::ONE)));
             let _ = self.world.insert_one(we, DebugName(wheel_names[i].clone()));
@@ -514,6 +515,7 @@ impl Engine {
                 frame_offset: Vec3::ZERO,
                 footprint: vec![],
                 ghost_group,
+                color: [1.0, 1.0, 1.0, 1.0],
             };
             let te = self.world.spawn((sprite, Transform::new(Vec3::new(x, y, 0.0), Vec3::ONE)));
             let _ = self.world.insert_one(te, DebugName(name.clone()));
@@ -535,6 +537,7 @@ impl Engine {
             frame_offset: Vec3::ZERO,
             footprint: vec![],
             ghost_group,
+            color: [1.0, 1.0, 1.0, 1.0],
         };
         let vehicle = IsoVehicle {
             tilemap: tilemap_name,

--- a/crates/classic-gfx/src/lib.rs
+++ b/crates/classic-gfx/src/lib.rs
@@ -614,6 +614,7 @@ impl Gfx {
         s.uniform_vec3(gl, "ambient_color", Vec3::from_array(settings.ambient));
         s.uniform_vec3(gl, "light_direction", Vec3::from_array(settings.light_dir));
         s.uniform_vec3(gl, "light_color", Vec3::from_array(settings.light_color));
+        s.uniform_vec3(gl, "tint", Vec3::from_array([1.0, 1.0, 1.0]));
 
         vertex_attrib_ptr_f32(gl, &self.quad.verts, s.attr("vertex_pos"), 3, 0, 0);
         vertex_attrib_ptr_f32(gl, &self.quad.uv, s.attr("tex_coord"), 2, 0, 0);
@@ -693,6 +694,7 @@ impl Gfx {
         depth_map: Option<(&str, f32)>,
         depth_base: f32,
         normal_map: Option<&str>,
+        tint: &[f32; 3],
         settings: &RenderSettings,
         ghost_alpha: f32,
     ) {
@@ -752,6 +754,7 @@ impl Gfx {
         s.uniform_vec3(gl, "ambient_color", Vec3::from_array(settings.ambient));
         s.uniform_vec3(gl, "light_direction", Vec3::from_array(settings.light_dir));
         s.uniform_vec3(gl, "light_color", Vec3::from_array(settings.light_color));
+        s.uniform_vec3(gl, "tint", Vec3::from_array(*tint));
 
         vertex_attrib_ptr_f32(gl, &self.quad.verts, s.attr("vertex_pos"), 3, 0, 0);
         vertex_attrib_ptr_f32(gl, &self.quad.uv, s.attr("tex_coord"), 2, 0, 0);
@@ -783,6 +786,7 @@ impl Gfx {
         depth_map: Option<(&str, f32)>,
         depth_base: f32,
         normal_map: Option<&str>,
+        tint: &[f32; 3],
         settings: &RenderSettings,
         ghost_group: u32,
         pass: IsoSpritePass,
@@ -801,6 +805,7 @@ impl Gfx {
             depth_map,
             depth_base,
             normal_map,
+            tint,
             settings,
             ghost_alpha,
         );

--- a/crates/classic-gfx/src/shaders/sheet.frag
+++ b/crates/classic-gfx/src/shaders/sheet.frag
@@ -23,6 +23,10 @@ uniform float use_normal_map;
 uniform vec3 ambient_color;
 uniform vec3 light_direction;
 uniform vec3 light_color;
+// Per-sprite tint (multiplied onto the albedo before the Lambertian term).
+// Defaults to (1,1,1) — a no-op for every existing asset.  Tintable sprites
+// ship a grayscale albedo and set this at runtime (see IsoSprite.color).
+uniform vec3 tint;
 
 out vec4 fragColor;
 
@@ -62,6 +66,7 @@ vec4 getTilePixel(float tile_id_flat, vec2 tex_coord) {
 void main(void ) {
     vec4 color = getTilePixel(tile_id_flat, vec2(vTexCoord.x, vTexCoord.y));
     if (color.a < 0.01) discard;
+    color.rgb *= tint;
     if (use_depth_map > 0.5) {
         highp float gray = texture(depth_sampler, sheetUv(vec2(vTexCoord.x, vTexCoord.y))).r;
         // `depth_base` and `depth_range` are both window-space iso depths, so

--- a/crates/classic-guest/src/imports.rs
+++ b/crates/classic-guest/src/imports.rs
@@ -86,6 +86,46 @@ macro_rules! install_host_imports {
             },
         )?;
 
+        $linker.func_wrap(
+            m,
+            "set_sprite_frame",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32, frame: f64| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().set_sprite_frame(&name, frame)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "set_sprite_color",
+            |mut caller: Caller<'_, $host>,
+             ptr: i32,
+             len: i32,
+             r: f64,
+             g: f64,
+             b: f64,
+             a: f64|
+             -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().set_sprite_color(&name, r, g, b, a)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "spawn_sprite_clone",
+            |mut caller: Caller<'_, $host>,
+             t_ptr: i32,
+             t_len: i32,
+             n_ptr: i32,
+             n_len: i32|
+             -> i32 {
+                let template = $read_str(&mut caller, t_ptr, t_len);
+                let name = $read_str(&mut caller, n_ptr, n_len);
+                caller.data_mut().guest_mut().spawn_sprite_clone(&template, &name)
+            },
+        )?;
+
         $linker.func_wrap(m, "mouse", |mut caller: Caller<'_, $host>, out_ptr: i32| -> i32 {
             let (x, y) = caller.data_mut().guest_mut().mouse();
             $write_f64_pair(&mut caller, out_ptr, x, y);

--- a/crates/classic-guest/src/runtime_web.rs
+++ b/crates/classic-guest/src/runtime_web.rs
@@ -579,6 +579,55 @@ impl WebWasmRuntime {
             );
         }
 
+        // set_sprite_frame
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "set_sprite_frame",
+                Box::new(move |ptr: i32, len: i32, frame: f64| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().set_sprite_frame(&name, frame)
+                }) as Box<dyn FnMut(i32, i32, f64) -> i32>
+            );
+        }
+
+        // set_sprite_color
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "set_sprite_color",
+                Box::new(move |ptr: i32, len: i32, r: f64, g: f64, b: f64, a: f64| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().set_sprite_color(&name, r, g, b, a)
+                }) as Box<dyn FnMut(i32, i32, f64, f64, f64, f64) -> i32>
+            );
+        }
+
+        // spawn_sprite_clone
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "spawn_sprite_clone",
+                Box::new(move |t_ptr: i32, t_len: i32, n_ptr: i32, n_len: i32| -> i32 {
+                    let (template, name) = {
+                        let mem = mem.borrow();
+                        let m = mem.as_ref().unwrap();
+                        (read_str(m, t_ptr, t_len), read_str(m, n_ptr, n_len))
+                    };
+                    host.borrow_mut().spawn_sprite_clone(&template, &name)
+                }) as Box<dyn FnMut(i32, i32, i32, i32) -> i32>
+            );
+        }
+
         // mouse
         {
             let host = host.clone();

--- a/crates/classic-guest/src/runtime_worker.rs
+++ b/crates/classic-guest/src/runtime_worker.rs
@@ -125,6 +125,9 @@ const OP_VEHICLE_GOTO: i32 = 73;
 const OP_VEHICLE_STOP: i32 = 74;
 const OP_VEHICLE_SPAWN: i32 = 75;
 const OP_POLL_PATH: i32 = 76;
+const OP_SET_SPRITE_FRAME: i32 = 77;
+const OP_SET_SPRITE_COLOR: i32 = 78;
+const OP_SPAWN_SPRITE_CLONE: i32 = 79;
 
 const WORKER_SRC: &str = include_str!("worker.js");
 
@@ -285,6 +288,11 @@ impl WorkerWasmRuntime {
             OP_VEHICLE_GOTO => (host.vehicle_goto(&strs[0], ni(0), ni(1)) as f64, None),
             OP_VEHICLE_STOP => (host.vehicle_stop(&strs[0]) as f64, None),
             OP_VEHICLE_SPAWN => (host.vehicle_spawn(&strs[0], &strs[1], nf(0), nf(1)) as f64, None),
+            OP_SET_SPRITE_FRAME => (host.set_sprite_frame(&strs[0], nf(0)) as f64, None),
+            OP_SET_SPRITE_COLOR => {
+                (host.set_sprite_color(&strs[0], nf(0), nf(1), nf(2), nf(3)) as f64, None)
+            }
+            OP_SPAWN_SPRITE_CLONE => (host.spawn_sprite_clone(&strs[0], &strs[1]) as f64, None),
             OP_GET_CAMERA => {
                 let (x, y, s) = host.get_camera();
                 (1.0, Some(enc_f64s(&[x, y, s])))

--- a/crates/classic-guest/src/sdk.rs
+++ b/crates/classic-guest/src/sdk.rs
@@ -134,6 +134,22 @@ impl GuestHost {
         self.engine().get_pos(name).map(|(x, y, z)| (x as f64, y as f64, z as f64))
     }
 
+    /// Set a named entity's `IsoSprite` frame index (packed-atlas aware).
+    pub fn set_sprite_frame(&mut self, name: &str, frame: f64) -> i32 {
+        self.engine_mut().set_sprite_frame(name, frame as f32) as i32
+    }
+
+    /// Set a named entity's `IsoSprite` tint colour (RGBA, `0..=1`).
+    pub fn set_sprite_color(&mut self, name: &str, r: f64, g: f64, b: f64, a: f64) -> i32 {
+        self.engine_mut().set_sprite_color(name, [r as f32, g as f32, b as f32, a as f32]) as i32
+    }
+
+    /// Spawn a new `IsoSprite` entity cloned from a template entity's
+    /// `IsoSprite` + `Transform` (e.g. a placement ghost), under a new name.
+    pub fn spawn_sprite_clone(&mut self, template: &str, name: &str) -> i32 {
+        self.engine_mut().spawn_sprite_clone(template, name) as i32
+    }
+
     pub fn mouse(&mut self) -> (f64, f64) {
         let p = self.engine().input.mouse_pos;
         (p.x as f64, p.y as f64)

--- a/crates/classic-guest/src/worker.js
+++ b/crates/classic-guest/src/worker.js
@@ -113,6 +113,9 @@ var OP_VEHICLE_GOTO = 73;
 var OP_VEHICLE_STOP = 74;
 var OP_VEHICLE_SPAWN = 75;
 var OP_POLL_PATH = 76;
+var OP_SET_SPRITE_FRAME = 77;
+var OP_SET_SPRITE_COLOR = 78;
+var OP_SPAWN_SPRITE_CLONE = 79;
 
 var encoder = new TextEncoder();
 var decoder = new TextDecoder();
@@ -200,6 +203,15 @@ function envImports() {
         },
         set_pos: function (ptr, len, x, y, z) {
             return hostCall(OP_SET_POS, [readStr(ptr, len)], [x, y, z]).ret | 0;
+        },
+        set_sprite_frame: function (ptr, len, frame) {
+            return hostCall(OP_SET_SPRITE_FRAME, [readStr(ptr, len)], [frame]).ret | 0;
+        },
+        set_sprite_color: function (ptr, len, r, g, b, a) {
+            return hostCall(OP_SET_SPRITE_COLOR, [readStr(ptr, len)], [r, g, b, a]).ret | 0;
+        },
+        spawn_sprite_clone: function (tPtr, tLen, nPtr, nLen) {
+            return hostCall(OP_SPAWN_SPRITE_CLONE, [readStr(tPtr, tLen), readStr(nPtr, nLen)], []).ret | 0;
         },
         get_pos: function (ptr, len, outPtr) {
             var r = hostCall(OP_GET_POS, [readStr(ptr, len)], [outPtr]);

--- a/crates/classic-guest/tests/guest.rs
+++ b/crates/classic-guest/tests/guest.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the WASM guest runtime, driving every backend (wasmi
 //! always; wasmtime on native) with small hand-written WAT guest modules.
 
-use classic_core::components::{Animator, ColliderData, NavMesh, Role, Shape, Tilemap};
+use classic_core::components::{Animator, ColliderData, IsoSprite, NavMesh, Role, Shape, Tilemap};
 use classic_core::types::AnimationData;
 use classic_core::RoleKind;
 use classic_engine::Engine;
@@ -65,6 +65,100 @@ fn guest_can_spawn_and_move_entities() {
 
             assert!(engine.has_name("unit"));
             assert_eq!(engine.get_pos("unit"), Some((10.0, 20.0, 3.0)));
+        },
+    );
+}
+
+#[test]
+fn guest_can_set_sprite_frame_and_color() {
+    with_each_runtime(
+        r#"(module
+            (import "env" "set_sprite_frame" (func $set_frame (param i32 i32 f64) (result i32)))
+            (import "env" "set_sprite_color" (func $set_color (param i32 i32 f64 f64 f64 f64) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "unit")
+            (func (export "update") (param f64)
+                (drop (call $set_frame (i32.const 0) (i32.const 4) (f64.const 42.0)))
+                (drop (call $set_color (i32.const 0) (i32.const 4) (f64.const 0.2) (f64.const 0.4) (f64.const 0.6) (f64.const 1.0)))))"#,
+        &GuestLimits::default(),
+        |rt| {
+            let mut engine = Engine::new_for_test();
+            engine.spawn_named("unit");
+            let entity = *engine.names.get("unit").unwrap();
+            engine
+                .world
+                .insert_one(
+                    entity,
+                    IsoSprite {
+                        position: Vec3::ZERO,
+                        scale: Vec3::ONE,
+                        texture: "shippingContainerBody".into(),
+                        tilemap: "tilemap".into(),
+                        frame: 0.0,
+                        frame_name: None,
+                        tile_set_size: glam::Vec2::ONE,
+                        anchor: glam::Vec2::new(0.5, 0.67),
+                        frame_offset: Vec3::ZERO,
+                        footprint: vec![],
+                        ghost_group: 0,
+                        color: [1.0, 1.0, 1.0, 1.0],
+                    },
+                )
+                .unwrap();
+
+            rt.update(&mut engine, 0.016).unwrap();
+
+            let sprite = engine.world.get::<&IsoSprite>(entity).unwrap();
+            assert_eq!(sprite.frame, 42.0);
+            assert_eq!(sprite.color, [0.2, 0.4, 0.6, 1.0]);
+        },
+    );
+}
+
+#[test]
+fn guest_can_spawn_sprite_clone() {
+    with_each_runtime(
+        r#"(module
+            (import "env" "spawn_sprite_clone" (func $clone (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "template")
+            (data (i32.const 16) "clone")
+            (func (export "update") (param f64)
+                (drop (call $clone (i32.const 0) (i32.const 8) (i32.const 16) (i32.const 5)))))"#,
+        &GuestLimits::default(),
+        |rt| {
+            let mut engine = Engine::new_for_test();
+            engine.spawn_named("template");
+            let template = *engine.names.get("template").unwrap();
+            engine
+                .world
+                .insert_one(
+                    template,
+                    IsoSprite {
+                        position: Vec3::ZERO,
+                        scale: Vec3::ONE,
+                        texture: "shippingContainerBody".into(),
+                        tilemap: "tilemap".into(),
+                        frame: 7.0,
+                        frame_name: Some("shippingContainerBody_7".into()),
+                        tile_set_size: glam::Vec2::ONE,
+                        anchor: glam::Vec2::new(0.5, 0.67),
+                        frame_offset: Vec3::ZERO,
+                        footprint: vec![],
+                        ghost_group: 0,
+                        color: [0.55, 0.65, 0.95, 1.0],
+                    },
+                )
+                .unwrap();
+
+            rt.update(&mut engine, 0.016).unwrap();
+
+            assert!(engine.has_name("clone"));
+            let clone = *engine.names.get("clone").unwrap();
+            let sprite = engine.world.get::<&IsoSprite>(clone).unwrap();
+            assert_eq!(sprite.texture, "shippingContainerBody");
+            assert_eq!(sprite.frame, 7.0);
+            assert_eq!(sprite.color, [0.55, 0.65, 0.95, 1.0]);
         },
     );
 }

--- a/tests/scenarios/container_ghost.test.json
+++ b/tests/scenarios/container_ghost.test.json
@@ -1,0 +1,24 @@
+[
+  {
+    "frame": 2,
+    "actions": [
+      { "setCameraIso": { "tx": 24.5, "ty": 43.5, "scale": 0.8 } },
+      { "setEntityPos": { "name": "container", "x": 24.5, "y": 43.5, "z": 96 } },
+      { "setSpriteFrame": { "name": "container", "frame": 56 } }
+    ],
+    "assertions": [],
+    "log": "place the container flat on the south plateau, level pitch/roll frame (56)"
+  },
+  {
+    "frame": 8,
+    "actions": [],
+    "assertions": [
+      { "kind": "entityPos", "region": [24, 43, 0, 0], "expected": 1.0, "log": "container" },
+      { "kind": "pixelAtEntity", "region": [0, 0, 0, 0], "expected": 0.9, "log": "container", "offset": [0, 0] },
+      { "kind": "pixelAtEntity", "region": [0, 0, 0, 0], "expected": 0.9, "log": "container", "offset": [-1.735, 1.735] },
+      { "kind": "pixelAtEntity", "region": [0, 0, 0, 0], "expected": 0.9, "log": "container", "offset": [1.735, 1.735] },
+      { "kind": "pixelAtEntity", "region": [0, 0, 0, 0], "expected": 0.9, "log": "container", "offset": [1.735, -1.735] }
+    ],
+    "log": "footprint corners render opaque on flat terrain (front-bottom corner no longer ghosts)"
+  }
+]


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/vehicle_climb_tolerance
base: wkt/shipping_container_tint
head_oid: e175408a96694676c90964d366cf042f0bd554c7
base_tip_oid: b947cfdb0afc39c1d2aa2c9db7bfc2c1fa48f264
merge_base_oid: b947cfdb0afc39c1d2aa2c9db7bfc2c1fa48f264
provider_diff_base_oid: unavailable
commit_range: b947cfdb0afc39c1d2aa2c9db7bfc2c1fa48f264..e175408a96694676c90964d366cf042f0bd554c7
diff_range: b947cfdb0afc39c1d2aa2c9db7bfc2c1fa48f264...e175408a96694676c90964d366cf042f0bd554c7
authority: forge-verified
submitted:
  github: ___
-->

## Let vehicle pathing climb by pitch/roll, not the walk grid

### Motivation

The LRV can't drive into or out of craters on the larger lunar
terrain.  Its suspension tolerance (`pitch_max_deg`/`roll_max_deg` =
20deg) already covers the whole surface (max slope ~19.7deg), but the
vehicle pathfinder ANDs that against a `structural` grid fed the
terrain nav grid — slope-limited *human* walkability (`nav_max_slope`
~= 10.9deg).  So the walk cap, not the vehicle's climb tolerance, is
what blocks crater rims.  Upward climbs can't use the jump mechanic
(downward-only), so the LRV drops in but can't climb out.

### Summary of changes

- Build the vehicle nav snapshot with a fully-open `structural` grid
  (no current vehicle scene — lunar, lrvtest, container — has hard
  obstacles), so the per-request pitch/roll check becomes the sole
  slope gate.

### Related issues & PRs

- Companion terrain change in classic-roms PR #9
  (https://github.com/guilledk/classic-roms/pull/9) enlarges the
  lunar crater field; this lets the LRV traverse those rims.

---

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
