### PR TITLE
add workspace versioning with changelog and release xtask

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: classic-release
+description: >
+  Cut a classic-wgl release: freeze the changelog, bump the workspace version,
+  and tag.  Use after a merge window lands on master and [Unreleased] is
+  non-empty.  Covers `cargo xtask release` / `check-version`, the
+  Keep-a-Changelog format, and the ROM-lock re-pin.  Trigger phrases: "release",
+  "bump version", "cut a release", "freeze changelog", "tag vX.Y.Z",
+  "version bump".
+---
+
+# Releasing classic-wgl
+
+Releases are **one per merge window**, cut directly on `master` (no release
+PR).  See [`VERSIONING.md`](../../VERSIONING.md) for the policy; this skill is
+the runbook.
+
+## When
+
+- A stack of `wkt/*` branches has been reviewed and merged to `master`.
+- CI is green (fmt, clippy, test, wasm-check, golden).
+- `CHANGELOG.md`'s `[Unreleased]` section is **non-empty** — otherwise skip
+  (housekeeping-only window).
+
+## How
+
+1. Confirm the tree is clean and on `master`:
+
+   ```bash
+   git status --short
+   git branch --show-current
+   ```
+
+2. Choose the bump from the `[Unreleased]` content:
+   - breaking change → `minor` (0.x rule),
+   - fixes/features only → `patch`,
+   - explicit prerelease → `--version X.Y.Z-alpha.N`.
+
+3. Run the release (bumps `Cargo.toml`, freezes `CHANGELOG.md`, tags):
+
+   ```bash
+   cargo xtask release patch
+   ```
+
+4. Verify the frozen entry reads well, then push:
+
+   ```bash
+   git show --stat HEAD
+   git push origin master --tags
+   ```
+
+5. Open a GitHub release with the new changelog section as the body.
+
+6. If the release changed anything the golden baselines depend on, re-pin the
+   ROM lock and re-baseline:
+
+   ```bash
+   cargo xtask lock-roms
+   CLASSIC_HEADLESS=1 CLASSIC_FRAMES=60 CLASSIC_TEST=all CLASSIC_GOLDEN=update \
+     cargo run -p classic-desktop
+   ```
+
+## Rules
+
+- Never hand-edit `workspace.package.version` or a version heading on a feature
+  branch — accumulate under `[Unreleased]` instead.
+- Never bump the ROM `format_version` here; that is `classic-roms`' domain.
+- One bullet per logical change, PR number in parentheses.
+- Keep the changelog entries in Keep-a-Changelog order: `Added`, `Changed`,
+  `Removed`, `Fixed`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,29 @@ env:
     CARGO_TERM_COLOR: always
 
 jobs:
+    version:
+        name: version + changelog
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - uses: dtolnay/rust-toolchain@stable
+            - name: Cargo.toml vs CHANGELOG.md
+              run: cargo xtask check-version
+            - name: changelog updated when code changed
+              if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+              run: |
+                  base="${{ github.event.pull_request.base.sha }}"
+                  changed_code=$(git diff --name-only "$base...HEAD" | grep -E '^(crates|apps)/' || true)
+                  changed_changelog=$(git diff --name-only "$base...HEAD" | grep -E '^CHANGELOG.md$' || true)
+                  if [ -n "$changed_code" ] && [ -z "$changed_changelog" ]; then
+                    echo "::error::source under crates/ or apps/ changed without a CHANGELOG.md update (add to [Unreleased], or label the PR 'skip-changelog')"
+                    exit 1
+                  fi
+                  echo "changelog ok"
+
     lint:
         name: lint (fmt + clippy)
         runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ cargo xtask fetch-roms               # downloads the staged demo/lunar ROMs (and
 # Web pathfinder module (must run before any --target wasm32 build/check;
 # trunk serve/build do it automatically via the `pre_build` hook in `Trunk.toml`)
 cargo xtask build-pathfinder         # compiles crates/classic-pathfinder-wasm to pathfinder.wasm and stages it next to web.rs
+
+# Versioning / releases (see VERSIONING.md)
+cargo xtask check-version            # fail when Cargo.toml/CHANGELOG.md drift
+cargo xtask release patch            # bump version + freeze changelog (prints commit/tag cmds)
 ```
 
 CI (`.github/workflows/ci.yml`) runs `cargo fmt` + `cargo clippy` + `cargo test` + `wasm check` +
@@ -267,6 +271,17 @@ plans/
 - Default branch is `master` (CI triggers on push to `master` and all PRs).
 - Commit messages are short, lowercase, imperative (`fix nav walkability transpose`).
 - No git submodules remain; the `assets/` submodule and its `GH_PAT` checkout token were removed.
+
+## Versioning / releases
+
+- Workspace-wide [semver](https://semver.org) (0.x: MINOR = breaking, PATCH =
+  fix/feature), tracked in `[workspace.package.version]` + `CHANGELOG.md`.
+  See `VERSIONING.md` for the full policy; the `classic-release` skill is the
+  runbook.
+- Releases are cut **once per merge window** via `cargo xtask release` — never
+  hand-edit versions on a feature branch; accumulate under `[Unreleased]`.
+- `cargo xtask check-version` (run in CI) fails on any `Cargo.toml` ↔
+  `CHANGELOG.md` drift.
 
 ## Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+See [`VERSIONING.md`](VERSIONING.md) for the release policy and process.
+
+## [Unreleased]
+
+## [0.1.0-alpha.0] - 2026-08-28
+
+The first recorded release covers the Rust rewrite and everything that landed
+since: the TypeScript engine was dropped and the codebase became the current
+Rust + wasm multi-target engine with ROM-driven content.
+
+### Added
+
+- Rust port of the engine — 7 crates, native (winit+glutin) and web
+  (web-sys+trunk) targets, parity with the TypeScript engine (#24).
+- `classic-demo` crate, isolating the prefab, editor, and test-runner layers
+  from the engine core (#26).
+- Procedural `lunar` terrain generator (layered simplex noise + crater field)
+  and demo scene (#27).
+- ROM layer (`classic-rom`): `RomArchive`/`Rom`, manifest, resources,
+  `load_rom`/`dump_rom` (#28).
+- WASM guest runtime (`classic-guest`): wasmtime (native) / wasmi (wasm) with
+  sandbox fuel + memory caps, and per-scene `#![no_std]` guests (#29).
+- `classic-terrain` noise toolkit; terrain generation moved into ROM guests
+  (`guest-driven maps`) (#30).
+- Per-frame animation offsets and the lunar landing rocket (#32).
+- `IsoVehicle` wheeled-vehicle system with the LRV rover (#34).
+- Worker offload for pathfinding and guest map generation (#41).
+- ROM release fetching from the `classic-roms.com` bucket (#44).
+- LRV vehicle pathing, turning, and cliff-jump (#46).
+- Packed-atlas sprites: frame tables + packed rendering for LRV, props, rocket
+  (#52).
+- Per-texture depth maps with a unified iso depth scale (#55).
+- Shared `#![no_std]` `pathfinder` crate (A* + vehicle search) and
+  `vehicle_goto` offload (#62).
+- Unified sprite draws and per-sheet normal/depth maps (#63).
+- Web guest worker offloaded to a browser `Worker` (#64).
+- Iso height axis re-expressed in metres (#67).
+- Clamped chassis-plane vehicle suspension (#68).
+- Front-wheel steering for the LRV (#69).
+- Vehicle speed/turn-rate tuning panel (#70).
+- Sprite tinting and guest-driven sprites (#71).
+- Vehicle pathing that climbs by pitch/roll rather than the walk grid (#72).
+- Packed-atlas companions uploaded in native channel counts (#73).
+- Coordinated steering, reverse recovery, and turn-cost routing for the LRV
+  (#74).
+- Sparse rocket offset interpolation and the landing/launch cycle (#75).
+- ROM content-hash lock (`cargo xtask lock-roms`/`check-roms`) to fail fast on
+  bucket drift (#76).
+
+### Changed
+
+- `classic-guest` guests own the scene and map; the engine was de-demo-ified
+  (#31).
+
+### Removed
+
+- TypeScript engine and tooling (−19 000 LOC) (#66).
+- TS/Vite conventions from ROMs, state, and tooling (#33).
+
+### Fixed
+
+- Headless EGL teardown segfault and CI coverage gaps (#51).
+- Iso depth clipping and mouse-iso debug overlay (#65).
+- Clippy `chunks_exact_to_as_chunks` in the byte decoders.
+- Pages deploy: stage `pathfinder.wasm` before `trunk build`.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,82 @@
+# Versioning
+
+`classic-wgl` versions the **whole workspace as a single unit** using
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html), with a
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) file at
+[`CHANGELOG.md`](CHANGELOG.md).
+
+## Version scheme
+
+- One version for the entire workspace: `[workspace.package.version]` in
+  `Cargo.toml` (every crate uses `version.workspace = true`).
+- Pre-1.0, the scheme is `0.MINOR.PATCH`:
+  - **MINOR** — breaking changes (the 0.x semver rule: bump minor on any
+    incompatible change).
+  - **PATCH** — backwards-compatible fixes and new features.
+- The current series carries a `-alpha.N` prerelease suffix. It is dropped
+  when we promote to `0.1.0`; `xtask release` promotes (drops the suffix) on
+  any bump, per cargo-release semantics. Use `xtask release --version X.Y.Z`
+  to set a prerelease explicitly.
+
+## What is *not* versioned here
+
+- The ROM **format contract** (`format_version` in a ROM manifest) is owned by
+  `classic-roms`, not by engine semver.
+- Per-ROM and per-asset versions live in `classic-roms` and `classic-assets`
+  respectively.
+
+## Changelog
+
+- `CHANGELOG.md` at the repo root, Keep-a-Changelog sections: `Added`,
+  `Changed`, `Removed`, `Fixed`.
+- Work in flight accumulates under `[Unreleased]`. Do **not** hand-edit a
+  version number or bump `Cargo.toml` on a feature branch — that happens once,
+  at release time.
+- Each entry is one bullet per logical change, with the PR number in
+  parentheses.
+
+## When to release
+
+Releases are cut **once per merge window**: after a stack of `wkt/*` branches
+has been reviewed and merged to `master` (CI green), and `[Unreleased]` is
+non-empty. Housekeeping-only windows (empty `[Unreleased]`) are skipped.
+
+## How to release
+
+Run the deterministic command — never hand-edit versions:
+
+```bash
+cargo xtask release <major|minor|patch>     # bump + freeze changelog + tag
+cargo xtask release --version 0.2.0-alpha.0 # explicit version
+```
+
+`xtask release` performs, in order:
+
+1. Bumps `[workspace.package.version]` in `Cargo.toml`.
+2. Freezes `[Unreleased]` → `[<version>] - <date>` in `CHANGELOG.md`.
+3. Verifies `Cargo.toml` version == top changelog version (`check-version`).
+4. Prints the commit/tag commands to run (it does not mutate git).
+
+Then commit, tag, and push (reviewing the frozen entry first):
+
+```bash
+git add Cargo.toml CHANGELOG.md
+git commit -m "release v<version>"
+git tag -a v<version> -m "release v<version>"
+git push origin master --tags
+```
+
+Because ROMs are validated against a content-hash lock, re-pin them when the
+release changes anything the golden baselines depend on:
+
+```bash
+cargo xtask lock-roms
+CLASSIC_GOLDEN=update <golden invocation>   # see AGENTS.md
+```
+
+## Enforcing the invariant
+
+- CI runs `cargo xtask check-version` on every PR/push, failing when
+  `Cargo.toml` and `CHANGELOG.md` drift.
+- CI also requires a `CHANGELOG.md` change when `crates/**` or `apps/**`
+  change; label the PR `skip-changelog` to waive it for docs/housekeeping.

--- a/crates/classic-rom/src/manifest.rs
+++ b/crates/classic-rom/src/manifest.rs
@@ -62,6 +62,12 @@ pub struct RomManifest {
     /// slow path (e.g. browser WebAssembly on web).
     #[serde(default)]
     pub trusted: bool,
+    /// Semantic version of the ROM content, stamped by `classic-roms` (see its
+    /// per-ROM `version` in `scene.json`).  Distinct from `format_version`,
+    /// which is the manifest schema contract.  `None` for ROMs packed before
+    /// per-ROM versioning existed.
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 fn default_format_version() -> u32 {
@@ -103,5 +109,16 @@ mod tests {
         let m: RomManifest = serde_json::from_str(json).unwrap();
         assert!(!m.host_features);
         assert!(!m.trusted);
+    }
+
+    #[test]
+    fn version_is_optional() {
+        let without = r#"{"shaders": [], "textures": [], "animations": []}"#;
+        let m: RomManifest = serde_json::from_str(without).unwrap();
+        assert_eq!(m.version, None);
+
+        let with = r#"{"shaders": [], "textures": [], "animations": [], "version": "0.2.0"}"#;
+        let m: RomManifest = serde_json::from_str(with).unwrap();
+        assert_eq!(m.version.as_deref(), Some("0.2.0"));
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,10 +13,13 @@
 //!   cargo xtask build-pathfinder               # compile + stage pathfinder.wasm
 //!   cargo xtask lock-roms [--url <rom-base>]   # pin the published checksums to the lockfile
 //!   cargo xtask check-roms [--url <rom-base>]  # fail fast when the published ROMs drift
+//!   cargo xtask release <major|minor|patch>    # bump version + freeze changelog
+//!   cargo xtask release --version <X.Y.Z>      # set an explicit version
+//!   cargo xtask check-version                  # fail when Cargo.toml/CHANGELOG.md drift
 
 use std::fs;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -46,9 +49,11 @@ fn main() -> anyhow::Result<()> {
         "build-pathfinder" => return build_pathfinder(),
         "lock-roms" => return cmd_lock_roms(arg_value(&args, "--url")),
         "check-roms" => return cmd_check_roms(arg_value(&args, "--url")),
+        "release" => return cmd_release(&args),
+        "check-version" => return cmd_check_version(),
         "fetch-roms" | "all" => {}
         other => anyhow::bail!(
-            "unknown command `{other}` (expected fetch-roms, lock-roms, check-roms, or build-pathfinder)"
+            "unknown command `{other}` (expected fetch-roms, lock-roms, check-roms, release, check-version, or build-pathfinder)"
         ),
     }
 
@@ -256,4 +261,195 @@ fn sha(entry: &serde_json::Value) -> String {
 /// `size` field of a `roms.json` entry, or 0 when absent.
 fn size(entry: &serde_json::Value) -> u64 {
     entry.get("size").and_then(|s| s.as_u64()).unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Versioning (`release` / `check-version`)
+// ---------------------------------------------------------------------------
+
+/// The repository root (parent of the xtask crate manifest dir).
+fn repo_root() -> anyhow::Result<PathBuf> {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|p| p.to_path_buf())
+        .context("xtask manifest dir has a repo-root parent")
+}
+
+/// Parse the `major.minor.patch` numeric prefix of a semver string (ignoring
+/// any `-prerelease` suffix).
+fn parse_version(v: &str) -> anyhow::Result<(u64, u64, u64)> {
+    let numeric = v.split('-').next().unwrap_or(v);
+    let mut parts = numeric.split('.');
+    let major = parts.next().context("version major")?.parse::<u64>()?;
+    let minor = parts.next().context("version minor")?.parse::<u64>()?;
+    let patch = parts.next().context("version patch")?.parse::<u64>()?;
+    Ok((major, minor, patch))
+}
+
+/// Apply a semver bump (major/minor/patch), dropping any prerelease suffix.
+fn bump_version(v: &str, kind: &str) -> anyhow::Result<String> {
+    let (mut major, mut minor, mut patch) = parse_version(v)?;
+    match kind {
+        "major" => {
+            major += 1;
+            minor = 0;
+            patch = 0;
+        }
+        "minor" => {
+            minor += 1;
+            patch = 0;
+        }
+        "patch" => patch += 1,
+        other => anyhow::bail!("unknown bump `{other}` (expected major, minor, or patch)"),
+    }
+    Ok(format!("{major}.{minor}.{patch}"))
+}
+
+/// Read `[workspace.package] version` from the root `Cargo.toml`.
+fn read_workspace_version(root: &Path) -> anyhow::Result<String> {
+    let cargo = fs::read_to_string(root.join("Cargo.toml")).context("read Cargo.toml")?;
+    let mut in_ws = false;
+    for line in cargo.lines() {
+        let t = line.trim();
+        if t == "[workspace.package]" {
+            in_ws = true;
+            continue;
+        }
+        if in_ws && t.starts_with('[') {
+            break;
+        }
+        if in_ws && t.starts_with("version") {
+            let v = t.split_once('=').context("parse version line")?.1.trim();
+            return Ok(v.trim_matches('"').to_string());
+        }
+    }
+    anyhow::bail!("no [workspace.package] version found in Cargo.toml")
+}
+
+/// Replace the `[workspace.package] version` in the root `Cargo.toml`.
+fn set_workspace_version(root: &Path, old: &str, new: &str) -> anyhow::Result<()> {
+    let path = root.join("Cargo.toml");
+    let cargo = fs::read_to_string(&path).context("read Cargo.toml")?;
+    let needle = format!("version = \"{old}\"");
+    if !cargo.contains(&needle) {
+        anyhow::bail!("version `{old}` not found in Cargo.toml");
+    }
+    fs::write(&path, cargo.replacen(&needle, &format!("version = \"{new}\""), 1))
+        .context("write Cargo.toml")
+}
+
+/// The first released version heading in `CHANGELOG.md` (skipping
+/// `[Unreleased]`).
+fn changelog_top_version(root: &Path) -> anyhow::Result<Option<String>> {
+    let text = fs::read_to_string(root.join("CHANGELOG.md")).context("read CHANGELOG.md")?;
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix("## [") {
+            if let Some(ver) = rest.split(']').next() {
+                if ver == "Unreleased" {
+                    continue;
+                }
+                return Ok(Some(ver.to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Freeze the `## [Unreleased]` section into `## [<version>] - <date>`.
+fn freeze_changelog(root: &Path, new_version: &str, date: &str) -> anyhow::Result<()> {
+    let path = root.join("CHANGELOG.md");
+    let text = fs::read_to_string(&path).context("read CHANGELOG.md")?;
+    const MARKER: &str = "## [Unreleased]";
+    if !text.contains(MARKER) {
+        anyhow::bail!("CHANGELOG.md has no `## [Unreleased]` section");
+    }
+    let block = format!("## [Unreleased]\n\n## [{new_version}] - {date}");
+    fs::write(&path, text.replacen(MARKER, &block, 1)).context("write CHANGELOG.md")
+}
+
+/// Today's date in `YYYY-MM-DD` (UTC).
+fn today_date() -> anyhow::Result<String> {
+    let out = Command::new("date").args(["-u", "+%Y-%m-%d"]).output().context("run date")?;
+    if !out.status.success() {
+        anyhow::bail!("`date` failed");
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// `cargo xtask check-version`: fail when `Cargo.toml` and `CHANGELOG.md`
+/// disagree about the current version.
+fn cmd_check_version() -> anyhow::Result<()> {
+    let root = repo_root()?;
+    let version = read_workspace_version(&root)?;
+    let top = changelog_top_version(&root)?.context("CHANGELOG.md has no released version")?;
+    if version != top {
+        anyhow::bail!(
+            "version drift: Cargo.toml `{version}` != CHANGELOG.md `{top}` \
+             (run `cargo xtask release ...`)"
+        );
+    }
+    println!("version `{version}` matches CHANGELOG.md");
+    Ok(())
+}
+
+/// `cargo xtask release <major|minor|patch>` (or `--version X.Y.Z`): bump the
+/// workspace version, freeze the changelog, and verify.  Prints the commit/tag
+/// commands — it does not mutate git.
+fn cmd_release(args: &[String]) -> anyhow::Result<()> {
+    let root = repo_root()?;
+    let current = read_workspace_version(&root)?;
+
+    let new_version = if let Some(explicit) = arg_value(args, "--version") {
+        explicit
+    } else {
+        let kind = args
+            .iter()
+            .skip(1)
+            .find(|a| !a.starts_with('-'))
+            .context("specify major, minor, patch, or --version X.Y.Z")?
+            .clone();
+        bump_version(&current, &kind)?
+    };
+
+    set_workspace_version(&root, &current, &new_version)?;
+    freeze_changelog(&root, &new_version, &today_date()?)?;
+    cmd_check_version()?;
+
+    println!("bumped {current} -> {new_version}");
+    println!("next:");
+    println!("  git add Cargo.toml CHANGELOG.md");
+    println!("  git commit -m \"release v{new_version}\"");
+    println!("  git tag -a v{new_version} -m \"release v{new_version}\"");
+    println!("  git push origin master --tags");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ignores_prerelease() {
+        assert_eq!(parse_version("0.1.0-alpha.0").unwrap(), (0, 1, 0));
+        assert_eq!(parse_version("1.2.3").unwrap(), (1, 2, 3));
+    }
+
+    #[test]
+    fn bump_semver() {
+        assert_eq!(bump_version("0.1.0-alpha.0", "patch").unwrap(), "0.1.1");
+        assert_eq!(bump_version("0.1.0-alpha.0", "minor").unwrap(), "0.2.0");
+        assert_eq!(bump_version("0.1.0-alpha.0", "major").unwrap(), "1.0.0");
+        assert_eq!(bump_version("1.2.3", "patch").unwrap(), "1.2.4");
+        assert!(bump_version("1.2.3", "wat").is_err());
+    }
+
+    #[test]
+    fn changelog_top_version_skips_unreleased() {
+        let dir = std::env::temp_dir().join("xtask_top_version");
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("CHANGELOG.md");
+        std::fs::write(&p, "## [Unreleased]\n\n## [0.1.0-alpha.0] - 2026-08-28\n").unwrap();
+        assert_eq!(changelog_top_version(&dir).unwrap(), Some("0.1.0-alpha.0".into()));
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }


### PR DESCRIPTION
Introduce a semver + Keep-a-Changelog policy for the workspace and the
tooling to enforce it.

### Summary of changes

- add `VERSIONING.md` (0.x semver, one release per merge window) and a
  `CHANGELOG.md` backfilled from the Rust rewrite onward.
- add `cargo xtask release` (bump version + freeze changelog) and
  `cargo xtask check-version` (fail on Cargo.toml/CHANGELOG.md drift).
- add a `classic-release` skill and a CI `version` job that runs
  check-version and requires a changelog update when code changes.

(this patch was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
