### PR TITLE
add RTS selection, inventory and drop-preview foundation to the engine

### DIFF
--- a/.claude/skills/classic-ecs/SKILL.md
+++ b/.claude/skills/classic-ecs/SKILL.md
@@ -102,6 +102,18 @@ categories:
   demo find the tilemap/nav/agent/cursor entities — via
   `Engine::entity_by_role(RoleKind::…)`, **not** by name.
 
+- **`Selectable { priority: i32, group: u32 }`** — advertises an entity to the
+  host-owned RTS selection system (`classic-engine/src/selection.rs`).  `group`
+  buckets selectables: `0 = unit` (vehicles/characters), `1 = building/structure`
+  (e.g. a shipping container).  `priority` breaks click-hit ties (higher wins).
+  Plain-click selection semantics are group-aware: clicking a unit replaces the
+  set with it, while clicking a building or empty ground *keeps* any selected
+  unit (a command target, not a re-selection) and only replaces/clears when no
+  unit is selected — so "select unit, click target/ground" survives as a command
+  without deselecting.  Shift-click toggles membership; drag box-selects.
+  `spawn_vehicle` tags vehicle bodies `group: 0`; scene JSON tags buildings
+  `group: 1`.
+
 - **`Camera`** — 2D orthographic camera (`position`, `scale`, runtime-only
   `size`).  Registered as a component so it round-trips through `state.json`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ See [`VERSIONING.md`](VERSIONING.md) for the release policy and process.
 
 ## [Unreleased]
 
+### Added
+
+- `Selectable` component and a host-owned `SelectionSet`
+  (`select_at`/`select_box`/`selected_names`) with unit/building group
+  semantics, plus a per-sprite selection silhouette (#80).
+- Inventory system: item catalog (`ItemId`/`ItemClass`/`StackRule`/`ItemDef`/
+  `InventoryType`/`Inventory`/`ItemRegistry`), host inventory I/O mechanics,
+  and `items`/`inventory_types` in the ROM manifest (#80).
+- Guest SDK surface for selection, inventory and vehicle control
+  (`selected_names`, `selection_clear`, `inventory_*`, `item_def`,
+  `vehicle_set_speed`, `vehicle_probe`, `vehicle_probe_clear`,
+  `get_sprite_frame`, `set_sprite_offset`, `inventory_capacity`) (#80).
+- Drop-preview path overlay and right-click deselect in the demo (#80).
+
 ## [0.1.0-alpha.0] - 2026-08-28
 
 The first recorded release covers the Rust rewrite and everything that landed

--- a/crates/classic-core/src/collision.rs
+++ b/crates/classic-core/src/collision.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use glam::{Mat4, Vec3};
 
-use crate::components::{ColliderData, Shape};
+use crate::components::{ColliderData, ColliderSpace, Shape};
 use crate::gjk::{GjkContext, GjkShape};
 use crate::quadtree::{Quadtree, RectBounds};
 use crate::types::Rect;
@@ -182,6 +182,9 @@ struct ColliderEntry {
     /// serializable component) so they never round-trip through `state.json`.
     handlers: HashMap<HandlerKind, Vec<Box<dyn FnMut() -> bool>>>,
     enabled: bool,
+    /// Screen-space projection of a [`ColliderSpace::World`] collider,
+    /// recomputed each `begin_frame`.  `None` for screen-space colliders.
+    projected: Option<Shape>,
 }
 
 impl ColliderEntry {
@@ -194,6 +197,27 @@ impl ColliderEntry {
     }
 }
 
+/// Project a world-space collider geometry to screen space through the camera
+/// matrix, so a single screen-space quadtree serves both UI (screen) and
+/// gameplay (world) colliders.
+fn project_shape(shape: &Shape, position: Vec3, scale: Vec3, m: Mat4) -> Shape {
+    match shape {
+        Shape::Circle { diameter } => {
+            // The camera scale is uniform; recover it from the x-axis length.
+            let cam_scale = m.transform_vector3(Vec3::X).length();
+            let r = diameter * 0.5 * scale.x * cam_scale;
+            Shape::Circle { diameter: r * 2.0 }
+        }
+        Shape::Polygon { verts, .. } => {
+            let model = Mat4::from_translation(Vec3::new(position.x, position.y, 0.0))
+                * Mat4::from_scale(scale);
+            let projected: Vec<Vec3> =
+                verts.iter().map(|v| m.transform_point3(model.transform_point3(*v))).collect();
+            polygon_from_verts(projected)
+        }
+    }
+}
+
 pub struct PhysicsProvider {
     next_id: u32,
     entries: HashMap<u32, ColliderEntry>,
@@ -203,6 +227,8 @@ pub struct PhysicsProvider {
     screen: Quadtree<ColliderHandle>,
     collided: HashMap<u32, HashMap<u32, bool>>,
     colliding: HashMap<u32, HashMap<u32, bool>>,
+    /// World → screen transform, set by the engine before `begin_frame`.
+    world_to_screen: Mat4,
     /// Set to true when a click handler fires on a collider with `consumes_click`.
     pub consumed_click: bool,
     /// Set by the engine before `perform_calls` — true only on actual mouse presses.
@@ -236,9 +262,16 @@ impl PhysicsProvider {
             screen: Quadtree::new(screen_collider, 10, 4),
             collided: HashMap::new(),
             colliding: HashMap::new(),
+            world_to_screen: Mat4::IDENTITY,
             consumed_click: false,
             mouse_clicked: false,
         }
+    }
+
+    /// Set the world → screen transform used to project [`ColliderSpace::World`]
+    /// colliders.  Call before `begin_frame` each frame.
+    pub fn set_world_to_screen(&mut self, m: Mat4) {
+        self.world_to_screen = m;
     }
 
     pub fn resize_screen(&mut self, w: f32, h: f32) {
@@ -249,8 +282,10 @@ impl PhysicsProvider {
     pub fn register_collider(&mut self, collider: ColliderData) -> u32 {
         let pid = self.next_id;
         self.next_id += 1;
-        self.entries
-            .insert(pid, ColliderEntry { collider, handlers: HashMap::new(), enabled: true });
+        self.entries.insert(
+            pid,
+            ColliderEntry { collider, handlers: HashMap::new(), enabled: true, projected: None },
+        );
         pid
     }
 
@@ -258,10 +293,23 @@ impl PhysicsProvider {
         self.entries.remove(&pid);
     }
 
+    /// Replace a collider's world-space shape in place (used by the engine to
+    /// keep runtime gameplay colliders tracking their entities).  The collider's
+    /// `space` is set to [`ColliderSpace::World`].
+    pub fn update_world_shape(&mut self, pid: u32, shape: Shape) {
+        if let Some(entry) = self.entries.get_mut(&pid) {
+            entry.collider.shape = shape;
+            entry.collider.space = ColliderSpace::World;
+            entry.collider.position = Vec3::ZERO;
+            entry.collider.scale = Vec3::ONE;
+        }
+    }
+
     /// Rebuild a collider's polygon shape from a (0,0)→(w,h) rect at a new position.
     pub fn sync_collider_rect(&mut self, pid: u32, x: f32, y: f32, w: f32, h: f32) {
         if let Some(entry) = self.entries.get_mut(&pid) {
             entry.collider.position = Vec3::new(x, y, 0.0);
+            entry.collider.space = ColliderSpace::Screen;
             let verts = vec![
                 Vec3::new(0.0, 0.0, 0.0),
                 Vec3::new(w, 0.0, 0.0),
@@ -319,6 +367,39 @@ impl PhysicsProvider {
         hits.into_iter().map(|(_, pid)| pid).collect()
     }
 
+    /// Collect the pids of enabled colliders intersecting the screen rectangle
+    /// `(begin_x, begin_y) → (end_x, end_y)`, GJK-tested against the rectangle —
+    /// the same intersect-collection `end_selection` performs, exposed read-only
+    /// for the RTS drag-box selection system.
+    pub fn box_query(&self, begin_x: f32, begin_y: f32, end_x: f32, end_y: f32) -> Vec<u32> {
+        let min = Vec3::new(begin_x.min(end_x), begin_y.min(end_y), 0.0);
+        let max = Vec3::new(begin_x.max(end_x), begin_y.max(end_y), 0.0);
+        let delta = max - min;
+        let rect = Rect::new(min.x, min.y, delta.x.max(1.0), delta.y.max(1.0));
+
+        let sel_shape = polygon_from_verts(vec![
+            Vec3::new(min.x, min.y, 0.0),
+            Vec3::new(max.x, min.y, 0.0),
+            Vec3::new(max.x, max.y, 0.0),
+            Vec3::new(min.x, max.y, 0.0),
+        ]);
+        let sel_ref = ShapeRef { shape: &sel_shape, position: Vec3::ZERO, scale: Vec3::ONE };
+
+        let candidates: Vec<_> = self.screen.retrieve(&rect).iter().copied().cloned().collect();
+        let mut out = Vec::new();
+        for ch in &candidates {
+            if ch.pid <= 1 {
+                continue;
+            }
+            let (shape, pos, scl) = self.shape_of(ch.pid);
+            let entry_ref = ShapeRef { shape, position: pos, scale: scl };
+            if GjkContext::new(&sel_ref, &entry_ref).perform_test() {
+                out.push(ch.pid);
+            }
+        }
+        out
+    }
+
     /// Run GJK test between two collider/virtual entries.
     pub fn gjk_test(&self, a_pid: u32, b_pid: u32) -> bool {
         let (shape_a, pos_a, scl_a) = self.shape_of(a_pid);
@@ -334,7 +415,11 @@ impl PhysicsProvider {
         } else if pid == 1 {
             (&self.selection.shape, self.selection.position, self.selection.scale)
         } else if let Some(e) = self.entries.get(&pid) {
-            (&e.collider.shape, e.collider.position, e.collider.scale)
+            match &e.projected {
+                // World colliders are queried through their screen projection.
+                Some(p) => (p, Vec3::ZERO, Vec3::ONE),
+                None => (&e.collider.shape, e.collider.position, e.collider.scale),
+            }
         } else {
             panic!("unknown collider pid {pid}");
         }
@@ -345,11 +430,24 @@ impl PhysicsProvider {
         let sc = self.screen_collider;
         self.screen = Quadtree::new(sc, 10, 4);
 
-        for (&pid, entry) in &self.entries {
+        for (&pid, entry) in &mut self.entries {
             if !entry.enabled {
                 continue;
             }
-            let r = entry.collider.shape.rect(entry.collider.position, entry.collider.scale);
+            let r = if entry.collider.space == ColliderSpace::World {
+                let projected = project_shape(
+                    &entry.collider.shape,
+                    entry.collider.position,
+                    entry.collider.scale,
+                    self.world_to_screen,
+                );
+                let r = projected.rect(Vec3::ZERO, Vec3::ONE);
+                entry.projected = Some(projected);
+                r
+            } else {
+                entry.projected = None;
+                entry.collider.shape.rect(entry.collider.position, entry.collider.scale)
+            };
             if r.intersects(&sc) {
                 self.screen.insert(ColliderHandle { pid, rect: r });
             }

--- a/crates/classic-core/src/components/mod.rs
+++ b/crates/classic-core/src/components/mod.rs
@@ -62,6 +62,17 @@ impl Role {
     }
 }
 
+/// Marks an entity as selectable by the RTS selection system (host-owned).
+///
+/// `group` buckets selectables for set operations (e.g. units vs buildings);
+/// `priority` breaks click-hit ties (higher wins).  The selection set lives on
+/// the `Engine`, not here — this component only advertises selectability.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Selectable {
+    pub priority: i32,
+    pub group: u32,
+}
+
 /// Render a solid-colour rectangle.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RectRender {
@@ -571,6 +582,21 @@ pub enum Shape {
     Polygon { verts: Vec<Vec3>, center: Vec3, min: Vec3, max: Vec3 },
 }
 
+/// The coordinate space a collider's geometry is authored in.
+///
+/// [`ColliderSpace::Screen`] colliders (UI, the mouse, the selection rubber
+/// band) are already in viewport pixel space.  [`ColliderSpace::World`]
+/// colliders (gameplay footprints) are in world/cartesian space and are
+/// projected to screen every frame by the physics system before any query, so
+/// a single screen-space quadtree serves both.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ColliderSpace {
+    #[default]
+    Screen,
+    World,
+}
+
 /// Collider component — serializable physics data (no runtime handlers).
 ///
 /// Interaction handlers
@@ -587,6 +613,9 @@ pub struct ColliderData {
     pub pid: u32,
     pub consumes_click: bool,
     pub click_priority: i32,
+    /// Coordinate space of `shape`/`position`/`scale`.
+    #[serde(default)]
+    pub space: ColliderSpace,
 }
 
 impl ColliderData {
@@ -599,7 +628,16 @@ impl ColliderData {
             pid: 0,
             consumes_click: false,
             click_priority: 0,
+            space: ColliderSpace::Screen,
         }
+    }
+
+    /// A world-space collider (e.g. a gameplay footprint), projected to screen
+    /// by the physics system before querying.
+    pub fn world(shape: Shape) -> Self {
+        let mut c = Self::new(shape);
+        c.space = ColliderSpace::World;
+        c
     }
 }
 

--- a/crates/classic-core/src/inventory.rs
+++ b/crates/classic-core/src/inventory.rs
@@ -1,0 +1,271 @@
+//! # Skill: `classic-ecs`
+//!
+//! **Read `.claude/skills/classic-ecs/SKILL.md` before working on this module.**
+//!
+//! Item catalog + inventory component types for the container-logistics layer.
+//!
+//! The item catalog is *ROM-namespaced data*: ROM manifests declare `items[]`
+//! and `inventory_types[]`, the host interns the item names into a per-ROM
+//! [`ItemRegistry`] (numeric [`ItemId`]s so hot paths never compare strings),
+//! and [`Inventory`] is a serializable ECS component that round-trips through
+//! the component registry.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// An interned item identifier.  The string name is kept only for
+/// serialization and logging; hot paths compare these integers.
+pub type ItemId = u32;
+
+/// The physical/material class of an item.  [`InventoryType`] scales a
+/// container's capacity per class, so a gas tank stacks [`ItemClass::Gas`]
+/// better than a bulk hopper does.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ItemClass {
+    Ore,
+    Metal,
+    Gas,
+    Fluid,
+    Munition,
+    Electronics,
+    Fuel,
+    Container,
+}
+
+/// How items of a class stack inside an inventory.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(tag = "rule", rename_all = "snake_case")]
+pub enum StackRule {
+    /// Loose solids: capped count per stack.
+    Bulk { max_per_stack: u32 },
+    /// Compressible gases: the effective capacity is the raw capacity scaled
+    /// by `pressure_factor`; still bounded by `max_per_stack` per stack.
+    Gaseous { pressure_factor: f32, max_per_stack: u32 },
+    /// Discrete, non-stacking units (vehicles, munitions boxes).
+    Unit { max_per_stack: u32 },
+}
+
+impl StackRule {
+    /// The maximum number of items allowed in a single stack.
+    pub fn max_per_stack(&self) -> u32 {
+        match *self {
+            StackRule::Bulk { max_per_stack }
+            | StackRule::Gaseous { max_per_stack, .. }
+            | StackRule::Unit { max_per_stack } => max_per_stack,
+        }
+    }
+}
+
+fn default_stack_rule() -> StackRule {
+    StackRule::Unit { max_per_stack: 1 }
+}
+
+/// A catalogued item definition (ROM manifest `items[]`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ItemDef {
+    /// The ROM-namespaced item name (also the interning key).
+    pub name: String,
+    pub class: ItemClass,
+    #[serde(default = "default_stack_rule")]
+    pub stack_rule: StackRule,
+    /// Mass per unit item.  Informational for v1.
+    #[serde(default)]
+    pub mass: f32,
+    /// Volume per unit item.  Informational for v1.
+    #[serde(default)]
+    pub volume: f32,
+}
+
+/// A named inventory type (ROM manifest `inventory_types[]`).  `capacity_mult`
+/// scales an inventory's raw capacity per [`ItemClass`] — "gas containers stack
+/// gas better" — expressed as data, not code.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InventoryType {
+    pub name: String,
+    /// Per-class capacity multipliers.  Absent classes default to `1.0`.
+    #[serde(default)]
+    pub capacity_mult: Vec<(ItemClass, f32)>,
+}
+
+impl InventoryType {
+    /// The capacity multiplier for a class (defaults to `1.0`).
+    pub fn multiplier(&self, class: ItemClass) -> f32 {
+        self.capacity_mult.iter().find(|(c, _)| *c == class).map(|(_, m)| *m).unwrap_or(1.0)
+    }
+}
+
+/// An inventory attached to an entity: a capacity, the item classes it accepts
+/// and provides, and its current stacks (sorted by [`ItemId`] for binary
+/// search).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Inventory {
+    /// Raw capacity, in "units".  [`InventoryType::multiplier`] scales it per
+    /// class at insertion time (see `classic-engine` `inventory.rs`).
+    #[serde(default)]
+    pub capacity: u32,
+    /// The name of the [`InventoryType`] this inventory realizes.
+    #[serde(default)]
+    pub kind: String,
+    /// Item classes this inventory accepts on input.
+    #[serde(default)]
+    pub accepts: Vec<ItemClass>,
+    /// Item classes this inventory provides on output.
+    #[serde(default)]
+    pub provides: Vec<ItemClass>,
+    /// Current contents: `(item id, count)`, sorted ascending by id.
+    #[serde(default)]
+    pub stacks: Vec<(ItemId, u32)>,
+}
+
+impl Inventory {
+    /// Total units currently stored (sum over stacks).
+    pub fn used(&self) -> u32 {
+        self.stacks.iter().map(|(_, n)| *n).sum()
+    }
+
+    /// Free capacity (raw capacity minus used).  Saturating at zero.
+    pub fn free(&self) -> u32 {
+        self.capacity.saturating_sub(self.used())
+    }
+}
+
+/// The host-side item catalog, interned once per ROM at `load_rom`.
+///
+/// Read-only after construction: hot paths look items up by [`ItemId`].
+#[derive(Clone, Debug, Default)]
+pub struct ItemRegistry {
+    /// Item name → interned id.
+    pub by_name: HashMap<String, ItemId>,
+    /// Interned definitions, indexed by [`ItemId`].
+    pub defs: Vec<ItemDef>,
+    /// Inventory types by name.
+    pub inventory_types: HashMap<String, InventoryType>,
+}
+
+impl ItemRegistry {
+    /// Build a registry from manifest data, interning item names in order.
+    pub fn build(items: &[ItemDef], inventory_types: &[InventoryType]) -> Self {
+        let mut reg = Self::default();
+        for def in items {
+            reg.intern(def.clone());
+        }
+        for it in inventory_types {
+            reg.inventory_types.insert(it.name.clone(), it.clone());
+        }
+        reg
+    }
+
+    /// Intern an item definition, returning its id (reusing an existing id if
+    /// the name is already present).
+    pub fn intern(&mut self, def: ItemDef) -> ItemId {
+        if let Some(&id) = self.by_name.get(&def.name) {
+            return id;
+        }
+        let id = self.defs.len() as ItemId;
+        self.defs.push(def.clone());
+        self.by_name.insert(def.name.clone(), id);
+        id
+    }
+
+    /// Look up an item's interned id by name.
+    pub fn id(&self, name: &str) -> Option<ItemId> {
+        self.by_name.get(name).copied()
+    }
+
+    /// The definition for an interned item id.
+    pub fn def(&self, id: ItemId) -> Option<&ItemDef> {
+        self.defs.get(id as usize)
+    }
+
+    /// The inventory type by name.
+    pub fn inventory_type(&self, name: &str) -> Option<&InventoryType> {
+        self.inventory_types.get(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ore() -> ItemDef {
+        ItemDef {
+            name: "regolith_ore".into(),
+            class: ItemClass::Ore,
+            stack_rule: StackRule::Bulk { max_per_stack: 100 },
+            mass: 1.0,
+            volume: 0.5,
+        }
+    }
+
+    #[test]
+    fn interning_reuses_ids_and_looks_up_defs() {
+        let mut reg = ItemRegistry::default();
+        let a = reg.intern(ore());
+        let b = reg.intern(ore());
+        assert_eq!(a, b, "same name interns to the same id");
+        assert_eq!(a, 0);
+
+        let fuel = reg.intern(ItemDef {
+            name: "lox".into(),
+            class: ItemClass::Fuel,
+            stack_rule: StackRule::Gaseous { pressure_factor: 2.0, max_per_stack: 500 },
+            mass: 1.1,
+            volume: 1.0,
+        });
+        assert_eq!(fuel, 1);
+
+        assert_eq!(reg.id("regolith_ore"), Some(0));
+        assert_eq!(reg.id("lox"), Some(1));
+        assert_eq!(reg.id("nope"), None);
+        assert_eq!(reg.def(0).map(|d| d.class), Some(ItemClass::Ore));
+        assert!(reg.def(2).is_none());
+    }
+
+    #[test]
+    fn inventory_type_multipliers_default_to_one() {
+        let ty =
+            InventoryType { name: "gas_tank".into(), capacity_mult: vec![(ItemClass::Gas, 4.0)] };
+        assert_eq!(ty.multiplier(ItemClass::Gas), 4.0);
+        assert_eq!(ty.multiplier(ItemClass::Ore), 1.0);
+    }
+
+    #[test]
+    fn stack_rule_max_per_stack() {
+        assert_eq!(StackRule::Bulk { max_per_stack: 100 }.max_per_stack(), 100);
+        assert_eq!(
+            StackRule::Gaseous { pressure_factor: 2.0, max_per_stack: 500 }.max_per_stack(),
+            500
+        );
+        assert_eq!(StackRule::Unit { max_per_stack: 1 }.max_per_stack(), 1);
+    }
+
+    #[test]
+    fn inventory_used_and_free() {
+        let inv = Inventory { capacity: 100, stacks: vec![(0, 30), (1, 5)], ..Default::default() };
+        assert_eq!(inv.used(), 35);
+        assert_eq!(inv.free(), 65);
+
+        let full = Inventory { capacity: 10, stacks: vec![(0, 99)], ..Default::default() };
+        assert_eq!(full.used(), 99);
+        assert_eq!(full.free(), 0, "free saturates at zero");
+    }
+
+    #[test]
+    fn item_def_defaults_stack_rule_to_unit() {
+        let def: ItemDef = serde_json::from_value(serde_json::json!({
+            "name": "container_box",
+            "class": "container"
+        }))
+        .unwrap();
+        assert_eq!(def.stack_rule.max_per_stack(), 1);
+    }
+
+    #[test]
+    fn item_class_serializes_snake_case() {
+        let s = serde_json::to_value(ItemClass::Electronics).unwrap();
+        assert_eq!(s, "electronics");
+        let back: ItemClass = serde_json::from_value(serde_json::json!("electronics")).unwrap();
+        assert_eq!(back, ItemClass::Electronics);
+    }
+}

--- a/crates/classic-core/src/lib.rs
+++ b/crates/classic-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod collision;
 pub mod components;
 pub mod fields;
 pub mod instrument;
+pub mod inventory;
 pub mod math;
 pub mod registry;
 pub mod sdf_builder;
@@ -16,8 +17,10 @@ pub mod quadtree;
 pub mod simplex_noise;
 
 use components::{
-    Animator, IsoAgent, IsoSprite, IsoVehicle, NavMesh, RectRender, Role, SdfTextRender, Tilemap,
+    Animator, IsoAgent, IsoSprite, IsoVehicle, NavMesh, RectRender, Role, SdfTextRender,
+    Selectable, Tilemap,
 };
+use inventory::Inventory;
 
 pub use camera::Camera;
 pub use components::{RoleKind, SpriteRender, Transform};
@@ -131,6 +134,28 @@ pub fn register_all_components() {
             subsumes: &[],
         },
         ComponentReg {
+            name: "Inventory",
+            spawn: |b, v| {
+                let inv: Inventory = serde_json::from_value(v)?;
+                b.add(inv);
+                Ok(())
+            },
+            dump: Some(dumper_inventory),
+            order: 38,
+            subsumes: &[],
+        },
+        ComponentReg {
+            name: "Selectable",
+            spawn: |b, v| {
+                let s: Selectable = serde_json::from_value(v)?;
+                b.add(s);
+                Ok(())
+            },
+            dump: Some(dumper_selectable),
+            order: 39,
+            subsumes: &[],
+        },
+        ComponentReg {
             name: "IsometricNavMesh",
             spawn: |b, v| {
                 let n: NavMesh = serde_json::from_value(v)?;
@@ -219,6 +244,16 @@ fn dumper_animator(world: &hecs::World, entity: hecs::Entity) -> Option<serde_js
 fn dumper_isovehicle(world: &hecs::World, entity: hecs::Entity) -> Option<serde_json::Value> {
     let v = world.get::<&IsoVehicle>(entity).ok()?;
     serde_json::to_value(&*v).ok().map(|v| component_value("IsoVehicle", v))
+}
+
+fn dumper_inventory(world: &hecs::World, entity: hecs::Entity) -> Option<serde_json::Value> {
+    let inv = world.get::<&Inventory>(entity).ok()?;
+    serde_json::to_value(&*inv).ok().map(|v| component_value("Inventory", v))
+}
+
+fn dumper_selectable(world: &hecs::World, entity: hecs::Entity) -> Option<serde_json::Value> {
+    let s = world.get::<&Selectable>(entity).ok()?;
+    serde_json::to_value(*s).ok().map(|v| component_value("Selectable", v))
 }
 
 fn dumper_navmesh(world: &hecs::World, entity: hecs::Entity) -> Option<serde_json::Value> {

--- a/crates/classic-core/tests/dumpers.rs
+++ b/crates/classic-core/tests/dumpers.rs
@@ -308,3 +308,61 @@ fn role_dumper_round_trips() {
         classic_core::RoleKind::Tilemap
     );
 }
+
+#[test]
+fn selectable_dumper_round_trips() {
+    register_all_components();
+
+    let sel = classic_core::components::Selectable { priority: 5, group: 1 };
+    let mut world = hecs::World::new();
+    let e = world.spawn((sel,));
+
+    let regs = classic_core::registry::ordered_regs();
+    let reg = regs.iter().find(|r| r.name == "Selectable").unwrap();
+    let val = reg.dump.unwrap()(&world, e).unwrap();
+    assert_eq!(val["type"], "Selectable");
+    assert_eq!(val["priority"], 5);
+    assert_eq!(val["group"], 1);
+
+    let mut fields = val.as_object().unwrap().clone();
+    fields.remove("type");
+    let mut builder = hecs::EntityBuilder::new();
+    (reg.spawn)(&mut builder, serde_json::Value::Object(fields)).unwrap();
+    let spawned = world.spawn(builder.build());
+    let back = world.get::<&classic_core::components::Selectable>(spawned).unwrap();
+    assert_eq!((back.priority, back.group), (5, 1));
+}
+
+#[test]
+fn inventory_dumper_round_trips() {
+    register_all_components();
+
+    let inv = classic_core::inventory::Inventory {
+        capacity: 100,
+        kind: "cargo_bay".into(),
+        accepts: vec![classic_core::inventory::ItemClass::Container],
+        provides: vec![],
+        stacks: vec![(0, 1), (1, 4)],
+    };
+    let mut world = hecs::World::new();
+    let e = world.spawn((inv,));
+
+    let regs = classic_core::registry::ordered_regs();
+    let reg = regs.iter().find(|r| r.name == "Inventory").unwrap();
+    let val = reg.dump.unwrap()(&world, e).unwrap();
+    assert_eq!(val["type"], "Inventory");
+    assert_eq!(val["capacity"], 100);
+    assert_eq!(val["kind"], "cargo_bay");
+    assert_eq!(val["accepts"], serde_json::json!(["container"]));
+    assert_eq!(val["stacks"], serde_json::json!([[0, 1], [1, 4]]));
+
+    let mut fields = val.as_object().unwrap().clone();
+    fields.remove("type");
+    let mut builder = hecs::EntityBuilder::new();
+    (reg.spawn)(&mut builder, serde_json::Value::Object(fields)).unwrap();
+    let spawned = world.spawn(builder.build());
+    let back = world.get::<&classic_core::inventory::Inventory>(spawned).unwrap();
+    assert_eq!(back.capacity, 100);
+    assert_eq!(back.kind, "cargo_bay");
+    assert_eq!(back.stacks, vec![(0, 1), (1, 4)]);
+}

--- a/crates/classic-demo/src/editor.rs
+++ b/crates/classic-demo/src/editor.rs
@@ -347,6 +347,11 @@ pub fn init_tool_buttons(engine: &mut Engine, state: &DemoStateRef) {
                 s.editor.agent_selected = es.agent_selected;
             }
             engine.set_guest_flag("agent_selected", es.agent_selected);
+            // RTS selection runs whenever a terrain-paint tool (tile/height/nav)
+            // is NOT active; when one is, the editor brush owns the drag and the
+            // RTS selection is disabled.
+            let rts = !matches!(es.target.as_str(), "tilemap" | "height" | "navMesh");
+            engine.set_guest_flag("rts_selection", rts);
             let open = es.panel_menu_open;
             drop(es);
             engine.set_enabled(menu_panel, open);

--- a/crates/classic-demo/src/hud.rs
+++ b/crates/classic-demo/src/hud.rs
@@ -15,6 +15,29 @@ use glam::{Mat4, Vec2, Vec3, Vec4};
 
 use crate::state::DemoStateRef;
 
+/// Draw the RTS selection rubber band (a screen-space rectangle) while the
+/// player drags a box selection.  `engine.rts_box` is `Some((begin, end))` only
+/// while dragging and outside a terrain-paint tool.
+pub fn draw_rts_rubber_band(engine: &mut Engine) {
+    let Some((begin, end)) = engine.rts_box else { return };
+    let x = begin.x.min(end.x);
+    let y = begin.y.min(end.y);
+    let w = (begin.x - end.x).abs();
+    let h = (begin.y - end.y).abs();
+    if w < 1.0 && h < 1.0 {
+        return;
+    }
+    let Some(gfx) = engine.gfx.as_mut() else { return };
+
+    let model =
+        Mat4::from_translation(Vec3::new(x, y, 0.0)) * Mat4::from_scale(Vec3::new(w, h, 1.0));
+    gfx.draw_rect(&model, &Mat4::IDENTITY, &[0.0, 1.0, 0.0, 0.12], true);
+
+    let verts = vec![x, y, 0.0, x + w, y, 0.0, x + w, y + h, 0.0, x, y + h, 0.0];
+    let buf = GlBuffer::from_slice(&gfx.gl, glow::ARRAY_BUFFER, &verts, glow::STREAM_DRAW);
+    gfx.draw_line_loop(&buf, 4, &Mat4::IDENTITY, &Mat4::IDENTITY, &[0.0, 1.0, 0.0, 0.9]);
+}
+
 /// Route the mouse wheel to the text-demo panel when it is open and under the
 /// cursor, before camera zoom (which runs first in registration order).
 pub fn route_text_scroll(engine: &mut Engine, state: &DemoStateRef) {
@@ -483,8 +506,11 @@ pub fn draw_debug_overlay(engine: &mut Engine, state: &DemoStateRef) {
         }
     }
 
-    // Vehicle path indicators (planned A* routes), gated on KeyV.
-    if state.borrow().debug_vehicle_paths {
+    // Vehicle path indicators (planned A* routes), shown while their vehicle is
+    // selected.  Snapshot the selection + preview paths before borrowing gfx.
+    let selected: Vec<hecs::Entity> = engine.selection().selected.iter().copied().collect();
+    let preview_paths: Vec<Vec<[i32; 2]>> = engine.preview_paths.values().cloned().collect();
+    {
         let tm_entity = engine.entity_by_role(classic_core::RoleKind::Tilemap);
         let Some(gfx) = engine.gfx.as_mut() else { return };
         let cam = engine.camera.matrix();
@@ -502,7 +528,10 @@ pub fn draw_debug_overlay(engine: &mut Engine, state: &DemoStateRef) {
                     tm.height_scale,
                 )
             };
-            for (_e, (vehicle, tf)) in engine.world.query::<(&IsoVehicle, &Transform)>().iter() {
+            for (e, (vehicle, tf)) in engine.world.query::<(&IsoVehicle, &Transform)>().iter() {
+                if !selected.contains(&e) {
+                    continue;
+                }
                 if vehicle.path.is_empty() || vehicle.path_idx >= vehicle.path.len() {
                     continue;
                 }
@@ -553,6 +582,36 @@ pub fn draw_debug_overlay(engine: &mut Engine, state: &DemoStateRef) {
                     glow::STREAM_DRAW,
                 );
                 gfx.draw_line_loop(&rb, 4, &Mat4::IDENTITY, &cam, &[1.0, 0.9, 0.2, 0.95]);
+            }
+
+            // Candidate path from the reachability probe (a drop-preview target),
+            // drawn as an orange strip so the player can see the planned route.
+            let to_world = |px: f32, py: f32| -> [f32; 3] {
+                let h = bilinear_height(&hd, size_x, size_y, px, py);
+                let mut v = Vec3::new(px, py, 0.0);
+                v = iso_to_cart_world.transform_point3(v);
+                v += tilemap_pos;
+                v.y -= h * hs;
+                [v.x, v.y, v.z]
+            };
+            for path in &preview_paths {
+                if path.len() < 2 {
+                    continue;
+                }
+                let mut verts: Vec<f32> = Vec::with_capacity(path.len() * 3);
+                for &[ix, iy] in path {
+                    verts.extend_from_slice(&to_world(ix as f32 + 0.5, iy as f32 + 0.5));
+                }
+                let buf =
+                    GlBuffer::from_slice(&gfx.gl, glow::ARRAY_BUFFER, &verts, glow::STREAM_DRAW);
+                gfx.draw_line_strip(
+                    &buf,
+                    0,
+                    (verts.len() / 3) as i32,
+                    &Mat4::IDENTITY,
+                    &cam,
+                    &[1.0, 0.55, 0.1, 0.95],
+                );
             }
         }
     }

--- a/crates/classic-demo/src/lib.rs
+++ b/crates/classic-demo/src/lib.rs
@@ -160,6 +160,9 @@ pub fn init_engine(gl: Rc<glow::Context>, rom: &Rom) -> Engine {
             let s = state.clone();
             e.add_overlay(move |engine| hud::draw_debug_overlay(engine, &s));
         }
+        {
+            e.add_overlay(hud::draw_rts_rubber_band);
+        }
     }
     testing::install(&mut e, &state);
 

--- a/crates/classic-demo/src/prefabs.rs
+++ b/crates/classic-demo/src/prefabs.rs
@@ -285,7 +285,7 @@ pub fn init_footprint_colliders(engine: &mut Engine) {
         };
 
         let Some((name, shape, terrain_z)) = result else { continue };
-        engine.register_named_collider(&name, ColliderData::new(shape));
+        engine.register_named_collider(&name, ColliderData::world(shape));
         log::debug!("registered footprint collider for sprite '{name}'");
 
         if let Ok(mut tf) = engine.world.get::<&mut Transform>(entity) {
@@ -305,10 +305,6 @@ pub fn init_debug_toggles(engine: &mut Engine, state: &DemoStateRef) {
                 s.editor.debug_footprints = !s.editor.debug_footprints;
                 engine.show_grid = s.editor.debug_footprints;
             }
-        }
-        if engine.input.was_key_pressed("KeyV") {
-            let mut s = state.borrow_mut();
-            s.debug_vehicle_paths = !s.debug_vehicle_paths;
         }
         // F9: dump state.json (tile/nav/height data is inlined).
         if engine.input.was_key_pressed("F9") {

--- a/crates/classic-demo/src/state.rs
+++ b/crates/classic-demo/src/state.rs
@@ -65,8 +65,6 @@ pub struct DemoState {
     pub iso_coord_x_e: Option<Entity>,
     pub iso_coord_y_e: Option<Entity>,
     pub iso_coord_z_e: Option<Entity>,
-    /// Draw each vehicle's planned A* path as a world-space overlay (KeyV).
-    pub debug_vehicle_paths: bool,
     /// The ROM guest runtime (installed by `init_guest`).
     pub guest: Option<Rc<RefCell<Box<dyn classic_guest::GuestRuntime>>>>,
 }
@@ -86,7 +84,6 @@ impl Default for DemoState {
             iso_coord_x_e: None,
             iso_coord_y_e: None,
             iso_coord_z_e: None,
-            debug_vehicle_paths: false,
             guest: None,
         }
     }

--- a/crates/classic-engine/src/inventory.rs
+++ b/crates/classic-engine/src/inventory.rs
@@ -1,0 +1,369 @@
+//! # Skill: `classic-ecs`
+//!
+//! **Read `.claude/skills/classic-ecs/SKILL.md` before working on this module.**
+//!
+//! Generic host-side inventory mechanics over the `classic-core` [`Inventory`]
+//! component and the per-ROM [`ItemRegistry`].  These functions enforce the
+//! I/O rules (accepts/provides, capacity, stack rule); *which* unit moves
+//! *what* *when* is ROM-guest behaviour.
+//!
+//! All rules are pure functions of `(&ItemRegistry, &mut Inventory)` — no GL,
+//! no engine state — so they are natively unit-tested.
+
+use classic_core::inventory::{Inventory, InventoryType, ItemClass, ItemId, ItemRegistry};
+
+use crate::Engine;
+
+/// The effective capacity of an inventory for a given item class: the raw
+/// capacity scaled by the inventory type's per-class multiplier (default 1.0).
+pub fn capacity_for(reg: &ItemRegistry, inv: &Inventory, class: ItemClass) -> u32 {
+    let mult = reg.inventory_type(&inv.kind).map(|t| t.multiplier(class)).unwrap_or(1.0);
+    (inv.capacity as f32 * mult).max(0.0) as u32
+}
+
+/// Whether an inventory accepts the given class on input.
+///
+/// An empty `accepts` list is *closed* (accepts nothing); a non-empty list must
+/// contain the class.
+pub fn accepts(reg: &ItemRegistry, inv: &Inventory, item: ItemId) -> bool {
+    let Some(def) = reg.def(item) else { return false };
+    !inv.accepts.is_empty() && inv.accepts.contains(&def.class)
+}
+
+/// Whether an inventory provides the given class on output.
+///
+/// An empty `provides` list is *closed* (provides nothing).
+pub fn provides(reg: &ItemRegistry, inv: &Inventory, item: ItemId) -> bool {
+    let Some(def) = reg.def(item) else { return false };
+    !inv.provides.is_empty() && inv.provides.contains(&def.class)
+}
+
+/// The stack count of an item already held by an inventory.
+pub fn count(inv: &Inventory, item: ItemId) -> u32 {
+    inv.stacks.binary_search_by_key(&item, |(id, _)| *id).map(|i| inv.stacks[i].1).unwrap_or(0)
+}
+
+/// Insert `n` units of `item`, returning the number actually added (0 = fully
+/// rejected).  Enforces `accepts`, per-class capacity, and the stack rule's
+/// `max_per_stack` (one stack per item id, so `max_per_stack` also caps the
+/// total for that item).
+pub fn add(reg: &ItemRegistry, inv: &mut Inventory, item: ItemId, n: u32) -> u32 {
+    if n == 0 || !accepts(reg, inv, item) {
+        return 0;
+    }
+    let def = match reg.def(item) {
+        Some(d) => d,
+        None => return 0,
+    };
+    let cap = capacity_for(reg, inv, def.class);
+    let used = inv.used();
+    let room = cap.saturating_sub(used);
+    let existing = count(inv, item);
+    let max_stack = def.stack_rule.max_per_stack();
+    let allowed = n.min(room).min(max_stack.saturating_sub(existing));
+
+    if allowed == 0 {
+        return 0;
+    }
+    if let Ok(i) = inv.stacks.binary_search_by_key(&item, |(id, _)| *id) {
+        inv.stacks[i].1 += allowed;
+    } else {
+        // `binary_search_by_key` returns the insertion index on miss.
+        let i = inv.stacks.binary_search_by_key(&item, |(id, _)| *id).unwrap_err();
+        inv.stacks.insert(i, (item, allowed));
+    }
+    allowed
+}
+
+/// Remove `n` units of `item`, returning the number actually removed.  Does not
+/// enforce `provides` (removal is an internal operation); use [`transfer`] for
+/// cross-inventory moves that must honour the output side's rules.
+pub fn remove(inv: &mut Inventory, item: ItemId, n: u32) -> u32 {
+    if n == 0 {
+        return 0;
+    }
+    let Ok(i) = inv.stacks.binary_search_by_key(&item, |(id, _)| *id) else {
+        return 0;
+    };
+    let taken = inv.stacks[i].1.min(n);
+    inv.stacks[i].1 -= taken;
+    if inv.stacks[i].1 == 0 {
+        inv.stacks.remove(i);
+    }
+    taken
+}
+
+/// Transfer up to `n` units of `item` from `from` to `to`, enforcing both
+/// sides' rules (`from.provides` must contain the class, `to.accepts` must
+/// contain the class, and `to`'s capacity/stack rule bound the amount).
+/// Returns the number actually transferred (0 = rejected).
+pub fn transfer(
+    reg: &ItemRegistry,
+    from: &mut Inventory,
+    to: &mut Inventory,
+    item: ItemId,
+    n: u32,
+) -> u32 {
+    if n == 0 || !provides(reg, from, item) || !accepts(reg, to, item) {
+        return 0;
+    }
+    let available = count(from, item);
+    let take = n.min(available);
+    if take == 0 {
+        return 0;
+    }
+    // Reserve the target-side allowance first (so a partial transfer is never
+    // double-counted), then commit both sides.
+    let def = match reg.def(item) {
+        Some(d) => d,
+        None => return 0,
+    };
+    let cap = capacity_for(reg, to, def.class);
+    let to_used = to.used();
+    let room = cap.saturating_sub(to_used);
+    let existing = count(to, item);
+    let max_stack = def.stack_rule.max_per_stack();
+    let amount = take.min(room).min(max_stack.saturating_sub(existing));
+    if amount == 0 {
+        return 0;
+    }
+
+    remove(from, item, amount);
+    add(reg, to, item, amount);
+    amount
+}
+
+/// Resolve an inventory's type by name, if declared.
+pub fn inventory_type<'a>(reg: &'a ItemRegistry, inv: &Inventory) -> Option<&'a InventoryType> {
+    if inv.kind.is_empty() {
+        None
+    } else {
+        reg.inventory_type(&inv.kind)
+    }
+}
+
+impl Engine {
+    /// Serialize a named entity's [`Inventory`] to JSON (empty if it has none).
+    pub fn inventory_dump(&self, name: &str) -> Option<String> {
+        let entity = *self.names.get(name)?;
+        let inv = self.world.get::<&Inventory>(entity).ok()?;
+        serde_json::to_string(&*inv).ok()
+    }
+
+    /// Read a named entity's raw [`Inventory`] capacity.
+    pub fn inventory_capacity(&self, name: &str) -> Option<u32> {
+        let entity = *self.names.get(name)?;
+        self.world.get::<&Inventory>(entity).ok().map(|inv| inv.capacity)
+    }
+
+    /// Serialize an item definition to JSON.
+    pub fn item_def(&self, name: &str) -> Option<String> {
+        let id = self.items.id(name)?;
+        let def = self.items.def(id)?;
+        serde_json::to_string(def).ok()
+    }
+
+    /// Add `n` units of `item` (by name) to a named entity's inventory,
+    /// returning the amount actually added.
+    pub fn inventory_add(&mut self, name: &str, item: &str, n: u32) -> u32 {
+        let Some(item_id) = self.items.id(item) else { return 0 };
+        let Some(&entity) = self.names.get(name) else { return 0 };
+        let Ok(mut inv) = self.world.get::<&mut Inventory>(entity) else { return 0 };
+        add(&self.items, &mut inv, item_id, n)
+    }
+
+    /// Remove `n` units of `item` (by name) from a named entity's inventory,
+    /// returning the amount actually removed.
+    pub fn inventory_remove(&mut self, name: &str, item: &str, n: u32) -> u32 {
+        let Some(item_id) = self.items.id(item) else { return 0 };
+        let Some(&entity) = self.names.get(name) else { return 0 };
+        let Ok(mut inv) = self.world.get::<&mut Inventory>(entity) else { return 0 };
+        remove(&mut inv, item_id, n)
+    }
+
+    /// Transfer up to `n` units of `item` (by name) between two named
+    /// entities' inventories, enforcing both sides' I/O rules.  Returns the
+    /// amount actually transferred.
+    pub fn inventory_transfer(&mut self, from: &str, to: &str, item: &str, n: u32) -> u32 {
+        let Some(item_id) = self.items.id(item) else { return 0 };
+        let (Some(&from_e), Some(&to_e)) = (self.names.get(from), self.names.get(to)) else {
+            return 0;
+        };
+        if from_e == to_e {
+            return 0;
+        }
+        // Take both inventories out (hecs forbids two simultaneous `&mut`
+        // borrows), transfer, then write them back.
+        let Ok((mut from_inv,)) = self.world.remove::<(Inventory,)>(from_e) else { return 0 };
+        let Ok((mut to_inv,)) = self.world.remove::<(Inventory,)>(to_e) else {
+            let _ = self.world.insert(from_e, (from_inv,));
+            return 0;
+        };
+        let moved = transfer(&self.items, &mut from_inv, &mut to_inv, item_id, n);
+        let _ = self.world.insert(from_e, (from_inv,));
+        let _ = self.world.insert(to_e, (to_inv,));
+        moved
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use classic_core::inventory::{Inventory, InventoryType, ItemClass, ItemDef, StackRule};
+
+    fn reg() -> ItemRegistry {
+        let items = vec![
+            ItemDef {
+                name: "regolith_ore".into(),
+                class: ItemClass::Ore,
+                stack_rule: StackRule::Bulk { max_per_stack: 100 },
+                mass: 1.0,
+                volume: 0.5,
+            },
+            ItemDef {
+                name: "lox".into(),
+                class: ItemClass::Fuel,
+                stack_rule: StackRule::Gaseous { pressure_factor: 4.0, max_per_stack: 500 },
+                mass: 1.1,
+                volume: 1.0,
+            },
+            ItemDef {
+                name: "shipping_container".into(),
+                class: ItemClass::Container,
+                stack_rule: StackRule::Unit { max_per_stack: 1 },
+                mass: 2200.0,
+                volume: 33.0,
+            },
+        ];
+        let types = vec![
+            InventoryType { name: "gas_tank".into(), capacity_mult: vec![(ItemClass::Fuel, 4.0)] },
+            InventoryType { name: "cargo_bay".into(), capacity_mult: vec![] },
+        ];
+        ItemRegistry::build(&items, &types)
+    }
+
+    fn cargo_bay() -> Inventory {
+        Inventory {
+            capacity: 100,
+            kind: "cargo_bay".into(),
+            accepts: vec![ItemClass::Ore, ItemClass::Container],
+            provides: vec![ItemClass::Ore, ItemClass::Container],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn add_enforces_accepts_and_capacity() {
+        let reg = reg();
+        let ore = reg.id("regolith_ore").unwrap();
+        let lox = reg.id("lox").unwrap();
+
+        let mut inv = cargo_bay();
+        // Fuel is not in `accepts` → rejected.
+        assert_eq!(add(&reg, &mut inv, lox, 10), 0);
+        // Ore accepted, capped by capacity (100) and max stack (100).
+        assert_eq!(add(&reg, &mut inv, ore, 150), 100);
+        // Now full → further adds rejected.
+        assert_eq!(add(&reg, &mut inv, ore, 1), 0);
+        assert_eq!(inv.used(), 100);
+    }
+
+    #[test]
+    fn add_caps_by_max_per_stack() {
+        let reg = reg();
+        let container = reg.id("shipping_container").unwrap();
+        let mut inv = Inventory {
+            capacity: 10,
+            kind: "cargo_bay".into(),
+            accepts: vec![ItemClass::Container],
+            provides: vec![ItemClass::Container],
+            ..Default::default()
+        };
+        // Unit stack caps at 1 even though capacity allows 10.
+        assert_eq!(add(&reg, &mut inv, container, 3), 1);
+        assert_eq!(count(&inv, container), 1);
+    }
+
+    #[test]
+    fn gaseous_capacity_multiplier_scales_storage() {
+        let reg = reg();
+        let lox = reg.id("lox").unwrap();
+        let mut tank = Inventory {
+            capacity: 100,
+            kind: "gas_tank".into(),
+            accepts: vec![ItemClass::Fuel],
+            provides: vec![ItemClass::Fuel],
+            ..Default::default()
+        };
+        // Raw 100 × 4.0 multiplier = 400 effective, capped by max stack 500.
+        assert_eq!(capacity_for(&reg, &tank, ItemClass::Fuel), 400);
+        assert_eq!(add(&reg, &mut tank, lox, 1000), 400);
+    }
+
+    #[test]
+    fn remove_and_count_round_trip() {
+        let reg = reg();
+        let ore = reg.id("regolith_ore").unwrap();
+        let mut inv = cargo_bay();
+        add(&reg, &mut inv, ore, 50);
+        assert_eq!(count(&inv, ore), 50);
+        assert_eq!(remove(&mut inv, ore, 20), 20);
+        assert_eq!(count(&inv, ore), 30);
+        // Removing an absent item is a no-op.
+        assert_eq!(remove(&mut inv, ore, 999), 30);
+        assert_eq!(count(&inv, ore), 0);
+    }
+
+    #[test]
+    fn transfer_enforces_both_sides() {
+        let reg = reg();
+        let ore = reg.id("regolith_ore").unwrap();
+
+        let mut mine = Inventory {
+            capacity: 100,
+            accepts: vec![ItemClass::Ore],
+            provides: vec![ItemClass::Ore],
+            stacks: vec![(ore, 40)],
+            ..Default::default()
+        };
+        let mut hopper = cargo_bay();
+
+        // `mine` provides ore, `hopper` accepts ore → ok.
+        assert_eq!(transfer(&reg, &mut mine, &mut hopper, ore, 25), 25);
+        assert_eq!(count(&mine, ore), 15);
+        assert_eq!(count(&hopper, ore), 25);
+
+        // A hopper that does not *provide* ore cannot send it back.
+        let mut closed = Inventory {
+            capacity: 100,
+            accepts: vec![ItemClass::Ore],
+            provides: vec![], // closed output
+            stacks: vec![(ore, 5)],
+            ..Default::default()
+        };
+        assert_eq!(transfer(&reg, &mut closed, &mut hopper, ore, 5), 0);
+    }
+
+    #[test]
+    fn transfer_clamps_to_target_capacity() {
+        let reg = reg();
+        let ore = reg.id("regolith_ore").unwrap();
+
+        let mut mine = Inventory {
+            capacity: 1000,
+            accepts: vec![ItemClass::Ore],
+            provides: vec![ItemClass::Ore],
+            stacks: vec![(ore, 1000)],
+            ..Default::default()
+        };
+        let mut tiny = Inventory {
+            capacity: 10,
+            accepts: vec![ItemClass::Ore],
+            provides: vec![],
+            ..Default::default()
+        };
+        assert_eq!(transfer(&reg, &mut mine, &mut tiny, ore, 500), 10);
+        assert_eq!(count(&tiny, ore), 10);
+        assert_eq!(count(&mine, ore), 990);
+    }
+}

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -15,6 +15,8 @@
 
 pub mod env_config;
 pub mod golden;
+pub mod inventory;
+pub mod selection;
 pub mod ui;
 pub mod vehicle;
 
@@ -26,8 +28,8 @@ use std::sync::Arc;
 
 use classic_core::collision::PhysicsProvider;
 use classic_core::components::{
-    Animator, ColliderData, DebugName, IsoSprite, NavMesh, RectRender, Role, SdfTextRender,
-    TextJustify, Tilemap, UiAlign, UiAnchor, UiNode,
+    Animator, ColliderData, DebugName, IsoSprite, IsoVehicle, NavMesh, RectRender, Role,
+    SdfTextRender, Selectable, TextJustify, Tilemap, UiAlign, UiAnchor, UiNode,
 };
 use classic_core::instrument::Chan;
 use classic_core::math::{cartesian_to_iso_4, iso_to_cartesian_4};
@@ -48,6 +50,15 @@ use glam::{Mat3, Mat4, Vec2, Vec3, Vec4};
 use glow::HasContext;
 
 type UpdateFn = Box<dyn FnMut(&mut Engine)>;
+
+/// Screen-space drag distance below which a selection gesture is a click
+/// (point-select) rather than a drag box.
+const RTS_DRAG_THRESHOLD_PX: f32 = 4.0;
+
+/// The RTS selection silhouette colour (bright green) and its outline width in
+/// content pixels.
+const SELECTION_COLOR: [f32; 3] = [0.25, 1.0, 0.35];
+const OUTLINE_RADIUS_PX: f32 = 1.0;
 
 /// An interaction event queued for a ROM guest.
 #[derive(Clone, Debug)]
@@ -96,6 +107,8 @@ struct IsoDraw {
     normal_map: Option<String>,
     ghost_group: u32,
     color: [f32; 4],
+    /// Whether the sprite is currently RTS-selected (draws a silhouette edge).
+    selected: bool,
 }
 
 impl IsoDraw {
@@ -155,6 +168,15 @@ pub struct Engine {
     /// Collider pid → entity name, populated by `register_named_collider` so the
     /// guest `pick_at` can resolve a screen point to a gameplay entity.
     collider_names: HashMap<u32, String>,
+    /// Entity name → collider pid (the reverse of `collider_names`), so the
+    /// engine can update a named entity's collider in place instead of
+    /// re-registering it every frame.
+    collider_pids: HashMap<String, u32>,
+    /// The host-owned RTS selection set (see `selection.rs`).
+    pub selection: selection::SelectionSet,
+    /// Active RTS drag-box rubber band, `Some((begin, end))` in screen space
+    /// while dragging, `None` otherwise.
+    pub rts_box: Option<(Vec2, Vec2)>,
     /// Entity names the guest has subscribed to for interaction events.
     subscribed: HashSet<String>,
     /// Events queued for the guest, drained via `poll_event`.
@@ -188,6 +210,9 @@ pub struct Engine {
     /// Wheeled-vehicle definitions keyed by name, loaded from the ROM's
     /// `vehicles` resources at boot.
     pub vehicles: HashMap<String, classic_core::types::VehicleDef>,
+    /// The ROM-namespaced item catalog, interned once at `load_rom`.  Read-only
+    /// after load; the inventory mechanics look items up by [`ItemId`].
+    pub items: classic_core::inventory::ItemRegistry,
     /// Next per-instance stencil ghost-group id handed out by `spawn_vehicle`
     /// (1..=255; 0 is reserved for ungrouped sprites).
     next_ghost_group: u32,
@@ -232,6 +257,11 @@ pub struct Engine {
     sync_vehicle_paths: HashMap<u64, vehicle::VehicleGotoPoll>,
     /// Vehicle entity for each in-flight vehicle path request id.
     vehicle_path_entities: HashMap<u64, hecs::Entity>,
+    /// Candidate vehicle path waypoints, keyed by vehicle name, computed by the
+    /// non-mutating `vehicle_probe` and drawn by the demo overlay as a preview.
+    pub preview_paths: HashMap<String, Vec<[i32; 2]>>,
+    /// The single in-flight (or cached) vehicle reachability probe, if any.
+    preview_probe: Option<vehicle::PreviewProbe>,
     /// Next background-task id handed to a guest.
     next_task_id: u64,
     /// Background guest worker (Tier 3): a second `.wasm` instance running pure
@@ -309,6 +339,7 @@ impl Engine {
             namespace: String::new(),
             physics: PhysicsProvider::new(),
             collider_names: HashMap::new(),
+            collider_pids: HashMap::new(),
             subscribed: HashSet::new(),
             guest_events: VecDeque::new(),
             guest_hover: None,
@@ -325,11 +356,14 @@ impl Engine {
             texture_depths: HashMap::new(),
             texture_normals: HashMap::new(),
             vehicles: HashMap::new(),
+            items: classic_core::inventory::ItemRegistry::default(),
             next_ghost_group: 1,
             rom_manifest_json: None,
             rom_manifest: None,
             rom_resources: None,
             ui: None,
+            selection: selection::SelectionSet::default(),
+            rts_box: None,
             selection_mode: -1,
             selection_begin_screen: glam::Vec3::new(-1.0, -1.0, -1.0),
             base_height_scale: 32.0,
@@ -350,6 +384,8 @@ impl Engine {
             )),
             sync_vehicle_paths: HashMap::new(),
             vehicle_path_entities: HashMap::new(),
+            preview_paths: HashMap::new(),
+            preview_probe: None,
             next_task_id: 0,
             guest_worker: None,
             fields: fields::FieldRegistry::default(),
@@ -535,6 +571,10 @@ impl Engine {
         self.init_gfx(gl, &rom.manifest, &rom.resources);
         self.load_state(&rom.state).expect("load ROM state");
         self.load_grids(&rom.resources);
+        self.items = classic_core::inventory::ItemRegistry::build(
+            &rom.manifest.items,
+            &rom.manifest.inventory_types,
+        );
         self.rom_manifest_json = Some(rom.manifest_json.clone());
         self.rom_manifest = Some(rom.manifest.clone());
         self.rom_resources = Some(rom.resources.clone());
@@ -1079,6 +1119,12 @@ impl Engine {
         true
     }
 
+    /// Read a named entity's `IsoSprite` frame index.
+    pub fn get_sprite_frame(&self, name: &str) -> Option<f32> {
+        let entity = *self.names.get(name)?;
+        self.world.get::<&IsoSprite>(entity).ok().map(|s| s.frame)
+    }
+
     /// Set a named entity's `IsoSprite` tint colour (RGBA).
     pub fn set_sprite_color(&mut self, name: &str, color: [f32; 4]) -> bool {
         let Some(&entity) = self.names.get(name) else { return false };
@@ -1087,13 +1133,26 @@ impl Engine {
         true
     }
 
+    /// Set a named entity's `IsoSprite` visual offset (`frame_offset`, in world
+    /// pixels; negative Y lifts the sprite on screen).  Lets guests elevate a
+    /// runtime sprite (e.g. a container sliding out of a rocket).  Only valid
+    /// for sprites without an animator or vehicle sim that overwrites
+    /// `frame_offset` each frame.
+    pub fn set_sprite_offset(&mut self, name: &str, dx: f32, dy: f32, dz: f32) -> bool {
+        let Some(&entity) = self.names.get(name) else { return false };
+        let Ok(mut sprite) = self.world.get::<&mut IsoSprite>(entity) else { return false };
+        sprite.frame_offset = glam::Vec3::new(dx, dy, dz);
+        true
+    }
+
     /// Spawn a new `IsoSprite` entity cloned from a template entity (e.g. a
     /// mouse-follow placement ghost), so a guest can drop copies at runtime.
     /// Copies the template's `IsoSprite` and `Transform` (the latter carries the
-    /// live position written by `set_pos`); the caller then adjusts the clone
-    /// with `set_pos`/`set_sprite_frame`/`set_sprite_color` as usual.  Returns
-    /// `false` when the name is taken, the template is unknown, or the template
-    /// has no `IsoSprite`.
+    /// live position written by `set_pos`), plus any gameplay markers
+    /// (`Selectable`, `Inventory`) the template carries; the caller then adjusts
+    /// the clone with `set_pos`/`set_sprite_frame`/`set_sprite_color` as usual.
+    /// Returns `false` when the name is taken, the template is unknown, or the
+    /// template has no `IsoSprite`.
     pub fn spawn_sprite_clone(&mut self, template: &str, name: &str) -> bool {
         if self.names.contains_key(name) {
             return false;
@@ -1109,7 +1168,23 @@ impl Engine {
             .ok()
             .map(|t| (*t).clone())
             .unwrap_or_else(|| Transform::new(sprite.position, sprite.scale));
-        let entity = self.world.spawn((sprite, transform));
+        let selectable = self.world.get::<&Selectable>(template_entity).ok().map(|s| *s);
+        let inventory = self
+            .world
+            .get::<&classic_core::inventory::Inventory>(template_entity)
+            .ok()
+            .map(|i| (*i).clone());
+
+        let mut builder = hecs::EntityBuilder::new();
+        builder.add(sprite);
+        builder.add(transform);
+        if let Some(s) = selectable {
+            builder.add(s);
+        }
+        if let Some(inv) = inventory {
+            builder.add(inv);
+        }
+        let entity = self.world.spawn(builder.build());
         self.register_named_entity(name, entity);
         true
     }
@@ -1129,6 +1204,33 @@ impl Engine {
         let iso = Mat4::from_scale(tm.scale) * cartesian_to_iso_4().inverse();
         let p = iso.transform_point3(Vec3::new(x, y, 0.0));
         Some((p.x, p.y))
+    }
+
+    /// The world → screen transform for the current frame, derived from the
+    /// camera (`T(-fix) · S(scale)`), matching the sprite/terrain projection.
+    fn world_to_screen_matrix(&self, vw: f32, vh: f32) -> Mat4 {
+        let size = Vec3::new(vw, vh, 0.0);
+        let fix = self.camera.position * self.camera.scale - size / Vec3::new(2.0, 2.0, 1.0);
+        Mat4::from_translation(-fix) * Mat4::from_scale(self.camera.scale)
+    }
+
+    /// Project an iso tile coordinate (at terrain height) to screen pixels
+    /// (top-left origin), matching the engine's sprite model + camera math.
+    pub fn iso_to_screen_px(&self, x: f32, y: f32) -> Option<(f32, f32)> {
+        let tm_entity = self.entity_by_role(RoleKind::Tilemap)?;
+        let tm = self.world.get::<&Tilemap>(tm_entity).ok()?;
+        let tm_tf = self.world.get::<&Transform>(tm_entity).ok()?;
+
+        let iso_to_cart_world = iso_to_cartesian_4() * Mat4::from_scale(tm_tf.scale);
+        let mut world = iso_to_cart_world.transform_point3(Vec3::new(x, y, 0.0));
+        world += tm_tf.position;
+        let h = bilinear_height(&tm.height_data, tm.size_x, tm.size_y, x, y);
+        world.y -= h * tm.height_scale;
+
+        let (vw, vh) = self.viewport_size();
+        let cam = self.world_to_screen_matrix(vw, vh);
+        let screen = cam.transform_point3(world);
+        Some((screen.x, screen.y))
     }
 
     /// Terrain height (in world z units) at the given iso tile coordinate.
@@ -1591,6 +1693,7 @@ impl Engine {
     pub fn register_named_collider(&mut self, name: &str, collider: ColliderData) -> u32 {
         let pid = self.physics.register_collider(collider);
         self.collider_names.insert(pid, name.to_string());
+        self.collider_pids.insert(name.to_string(), pid);
         pid
     }
 
@@ -2083,6 +2186,10 @@ impl Engine {
             }
         }
 
+        // Sync world-space colliders for selectable entities, then project them
+        // (and any other World colliders) to screen before rebuilding the tree.
+        self.sync_selectable_colliders();
+        self.physics.set_world_to_screen(self.world_to_screen_matrix(vw, vh));
         self.physics.begin_frame();
         classic_core::cl_debug!(classic_core::instrument::Chan::Collision, "begin_frame");
         self.physics.mouse.position = Vec3::new(mp.x, mp.y, 0.0);
@@ -2135,10 +2242,27 @@ impl Engine {
             self.physics.begin_selection(Vec3::new(mp.x, mp.y, 0.0));
         }
 
+        // Right-click clears the RTS selection (and, via the guest's
+        // `selected_names`, any in-progress drop preview).
+        if self.input.was_mouse_pressed(1) && !self.guest_flag("ui_consumed_click") {
+            self.selection_clear();
+        }
+
         // Stretch selection rect every frame while dragging.
         if self.selection_mode == 1 {
             self.physics.update_selection(self.selection_begin_screen, Vec3::new(mp.x, mp.y, 0.0));
         }
+
+        // RTS rubber band (screen-space rectangle), shown only while dragging and
+        // a terrain-paint tool is not active.
+        self.rts_box = if self.selection_mode == 1 && self.guest_flag("rts_selection") {
+            Some((
+                Vec2::new(self.selection_begin_screen.x, self.selection_begin_screen.y),
+                Vec2::new(mp.x, mp.y),
+            ))
+        } else {
+            None
+        };
 
         // Frame ordering: demo pre-update hooks run BEFORE on_update closures.
         // The camera's on_update runs first in registration order and would
@@ -2246,6 +2370,22 @@ impl Engine {
             }
             self.physics.end_selection();
 
+            // RTS selection (host-owned): click = point-select, drag = box-select,
+            // shift = additive.  Gated on `rts_selection` (cleared while a
+            // terrain-paint tool owns the drag gesture).
+            if just_finished_selection && self.guest_flag("rts_selection") {
+                let begin = Vec2::new(self.selection_begin_screen.x, self.selection_begin_screen.y);
+                let end = Vec2::new(mp.x, mp.y);
+                let additive =
+                    self.input.is_key_down("ShiftLeft") || self.input.is_key_down("ShiftRight");
+                if (end - begin).length() < RTS_DRAG_THRESHOLD_PX {
+                    self.select_at(end.x, end.y, additive);
+                } else {
+                    self.select_box((begin.x, begin.y), (end.x, end.y), additive);
+                }
+            }
+            self.rts_box = None;
+
             // Editor paint on selection-end (registered by the demo).
             if just_finished_selection {
                 let mut hooks = std::mem::take(&mut self.selection_end_hooks);
@@ -2334,6 +2474,10 @@ impl Engine {
         let name_by_entity: HashMap<hecs::Entity, &str> =
             entity_names.iter().map(|(e, n)| (*e, n.as_str())).collect();
 
+        // The tilemap's paint highlight only shows when a terrain tool owns the
+        // drag; under RTS selection the tilemap selection is off.
+        let paint_mode = if self.guest_flag("rts_selection") { -1 } else { self.selection_mode };
+
         let Some(gfx) = self.gfx.as_mut() else { return };
         let vp = gfx.viewport_w;
         let vh2 = gfx.viewport_h;
@@ -2361,6 +2505,27 @@ impl Engine {
         // Model matrix z MUST stay inside [-10000, 10000] — the orthographic
         // projection clips everything outside. The sort key can differ from
         // the model z. Cursor uses sort_z=-20000 but model_z=-10000.
+        // Expand the selection set to include a selected vehicle's wheels and
+        // steering tires, so the silhouette outlines the whole vehicle, not
+        // just its body.
+        let mut visual_selected: HashSet<hecs::Entity> =
+            self.selection.selected.iter().copied().collect();
+        {
+            let selected: Vec<hecs::Entity> = self.selection.selected.iter().copied().collect();
+            for entity in selected {
+                if let Ok(veh) = self.world.get::<&IsoVehicle>(entity) {
+                    for name in veh.wheel_entities.iter().chain(veh.tire_entities.iter()) {
+                        if name.is_empty() {
+                            continue;
+                        }
+                        if let Some(&part) = self.names.get(name) {
+                            visual_selected.insert(part);
+                        }
+                    }
+                }
+            }
+        }
+
         // Precompute isometric-sprite draw params once, shared by the normal
         // and ghost passes below.
         let mut iso_draws: Vec<IsoDraw> = Vec::new();
@@ -2458,6 +2623,7 @@ impl Engine {
                 normal_map,
                 ghost_group: iso_sprite.ghost_group,
                 color: iso_sprite.color,
+                selected: visual_selected.contains(entity),
             });
         }
 
@@ -2584,7 +2750,7 @@ impl Engine {
                     &[tm.size_x as f32, tm.size_y as f32],
                     &[tm.mouse_iso_pos.x, tm.mouse_iso_pos.y],
                     &[tm.selection_iso_begin.x, tm.selection_iso_begin.y],
-                    self.selection_mode,
+                    paint_mode,
                     &[0.0, 1.0, 1.0, 1.0],
                     &RenderSettings {
                         ambient: self.light_ambient,
@@ -2648,6 +2814,9 @@ impl Engine {
                 &sprite_settings,
                 draw.ghost_group,
                 IsoSpritePass::Normal,
+                draw.selected,
+                &SELECTION_COLOR,
+                OUTLINE_RADIUS_PX,
             );
         }
 
@@ -2667,6 +2836,9 @@ impl Engine {
                 &sprite_settings,
                 draw.ghost_group,
                 IsoSpritePass::Ghost,
+                draw.selected,
+                &SELECTION_COLOR,
+                OUTLINE_RADIUS_PX,
             );
         }
 

--- a/crates/classic-engine/src/selection.rs
+++ b/crates/classic-engine/src/selection.rs
@@ -1,0 +1,399 @@
+//! # Skill: `classic-physics`
+//!
+//! **Read `.claude/skills/classic-physics/SKILL.md` before working on this module.**
+//!
+//! Host-owned RTS selection.  The [`SelectionSet`] lives on the [`Engine`] and
+//! is driven by the host's click/drag-box/shift input (see `Engine::frame`);
+//! ROM guests read the set through `selected_names()` and can clear it through
+//! `selection_clear()`.  Hit-testing walks the physics `point_query`/`box_query`
+//! results (collider pid → name → entity) and gates on the [`Selectable`]
+//! component.
+
+use std::collections::BTreeSet;
+
+use classic_core::collision::polygon_from_verts;
+use classic_core::components::{
+    ColliderData, DebugName, IsoSprite, IsoVehicle, Selectable, Tilemap,
+};
+use classic_core::math::iso_to_cartesian_4;
+use classic_core::tilemap::bilinear_height;
+use classic_core::{RoleKind, Transform};
+use glam::{Mat4, Vec2, Vec3};
+
+use crate::Engine;
+
+/// The current RTS selection: a set of entity handles plus a monotonic
+/// `version` bumped on every membership change.
+#[derive(Clone, Debug, Default)]
+pub struct SelectionSet {
+    pub selected: BTreeSet<hecs::Entity>,
+    pub version: u64,
+}
+
+impl SelectionSet {
+    pub fn is_empty(&self) -> bool {
+        self.selected.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.selected.len()
+    }
+
+    pub fn contains(&self, e: hecs::Entity) -> bool {
+        self.selected.contains(&e)
+    }
+}
+
+impl Engine {
+    /// The current selection set (read-only).
+    pub fn selection(&self) -> &SelectionSet {
+        &self.selection
+    }
+
+    /// Select the top selectable entity under a screen point.  A plain click
+    /// (`additive == false`) uses unit/building group semantics: clicking a
+    /// unit replaces the set with it, while clicking a building or empty ground
+    /// keeps any selected unit (a command target, not a re-selection) and only
+    /// replaces/clears when no unit is selected.  A shift-click (`additive ==
+    /// true`) toggles membership.
+    pub fn select_at(&mut self, x: f32, y: f32, additive: bool) {
+        let hit = self.selectable_at(x, y);
+        let before = self.selection.selected.clone();
+        if additive {
+            if let Some((e, _group)) = hit {
+                if !self.selection.selected.remove(&e) {
+                    self.selection.selected.insert(e);
+                }
+            }
+        } else {
+            let has_unit = self.has_selected_unit();
+            match hit {
+                Some((e, 0)) => {
+                    // Click a unit → select only it.
+                    self.selection.selected.clear();
+                    self.selection.selected.insert(e);
+                }
+                Some((e, _group)) => {
+                    // Click a building → keep a selected unit (command), else
+                    // select the building.
+                    if !has_unit {
+                        self.selection.selected.clear();
+                        self.selection.selected.insert(e);
+                    }
+                }
+                None => {
+                    // Click empty ground → keep a selected unit (move command),
+                    // else clear.
+                    if !has_unit {
+                        self.selection.selected.clear();
+                    }
+                }
+            }
+        }
+        if self.selection.selected != before {
+            self.selection.version += 1;
+        }
+    }
+
+    /// Whether the selection contains a unit (`Selectable.group == 0`), i.e. a
+    /// vehicle/character rather than a building/structure.
+    pub fn has_selected_unit(&self) -> bool {
+        self.selection
+            .selected
+            .iter()
+            .any(|e| self.world.get::<&Selectable>(*e).map(|s| s.group == 0).unwrap_or(false))
+    }
+
+    /// Select every selectable entity whose collider intersects the screen
+    /// rectangle `begin → end`.  `additive` adds to the current set instead of
+    /// replacing it.
+    pub fn select_box(&mut self, begin: (f32, f32), end: (f32, f32), additive: bool) {
+        let hits = self.selectables_in_box(begin, end);
+        let before = self.selection.selected.clone();
+        if additive {
+            for e in hits {
+                self.selection.selected.insert(e);
+            }
+        } else {
+            self.selection.selected = hits.into_iter().collect();
+        }
+        if self.selection.selected != before {
+            self.selection.version += 1;
+        }
+    }
+
+    /// Clear the selection (bumps `version` only if it was non-empty).
+    pub fn selection_clear(&mut self) {
+        if !self.selection.selected.is_empty() {
+            self.selection.selected.clear();
+            self.selection.version += 1;
+        }
+    }
+
+    /// The debug names of the currently-selected entities.
+    pub fn selected_names(&self) -> Vec<String> {
+        self.selection
+            .selected
+            .iter()
+            .filter_map(|e| self.world.get::<&DebugName>(*e).ok().map(|n| n.0.clone()))
+            .collect()
+    }
+
+    /// The top [`Selectable`] entity under a screen point, plus its `group`, if
+    /// any.
+    fn selectable_at(&self, x: f32, y: f32) -> Option<(hecs::Entity, u32)> {
+        self.physics.point_query(x, y).into_iter().find_map(|pid| {
+            let name = self.collider_names.get(&pid)?;
+            let entity = self.names.get(name)?;
+            if self.is_disabled(*entity) {
+                return None;
+            }
+            let sel = self.world.get::<&Selectable>(*entity).ok()?;
+            Some((*entity, sel.group))
+        })
+    }
+
+    /// The [`Selectable`] entities whose colliders intersect a screen rectangle.
+    fn selectables_in_box(&self, begin: (f32, f32), end: (f32, f32)) -> Vec<hecs::Entity> {
+        self.physics
+            .box_query(begin.0, begin.1, end.0, end.1)
+            .into_iter()
+            .filter_map(|pid| {
+                let name = self.collider_names.get(&pid)?;
+                let entity = self.names.get(name)?;
+                (!self.is_disabled(*entity) && self.world.get::<&Selectable>(*entity).is_ok())
+                    .then_some(*entity)
+            })
+            .collect()
+    }
+
+    /// The footprint corners (iso tile space, relative to the sprite position)
+    /// used to build a selectable entity's collider: the `IsoSprite.footprint`
+    /// when present, else the vehicle's `path_footprint` AABB, else a default
+    /// unit diamond.
+    fn selectable_footprint(&self, entity: hecs::Entity) -> Vec<Vec2> {
+        if let Ok(s) = self.world.get::<&IsoSprite>(entity) {
+            if !s.footprint.is_empty() {
+                return s.footprint.clone();
+            }
+        }
+        if let Ok(v) = self.world.get::<&IsoVehicle>(entity) {
+            if !v.path_footprint.is_empty() {
+                let min_x = v.path_footprint.iter().map(|o| o.0).min().unwrap_or(0) as f32 - 0.5;
+                let max_x = v.path_footprint.iter().map(|o| o.0).max().unwrap_or(0) as f32 + 0.5;
+                let min_y = v.path_footprint.iter().map(|o| o.1).min().unwrap_or(0) as f32 - 0.5;
+                let max_y = v.path_footprint.iter().map(|o| o.1).max().unwrap_or(0) as f32 + 0.5;
+                return vec![
+                    Vec2::new(max_x, min_y),
+                    Vec2::new(max_x, max_y),
+                    Vec2::new(min_x, max_y),
+                    Vec2::new(min_x, min_y),
+                ];
+            }
+        }
+        vec![Vec2::new(0.5, -0.5), Vec2::new(0.5, 0.5), Vec2::new(-0.5, 0.5), Vec2::new(-0.5, -0.5)]
+    }
+
+    /// Build the world-space footprint polygon for a selectable entity (iso
+    /// footprint corners → world cartesian, height-lifted like the sprite model).
+    fn selectable_world_polygon(
+        &self,
+        tm_entity: hecs::Entity,
+        iso_to_cart_world: &Mat4,
+        tilemap_pos: Vec3,
+        pos: Vec2,
+        footprint: &[Vec2],
+    ) -> Option<classic_core::components::Shape> {
+        let tm = self.world.get::<&Tilemap>(tm_entity).ok()?;
+        let hd = &tm.height_data;
+        let sx = tm.size_x;
+        let sy = tm.size_y;
+        let hs = tm.height_scale;
+        let mut world_verts = Vec::with_capacity(footprint.len());
+        for pt in footprint {
+            let px = pos.x + pt.x;
+            let py = pos.y + pt.y;
+            let h = bilinear_height(hd, sx, sy, px, py);
+            let mut v = iso_to_cart_world.transform_point3(Vec3::new(px, py, 0.0));
+            v += tilemap_pos;
+            v.y -= h * hs;
+            world_verts.push(v);
+        }
+        Some(polygon_from_verts(world_verts))
+    }
+
+    /// Ensure every selectable entity has an up-to-date world-space collider
+    /// (projected to screen by the physics system each frame).  Runs every frame
+    /// before `begin_frame`; creates colliders on first sight and updates them in
+    /// place afterwards.  Disabled entities are skipped.
+    pub fn sync_selectable_colliders(&mut self) {
+        let Some(tm_entity) = self.entity_by_role(RoleKind::Tilemap) else { return };
+
+        let (iso_to_cart_world, tilemap_pos) = {
+            let Some(tm_tf) = self.world.get::<&Transform>(tm_entity).ok() else { return };
+            (iso_to_cartesian_4() * Mat4::from_scale(tm_tf.scale), tm_tf.position)
+        };
+
+        // Phase 1: gather (name, world polygon) for every visible selectable.
+        let mut updates: Vec<(String, classic_core::components::Shape)> = Vec::new();
+        {
+            // Position comes from `Transform`, not `IsoSprite.position`: the
+            // latter is only written at spawn/clone time and goes stale once an
+            // entity moves (the vehicle sim and `set_pos` both write `Transform`
+            // exclusively).  Reading `IsoSprite.position` left a moved LRV's
+            // collider stuck at its spawn point, so it stopped being clickable
+            // after driving away.
+            let mut query = self.world.query::<(&Selectable, &IsoSprite, &Transform)>();
+            for (entity, (_sel, _sprite, tf)) in query.iter() {
+                if self.is_disabled(entity) {
+                    continue;
+                }
+                let pos = Vec2::new(tf.position.x, tf.position.y);
+                let footprint = self.selectable_footprint(entity);
+                if let Some(shape) = self.selectable_world_polygon(
+                    tm_entity,
+                    &iso_to_cart_world,
+                    tilemap_pos,
+                    pos,
+                    &footprint,
+                ) {
+                    updates.push((self.debug_name(entity), shape));
+                }
+            }
+        }
+
+        // Phase 2: register or update colliders in place.
+        for (name, shape) in updates {
+            if let Some(&pid) = self.collider_pids.get(&name) {
+                self.physics.update_world_shape(pid, shape);
+            } else {
+                self.register_named_collider(&name, ColliderData::world(shape));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use classic_core::components::Selectable;
+
+    /// Spawn a named selectable entity with an AABB collider at `(x, y, w, h)`.
+    fn add_selectable(engine: &mut Engine, name: &str, x: f32, y: f32, w: f32, h: f32, group: u32) {
+        assert!(engine.spawn_named(name));
+        let entity = *engine.names.get(name).unwrap();
+        engine.world.insert_one(entity, Selectable { priority: 0, group }).unwrap();
+        engine.spawn_collider(name, x, y, w, h);
+    }
+
+    #[test]
+    fn click_selects_top_entity_only() {
+        let mut e = Engine::new_for_test();
+        add_selectable(&mut e, "a", 10.0, 10.0, 10.0, 10.0, 0);
+        add_selectable(&mut e, "b", 30.0, 10.0, 10.0, 10.0, 0);
+        e.physics.begin_frame();
+
+        e.select_at(15.0, 15.0, false);
+        assert_eq!(e.selected_names(), vec!["a".to_string()]);
+
+        // A plain click on empty ground keeps the selected unit (a move command).
+        e.select_at(100.0, 100.0, false);
+        assert_eq!(e.selected_names(), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn click_building_with_unit_selected_keeps_unit() {
+        let mut e = Engine::new_for_test();
+        add_selectable(&mut e, "a", 10.0, 10.0, 10.0, 10.0, 0);
+        add_selectable(&mut e, "bldg", 60.0, 60.0, 10.0, 10.0, 1);
+        e.physics.begin_frame();
+
+        e.select_at(15.0, 15.0, false);
+        assert_eq!(e.selected_names(), vec!["a".to_string()]);
+
+        // Clicking a building while a unit is selected is a command, not a
+        // re-selection: the unit stays selected.
+        e.select_at(65.0, 65.0, false);
+        assert_eq!(e.selected_names(), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn empty_click_clears_when_only_building_selected() {
+        let mut e = Engine::new_for_test();
+        add_selectable(&mut e, "bldg", 60.0, 60.0, 10.0, 10.0, 1);
+        e.physics.begin_frame();
+
+        // With no unit selected, a building click selects the building.
+        e.select_at(65.0, 65.0, false);
+        assert_eq!(e.selected_names(), vec!["bldg".to_string()]);
+
+        // And an empty click clears it.
+        e.select_at(10.0, 10.0, false);
+        assert!(e.selection.is_empty());
+    }
+
+    #[test]
+    fn shift_click_toggles_additively() {
+        let mut e = Engine::new_for_test();
+        add_selectable(&mut e, "a", 10.0, 10.0, 10.0, 10.0, 0);
+        add_selectable(&mut e, "b", 30.0, 10.0, 10.0, 10.0, 0);
+        e.physics.begin_frame();
+
+        e.select_at(15.0, 15.0, false);
+        e.select_at(35.0, 15.0, true);
+        let mut names = e.selected_names();
+        names.sort();
+        assert_eq!(names, vec!["a".to_string(), "b".to_string()]);
+
+        // Shift-clicking an already-selected entity removes it.
+        e.select_at(15.0, 15.0, true);
+        assert_eq!(e.selected_names(), vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn drag_box_selects_multiple_and_respects_additive() {
+        let mut e = Engine::new_for_test();
+        add_selectable(&mut e, "a", 10.0, 10.0, 10.0, 10.0, 0);
+        add_selectable(&mut e, "b", 30.0, 10.0, 10.0, 10.0, 0);
+        add_selectable(&mut e, "c", 10.0, 40.0, 10.0, 10.0, 0);
+        e.physics.begin_frame();
+
+        e.select_box((5.0, 5.0), (45.0, 25.0), false);
+        let mut names = e.selected_names();
+        names.sort();
+        assert_eq!(names, vec!["a".to_string(), "b".to_string()]);
+
+        // Additive box adds to the existing set.
+        e.select_box((5.0, 35.0), (25.0, 55.0), true);
+        let mut names = e.selected_names();
+        names.sort();
+        assert_eq!(names, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+
+        // Non-additive box replaces the set.
+        e.select_box((5.0, 35.0), (25.0, 55.0), false);
+        assert_eq!(e.selected_names(), vec!["c".to_string()]);
+    }
+
+    #[test]
+    fn version_bumps_only_on_change() {
+        let mut e = Engine::new_for_test();
+        add_selectable(&mut e, "a", 10.0, 10.0, 10.0, 10.0, 0);
+        e.physics.begin_frame();
+
+        e.select_at(15.0, 15.0, false);
+        let v1 = e.selection.version;
+        assert!(v1 > 0);
+
+        // Selecting the same entity again (plain click) does not bump version.
+        e.select_at(15.0, 15.0, false);
+        assert_eq!(e.selection.version, v1);
+
+        // Clearing a non-empty selection bumps it.
+        e.selection_clear();
+        assert_eq!(e.selection.version, v1 + 1);
+
+        // Clearing an already-empty selection does not.
+        e.selection_clear();
+        assert_eq!(e.selection.version, v1 + 1);
+    }
+}

--- a/crates/classic-engine/src/vehicle.rs
+++ b/crates/classic-engine/src/vehicle.rs
@@ -11,7 +11,9 @@
 //! runs each frame (after the guest update closures) and pushes
 //! positions/frames/anchors/offsets into the five sprites.
 
-use classic_core::components::{DebugName, IsoSprite, IsoVehicle, RoleKind, Tilemap, Transform};
+use classic_core::components::{
+    DebugName, IsoSprite, IsoVehicle, RoleKind, Selectable, Tilemap, Transform,
+};
 use classic_core::math::cartesian_to_iso_4;
 use classic_core::pathfinder::PathPoll;
 use classic_core::tilemap::sample_height_mesh;
@@ -84,6 +86,24 @@ pub enum VehicleGotoPoll {
     Accepted(Vec<[i32; 2]>),
     /// No route exists (drop the request).
     NoPath,
+}
+
+/// The state of the single in-flight (or cached) non-mutating reachability
+/// probe tracked by [`Engine::vehicle_probe`].  The result is cached per target
+/// so an unchanged probe target doesn't re-run A* every frame.
+pub struct PreviewProbe {
+    pub name: String,
+    pub target: (i32, i32),
+    pub state: PreviewProbeState,
+}
+
+/// The in-flight/cached phase of a [`PreviewProbe`].
+#[derive(Clone, Copy)]
+pub enum PreviewProbeState {
+    /// Search running on the worker; poll `id` via `poll_vehicle_path`.
+    Pending { id: u64 },
+    /// Search finished; `reachable` is the cached answer.
+    Done { reachable: bool },
 }
 
 /// A terrain-height sampler snapshot, cloned once per frame so the mutation
@@ -608,6 +628,7 @@ impl Engine {
             body_sprite,
             vehicle,
             Transform::new(Vec3::new(x, y, 0.0), Vec3::ONE),
+            Selectable { priority: 1, group: 0 },
         ));
         let _ = self.world.insert_one(be, DebugName(entity_name.to_string()));
         self.names.insert(entity_name.to_string(), be);
@@ -1095,6 +1116,200 @@ impl Engine {
             return true;
         }
         false
+    }
+
+    /// Set a vehicle's speed (tiles per second), mutating its `IsoVehicle.speed`
+    /// (e.g. slow a loaded LRV).  Returns `false` for an unknown vehicle.
+    pub fn vehicle_set_speed(&mut self, name: &str, speed: f32) -> bool {
+        let Some(&ve) = self.names.get(name) else { return false };
+        if let Ok(mut v) = self.world.get::<&mut IsoVehicle>(ve) {
+            v.speed = speed;
+            return true;
+        }
+        false
+    }
+
+    /// Non-mutating vehicle reachability probe: run the same footprint-, slope-
+    /// and jump-aware A* as [`Engine::vehicle_goto`] to `(tx, ty)` but do **not**
+    /// install the route on the vehicle.  On success the waypoints are stored in
+    /// `Engine::preview_paths[name]` for the demo overlay to draw.
+    ///
+    /// Return codes: `1` reachable, `-1` no path, `0` pending (search still
+    /// running — call again), `-2` unknown vehicle.  Results are cached per
+    /// target: a repeated call with the same `(name, tx, ty)` returns the cached
+    /// answer without re-running A*, and a target change resubmits.
+    pub fn vehicle_probe(&mut self, name: &str, tx: i32, ty: i32) -> i32 {
+        let Some(&ve) = self.names.get(name) else { return -2 };
+        let (footprint, pitch_max, roll_max, wheelbase_px, track_px, safe_fall_px, turn_cost) = {
+            let Ok(v) = self.world.get::<&IsoVehicle>(ve) else { return -2 };
+            (
+                v.path_footprint.clone(),
+                v.pitch_max,
+                v.roll_max,
+                v.wheelbase_px,
+                v.track_px,
+                v.safe_fall_px,
+                v.turn_cost,
+            )
+        };
+        let from = {
+            let Ok(tf) = self.world.get::<&Transform>(ve) else { return -2 };
+            (tf.position.x.floor() as i32, tf.position.y.floor() as i32)
+        };
+        let target = (tx, ty);
+
+        // Same target: return the cached answer, or poll the in-flight request.
+        if let Some(p) = &self.preview_probe {
+            if p.name == name && p.target == target {
+                return match p.state {
+                    PreviewProbeState::Done { reachable } => {
+                        if reachable {
+                            1
+                        } else {
+                            -1
+                        }
+                    }
+                    PreviewProbeState::Pending { id } => self.poll_preview_probe(id),
+                };
+            }
+        }
+
+        // Different target (or none): drain any in-flight probe before
+        // submitting a fresh one, so at most one worker result is outstanding at
+        // a time (no orphaned results accumulate on rapid target changes).
+        if let Some(id) = self.preview_probe.as_ref().and_then(|p| match p.state {
+            PreviewProbeState::Pending { id } => Some(id),
+            PreviewProbeState::Done { .. } => None,
+        }) {
+            if self.poll_preview_probe(id) == 0 {
+                return 0; // old probe still running; defer the new target
+            }
+        }
+        self.preview_paths.remove(name);
+
+        // New target (or first call): submit a fresh probe.
+        let id = self.next_path_id;
+        self.next_path_id = self.next_path_id.wrapping_add(1);
+        if self.synchronous_workers {
+            let path = self.find_vehicle_path(
+                from,
+                target,
+                &footprint,
+                pitch_max,
+                roll_max,
+                wheelbase_px,
+                track_px,
+                safe_fall_px,
+                JUMP_COST,
+                turn_cost,
+            );
+            let found = path.is_some();
+            self.preview_probe = Some(PreviewProbe {
+                name: name.to_string(),
+                target,
+                state: PreviewProbeState::Done { reachable: found },
+            });
+            if let Some(path) = path {
+                self.preview_paths
+                    .insert(name.to_string(), path.into_iter().map(|(x, y)| [x, y]).collect());
+                return 1;
+            }
+            self.preview_paths.remove(name);
+            return -1;
+        }
+
+        self.ensure_pathfinder();
+        if let Some(worker) = self.pathfinder.as_mut() {
+            worker.request_vehicle_path(
+                id,
+                from,
+                target,
+                footprint,
+                pitch_max,
+                roll_max,
+                wheelbase_px,
+                track_px,
+                safe_fall_px,
+                JUMP_COST,
+                turn_cost,
+            );
+        }
+        self.preview_probe = Some(PreviewProbe {
+            name: name.to_string(),
+            target,
+            state: PreviewProbeState::Pending { id },
+        });
+        0
+    }
+
+    /// Poll an in-flight preview probe by id, finalising `preview_probe` (and
+    /// `preview_paths`) when the worker resolves it.  The resolved outcome is
+    /// cached as `Done { reachable }` so a repeated identical call returns the
+    /// answer without re-running A* (see `vehicle_probe`'s per-target cache).
+    fn poll_preview_probe(&mut self, id: u64) -> i32 {
+        let poll = if let Some(worker) = self.pathfinder.as_mut() {
+            worker.poll_vehicle_path(id)
+        } else {
+            PathPoll::Pending
+        };
+        let (name, target) = match self.preview_probe.as_ref() {
+            Some(p) => (p.name.clone(), p.target),
+            None => (String::new(), (0, 0)),
+        };
+        match poll {
+            PathPoll::Pending => 0,
+            PathPoll::NoPath => {
+                classic_core::cl_debug!(
+                    classic_core::instrument::Chan::Path,
+                    "vehicle_probe {name} -> {target:?}: no path"
+                );
+                self.preview_paths.remove(&name);
+                self.preview_probe = Some(PreviewProbe {
+                    name,
+                    target,
+                    state: PreviewProbeState::Done { reachable: false },
+                });
+                -1
+            }
+            PathPoll::Path(cells) => {
+                classic_core::cl_debug!(
+                    classic_core::instrument::Chan::Path,
+                    "vehicle_probe {name} -> {target:?}: {} waypoints",
+                    cells.len()
+                );
+                let path: Vec<[i32; 2]> = cells.into_iter().map(|(x, y)| [x, y]).collect();
+                self.preview_paths.insert(name.clone(), path);
+                self.preview_probe = Some(PreviewProbe {
+                    name,
+                    target,
+                    state: PreviewProbeState::Done { reachable: true },
+                });
+                1
+            }
+        }
+    }
+
+    /// Clear a vehicle's drop-preview state (candidate path + cached/in-flight
+    /// probe), e.g. when the guest leaves preview mode.  Returns `true` when
+    /// anything was cleared.  An in-flight probe is best-effort drained first so
+    /// a ready result doesn't linger.
+    pub fn vehicle_probe_clear(&mut self, name: &str) -> bool {
+        let pending_id = match self.preview_probe.as_ref() {
+            Some(p) if p.name == name => match p.state {
+                PreviewProbeState::Pending { id } => Some(id),
+                PreviewProbeState::Done { .. } => None,
+            },
+            _ => None,
+        };
+        let had_probe = self.preview_probe.as_ref().map(|p| p.name == name).unwrap_or(false);
+        if let Some(id) = pending_id {
+            let _ = self.poll_preview_probe(id);
+        }
+        if self.preview_probe.as_ref().map(|p| p.name == name).unwrap_or(false) {
+            self.preview_probe = None;
+        }
+        let had_path = self.preview_paths.remove(name).is_some();
+        had_probe || had_path
     }
 }
 
@@ -2072,6 +2287,36 @@ mod tests {
         );
         // pitch_levels = 5 for the real def, so the dead-zone is non-zero.
         assert!(v.tilt_dead_zone > 0.0, "dead-zone must be derived from frame quantization");
+    }
+
+    #[test]
+    fn vehicle_probe_reports_reachability_and_caches_result() {
+        let mut engine = engine_with_lrvtest_like_map(None);
+        engine.vehicles.insert("lrv".into(), lrv_def_real());
+        assert!(engine.spawn_vehicle("lrv", "lrv", 5.0, 5.0));
+        engine.set_synchronous_workers(true);
+
+        // A reachable target stores its waypoints and reports 1.
+        assert_eq!(engine.vehicle_probe("lrv", 24, 24), 1);
+        assert!(engine.preview_paths.contains_key("lrv"));
+
+        // The resolved result is cached as `Done { reachable: true }` (not
+        // cleared), so a repeat identical call returns the cached answer and
+        // keeps the path (previously it cleared the probe and re-ran A*, which
+        // made the preview line vanish and flicker every frame).
+        assert!(matches!(
+            engine.preview_probe.as_ref().map(|p| p.state),
+            Some(PreviewProbeState::Done { reachable: true })
+        ));
+        assert_eq!(engine.vehicle_probe("lrv", 24, 24), 1);
+        assert!(engine.preview_paths.contains_key("lrv"));
+        assert!(matches!(
+            engine.preview_probe.as_ref().map(|p| p.state),
+            Some(PreviewProbeState::Done { reachable: true })
+        ));
+
+        // An unknown vehicle is reported distinctly.
+        assert_eq!(engine.vehicle_probe("nope", 5, 5), -2);
     }
 
     #[test]

--- a/crates/classic-gfx/src/lib.rs
+++ b/crates/classic-gfx/src/lib.rs
@@ -646,6 +646,11 @@ impl Gfx {
         s.uniform_1f(gl, "use_iso_depth", 0.0);
         s.uniform_vec4(gl, "iso_depth_corners", &[0.0, 0.0, 0.0, 0.0]);
         s.uniform_1f(gl, "ghost_alpha", ghost_alpha);
+        // Non-iso sprites never show the RTS silhouette; reset the uniforms so a
+        // previously-selected iso sprite doesn't leak into the UI/Sprite phase.
+        s.uniform_1f(gl, "selected", 0.0);
+        s.uniform_vec3(gl, "selection_color", Vec3::from_array([0.0, 0.0, 0.0]));
+        s.uniform_vec2(gl, "outline_delta", &[0.0, 0.0]);
         s.uniform_1f(gl, "use_normal_map", 0.0);
         s.uniform_vec3(gl, "ambient_color", Vec3::from_array(settings.ambient));
         s.uniform_vec3(gl, "light_direction", Vec3::from_array(settings.light_dir));
@@ -733,6 +738,9 @@ impl Gfx {
         tint: &[f32; 3],
         settings: &RenderSettings,
         ghost_alpha: f32,
+        selected: bool,
+        selection_color: &[f32; 3],
+        outline_radius: f32,
     ) {
         let gl = &self.gl;
         let s = self.shader("imageSheet");
@@ -743,6 +751,24 @@ impl Gfx {
 
         s.uniform_1i(gl, "tex_sampler", 0);
         self.bind_view(s, camera, model, false);
+
+        // Silhouette outline: the sheet-UV offset of `outline_radius` content
+        // pixels, so a selected sprite's transparent edge samples its own cell's
+        // opaque neighbours without cross-frame bleed.
+        let outline_delta: [f32; 2] = match &region {
+            SpriteRegion::Grid { .. } => {
+                [outline_radius / t.size.0.max(1) as f32, outline_radius / t.size.1.max(1) as f32]
+            }
+            SpriteRegion::Uv { uv_rect, content_size, .. } => {
+                let ext_x = (uv_rect[2] - uv_rect[0]).abs().max(1e-6);
+                let ext_y = (uv_rect[3] - uv_rect[1]).abs().max(1e-6);
+                [
+                    outline_radius * ext_x / content_size[0].max(1.0),
+                    outline_radius * ext_y / content_size[1].max(1.0),
+                ]
+            }
+        };
+
         match region {
             SpriteRegion::Grid { frame, tile_set_size } => {
                 s.uniform_1f(gl, "tile_id_flat", frame);
@@ -763,6 +789,9 @@ impl Gfx {
         s.uniform_1f(gl, "use_iso_depth", 1.0);
         s.uniform_vec4(gl, "iso_depth_corners", iso_depth_corners);
         s.uniform_1f(gl, "ghost_alpha", ghost_alpha);
+        s.uniform_1f(gl, "selected", if selected { 1.0 } else { 0.0 });
+        s.uniform_vec3(gl, "selection_color", Vec3::from_array(*selection_color));
+        s.uniform_vec2(gl, "outline_delta", &outline_delta);
 
         if let Some((depth_tex, depth_range)) = depth_map {
             if let Some(dt) = self.textures.get(depth_tex) {
@@ -826,6 +855,9 @@ impl Gfx {
         settings: &RenderSettings,
         ghost_group: u32,
         pass: IsoSpritePass,
+        selected: bool,
+        selection_color: &[f32; 3],
+        outline_radius: f32,
     ) {
         let gl = &self.gl;
         let ghost_alpha = match pass {
@@ -844,6 +876,9 @@ impl Gfx {
             tint,
             settings,
             ghost_alpha,
+            selected,
+            selection_color,
+            outline_radius,
         );
 
         unsafe {

--- a/crates/classic-gfx/src/shaders/sheet.frag
+++ b/crates/classic-gfx/src/shaders/sheet.frag
@@ -27,6 +27,12 @@ uniform vec3 light_color;
 // Defaults to (1,1,1) — a no-op for every existing asset.  Tintable sprites
 // ship a grayscale albedo and set this at runtime (see IsoSprite.color).
 uniform vec3 tint;
+// RTS selection silhouette: when `selected` is set, transparent edge texels
+// adjacent to an opaque texel (within `outline_delta` sheet-UV) are drawn in
+// `selection_color` as a per-sprite outline.
+uniform float selected;
+uniform vec3 selection_color;
+uniform vec2 outline_delta;
 
 out vec4 fragColor;
 
@@ -65,7 +71,29 @@ vec4 getTilePixel(float tile_id_flat, vec2 tex_coord) {
 
 void main(void ) {
     vec4 color = getTilePixel(tile_id_flat, vec2(vTexCoord.x, vTexCoord.y));
-    if (color.a < 0.01) discard;
+
+    if (selected > 0.5) {
+        if (color.a < 0.01) {
+            // Transparent texel: draw a silhouette edge where a cardinal
+            // neighbour is opaque.  `sheetUv` maps the current texel to the
+            // sheet; neighbours are sampled directly (no re-discard).
+            vec2 suv = sheetUv(vec2(vTexCoord.x, vTexCoord.y));
+            float neighbour = max(
+                max(texture(tex_sampler, suv + vec2(outline_delta.x, 0.0)).a,
+                    texture(tex_sampler, suv - vec2(outline_delta.x, 0.0)).a),
+                max(texture(tex_sampler, suv + vec2(0.0, outline_delta.y)).a,
+                    texture(tex_sampler, suv - vec2(0.0, outline_delta.y)).a)
+            );
+            if (neighbour < 0.01) {
+                discard;
+            }
+            fragColor = vec4(selection_color, 1.0);
+            return;
+        }
+    } else if (color.a < 0.01) {
+        discard;
+    }
+
     color.rgb *= tint;
     if (use_depth_map > 0.5) {
         highp float gray = texture(depth_sampler, sheetUv(vec2(vTexCoord.x, vTexCoord.y))).r;

--- a/crates/classic-guest/src/imports.rs
+++ b/crates/classic-guest/src/imports.rs
@@ -97,6 +97,15 @@ macro_rules! install_host_imports {
 
         $linker.func_wrap(
             m,
+            "get_sprite_frame",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32| -> f64 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().get_sprite_frame(&name)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
             "set_sprite_color",
             |mut caller: Caller<'_, $host>,
              ptr: i32,
@@ -108,6 +117,15 @@ macro_rules! install_host_imports {
              -> i32 {
                 let name = $read_str(&mut caller, ptr, len);
                 caller.data_mut().guest_mut().set_sprite_color(&name, r, g, b, a)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "set_sprite_offset",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32, dx: f64, dy: f64, dz: f64| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().set_sprite_offset(&name, dx, dy, dz)
             },
         )?;
 
@@ -375,6 +393,145 @@ macro_rules! install_host_imports {
             |mut caller: Caller<'_, $host>, ptr: i32, len: i32| -> i32 {
                 let name = $read_str(&mut caller, ptr, len);
                 caller.data_mut().guest_mut().vehicle_stop(&name)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "vehicle_set_speed",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32, speed: f64| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().vehicle_set_speed(&name, speed)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "vehicle_probe",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32, tx: i32, ty: i32| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().vehicle_probe(&name, tx, ty)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "vehicle_probe_clear",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().vehicle_probe_clear(&name)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "selected_names",
+            |mut caller: Caller<'_, $host>, out_ptr: i32, out_cap: i32| -> i32 {
+                let json = caller.data_mut().guest_mut().selected_names();
+                if out_cap < json.len() as i32 {
+                    return -1;
+                }
+                $write_str(&mut caller, out_ptr, &json)
+            },
+        )?;
+
+        $linker.func_wrap(m, "selection_clear", |mut caller: Caller<'_, $host>| -> i32 {
+            caller.data_mut().guest_mut().selection_clear()
+        })?;
+
+        $linker.func_wrap(
+            m,
+            "inventory_dump",
+            |mut caller: Caller<'_, $host>,
+             ptr: i32,
+             len: i32,
+             out_ptr: i32,
+             out_cap: i32|
+             -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                let json = caller.data_mut().guest_mut().inventory_dump(&name);
+                if out_cap < json.len() as i32 {
+                    return -1;
+                }
+                $write_str(&mut caller, out_ptr, &json)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "inventory_capacity",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().inventory_capacity(&name)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "inventory_add",
+            |mut caller: Caller<'_, $host>,
+             ptr: i32,
+             len: i32,
+             item_ptr: i32,
+             item_len: i32,
+             n: i32|
+             -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                let item = $read_str(&mut caller, item_ptr, item_len);
+                caller.data_mut().guest_mut().inventory_add(&name, &item, n)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "inventory_remove",
+            |mut caller: Caller<'_, $host>,
+             ptr: i32,
+             len: i32,
+             item_ptr: i32,
+             item_len: i32,
+             n: i32|
+             -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                let item = $read_str(&mut caller, item_ptr, item_len);
+                caller.data_mut().guest_mut().inventory_remove(&name, &item, n)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "inventory_transfer",
+            |mut caller: Caller<'_, $host>,
+             from_ptr: i32,
+             from_len: i32,
+             to_ptr: i32,
+             to_len: i32,
+             item_ptr: i32,
+             item_len: i32,
+             n: i32|
+             -> i32 {
+                let from = $read_str(&mut caller, from_ptr, from_len);
+                let to = $read_str(&mut caller, to_ptr, to_len);
+                let item = $read_str(&mut caller, item_ptr, item_len);
+                caller.data_mut().guest_mut().inventory_transfer(&from, &to, &item, n)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
+            "item_def",
+            |mut caller: Caller<'_, $host>,
+             ptr: i32,
+             len: i32,
+             out_ptr: i32,
+             out_cap: i32|
+             -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                let json = caller.data_mut().guest_mut().item_def(&name);
+                if out_cap < json.len() as i32 {
+                    return -1;
+                }
+                $write_str(&mut caller, out_ptr, &json)
             },
         )?;
 

--- a/crates/classic-guest/src/runtime_web.rs
+++ b/crates/classic-guest/src/runtime_web.rs
@@ -595,6 +595,22 @@ impl WebWasmRuntime {
             );
         }
 
+        // get_sprite_frame
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "get_sprite_frame",
+                Box::new(move |ptr: i32, len: i32| -> f64 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().get_sprite_frame(&name)
+                }) as Box<dyn FnMut(i32, i32) -> f64>
+            );
+        }
+
         // set_sprite_color
         {
             let host = host.clone();
@@ -608,6 +624,22 @@ impl WebWasmRuntime {
                     };
                     host.borrow_mut().set_sprite_color(&name, r, g, b, a)
                 }) as Box<dyn FnMut(i32, i32, f64, f64, f64, f64) -> i32>
+            );
+        }
+
+        // set_sprite_offset
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "set_sprite_offset",
+                Box::new(move |ptr: i32, len: i32, dx: f64, dy: f64, dz: f64| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().set_sprite_offset(&name, dx, dy, dz)
+                }) as Box<dyn FnMut(i32, i32, f64, f64, f64) -> i32>
             );
         }
 
@@ -1007,6 +1039,203 @@ impl WebWasmRuntime {
                     };
                     host.borrow_mut().vehicle_stop(&name)
                 }) as Box<dyn FnMut(i32, i32) -> i32>
+            );
+        }
+
+        // vehicle_set_speed
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "vehicle_set_speed",
+                Box::new(move |ptr: i32, len: i32, speed: f64| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().vehicle_set_speed(&name, speed)
+                }) as Box<dyn FnMut(i32, i32, f64) -> i32>
+            );
+        }
+
+        // vehicle_probe
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "vehicle_probe",
+                Box::new(move |ptr: i32, len: i32, tx: i32, ty: i32| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().vehicle_probe(&name, tx, ty)
+                }) as Box<dyn FnMut(i32, i32, i32, i32) -> i32>
+            );
+        }
+
+        // vehicle_probe_clear
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "vehicle_probe_clear",
+                Box::new(move |ptr: i32, len: i32| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().vehicle_probe_clear(&name)
+                }) as Box<dyn FnMut(i32, i32) -> i32>
+            );
+        }
+
+        // selected_names
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "selected_names",
+                Box::new(move |out_ptr: i32, out_cap: i32| -> i32 {
+                    let json = host.borrow_mut().selected_names();
+                    if out_cap < json.len() as i32 {
+                        return -1;
+                    }
+                    let mem = mem.borrow();
+                    write_str(mem.as_ref().unwrap(), out_ptr, &json)
+                }) as Box<dyn FnMut(i32, i32) -> i32>
+            );
+        }
+
+        // selection_clear
+        {
+            let host = host.clone();
+            set_import!(
+                "selection_clear",
+                Box::new(move || -> i32 { host.borrow_mut().selection_clear() })
+                    as Box<dyn FnMut() -> i32>
+            );
+        }
+
+        // inventory_dump
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "inventory_dump",
+                Box::new(move |ptr: i32, len: i32, out_ptr: i32, out_cap: i32| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    let json = host.borrow_mut().inventory_dump(&name);
+                    if out_cap < json.len() as i32 {
+                        return -1;
+                    }
+                    let mem = mem.borrow();
+                    write_str(mem.as_ref().unwrap(), out_ptr, &json)
+                }) as Box<dyn FnMut(i32, i32, i32, i32) -> i32>
+            );
+        }
+
+        // inventory_capacity
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "inventory_capacity",
+                Box::new(move |ptr: i32, len: i32| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().inventory_capacity(&name)
+                }) as Box<dyn FnMut(i32, i32) -> i32>
+            );
+        }
+
+        // inventory_add
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "inventory_add",
+                Box::new(move |ptr: i32, len: i32, item_ptr: i32, item_len: i32, n: i32| -> i32 {
+                    let (name, item) = {
+                        let mem = mem.borrow();
+                        let m = mem.as_ref().unwrap();
+                        (read_str(m, ptr, len), read_str(m, item_ptr, item_len))
+                    };
+                    host.borrow_mut().inventory_add(&name, &item, n)
+                }) as Box<dyn FnMut(i32, i32, i32, i32, i32) -> i32>
+            );
+        }
+
+        // inventory_remove
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "inventory_remove",
+                Box::new(move |ptr: i32, len: i32, item_ptr: i32, item_len: i32, n: i32| -> i32 {
+                    let (name, item) = {
+                        let mem = mem.borrow();
+                        let m = mem.as_ref().unwrap();
+                        (read_str(m, ptr, len), read_str(m, item_ptr, item_len))
+                    };
+                    host.borrow_mut().inventory_remove(&name, &item, n)
+                }) as Box<dyn FnMut(i32, i32, i32, i32, i32) -> i32>
+            );
+        }
+
+        // inventory_transfer
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "inventory_transfer",
+                Box::new(
+                    move |from_ptr: i32,
+                          from_len: i32,
+                          to_ptr: i32,
+                          to_len: i32,
+                          item_ptr: i32,
+                          item_len: i32,
+                          n: i32|
+                          -> i32 {
+                        let (from, to, item) = {
+                            let mem = mem.borrow();
+                            let m = mem.as_ref().unwrap();
+                            (
+                                read_str(m, from_ptr, from_len),
+                                read_str(m, to_ptr, to_len),
+                                read_str(m, item_ptr, item_len),
+                            )
+                        };
+                        host.borrow_mut().inventory_transfer(&from, &to, &item, n)
+                    }
+                ) as Box<dyn FnMut(i32, i32, i32, i32, i32, i32, i32) -> i32>
+            );
+        }
+
+        // item_def
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "item_def",
+                Box::new(move |ptr: i32, len: i32, out_ptr: i32, out_cap: i32| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    let json = host.borrow_mut().item_def(&name);
+                    if out_cap < json.len() as i32 {
+                        return -1;
+                    }
+                    let mem = mem.borrow();
+                    write_str(mem.as_ref().unwrap(), out_ptr, &json)
+                }) as Box<dyn FnMut(i32, i32, i32, i32) -> i32>
             );
         }
 

--- a/crates/classic-guest/src/runtime_worker.rs
+++ b/crates/classic-guest/src/runtime_worker.rs
@@ -129,6 +129,19 @@ const OP_SET_SPRITE_FRAME: i32 = 77;
 const OP_SET_SPRITE_COLOR: i32 = 78;
 const OP_SPAWN_SPRITE_CLONE: i32 = 79;
 const OP_SET_ENABLED: i32 = 80;
+const OP_VEHICLE_SET_SPEED: i32 = 81;
+const OP_SELECTED_NAMES: i32 = 82;
+const OP_SELECTION_CLEAR: i32 = 83;
+const OP_INVENTORY_DUMP: i32 = 84;
+const OP_INVENTORY_ADD: i32 = 85;
+const OP_INVENTORY_REMOVE: i32 = 86;
+const OP_INVENTORY_TRANSFER: i32 = 87;
+const OP_ITEM_DEF: i32 = 88;
+const OP_SET_SPRITE_OFFSET: i32 = 89;
+const OP_GET_SPRITE_FRAME: i32 = 90;
+const OP_INVENTORY_CAPACITY: i32 = 91;
+const OP_VEHICLE_PROBE: i32 = 92;
+const OP_VEHICLE_PROBE_CLEAR: i32 = 93;
 
 const WORKER_SRC: &str = include_str!("worker.js");
 
@@ -290,11 +303,49 @@ impl WorkerWasmRuntime {
             OP_VEHICLE_STOP => (host.vehicle_stop(&strs[0]) as f64, None),
             OP_VEHICLE_SPAWN => (host.vehicle_spawn(&strs[0], &strs[1], nf(0), nf(1)) as f64, None),
             OP_SET_SPRITE_FRAME => (host.set_sprite_frame(&strs[0], nf(0)) as f64, None),
+            OP_GET_SPRITE_FRAME => (host.get_sprite_frame(&strs[0]), None),
             OP_SET_SPRITE_COLOR => {
                 (host.set_sprite_color(&strs[0], nf(0), nf(1), nf(2), nf(3)) as f64, None)
             }
+            OP_SET_SPRITE_OFFSET => {
+                (host.set_sprite_offset(&strs[0], nf(0), nf(1), nf(2)) as f64, None)
+            }
             OP_SPAWN_SPRITE_CLONE => (host.spawn_sprite_clone(&strs[0], &strs[1]) as f64, None),
             OP_SET_ENABLED => (host.set_enabled(&strs[0], ni(0)) as f64, None),
+            OP_VEHICLE_SET_SPEED => (host.vehicle_set_speed(&strs[0], nf(0)) as f64, None),
+            OP_VEHICLE_PROBE => (host.vehicle_probe(&strs[0], ni(0), ni(1)) as f64, None),
+            OP_VEHICLE_PROBE_CLEAR => (host.vehicle_probe_clear(&strs[0]) as f64, None),
+            OP_SELECTED_NAMES => {
+                let json = host.selected_names();
+                if ni(1) < json.len() as i32 || json.len() as u32 > OUT_BYTES {
+                    (-1.0, None)
+                } else {
+                    (json.len() as f64, Some(json.into_bytes()))
+                }
+            }
+            OP_SELECTION_CLEAR => (host.selection_clear() as f64, None),
+            OP_INVENTORY_DUMP => {
+                let json = host.inventory_dump(&strs[0]);
+                if ni(1) < json.len() as i32 || json.len() as u32 > OUT_BYTES {
+                    (-1.0, None)
+                } else {
+                    (json.len() as f64, Some(json.into_bytes()))
+                }
+            }
+            OP_INVENTORY_CAPACITY => (host.inventory_capacity(&strs[0]) as f64, None),
+            OP_INVENTORY_ADD => (host.inventory_add(&strs[0], &strs[1], ni(0)) as f64, None),
+            OP_INVENTORY_REMOVE => (host.inventory_remove(&strs[0], &strs[1], ni(0)) as f64, None),
+            OP_INVENTORY_TRANSFER => {
+                (host.inventory_transfer(&strs[0], &strs[1], &strs[2], ni(0)) as f64, None)
+            }
+            OP_ITEM_DEF => {
+                let json = host.item_def(&strs[0]);
+                if ni(1) < json.len() as i32 || json.len() as u32 > OUT_BYTES {
+                    (-1.0, None)
+                } else {
+                    (json.len() as f64, Some(json.into_bytes()))
+                }
+            }
             OP_GET_CAMERA => {
                 let (x, y, s) = host.get_camera();
                 (1.0, Some(enc_f64s(&[x, y, s])))

--- a/crates/classic-guest/src/sdk.rs
+++ b/crates/classic-guest/src/sdk.rs
@@ -139,9 +139,21 @@ impl GuestHost {
         self.engine_mut().set_sprite_frame(name, frame as f32) as i32
     }
 
+    /// Read a named entity's `IsoSprite` frame index (`-1.0` when it has none).
+    pub fn get_sprite_frame(&mut self, name: &str) -> f64 {
+        self.engine().get_sprite_frame(name).map(|f| f as f64).unwrap_or(-1.0)
+    }
+
     /// Set a named entity's `IsoSprite` tint colour (RGBA, `0..=1`).
     pub fn set_sprite_color(&mut self, name: &str, r: f64, g: f64, b: f64, a: f64) -> i32 {
         self.engine_mut().set_sprite_color(name, [r as f32, g as f32, b as f32, a as f32]) as i32
+    }
+
+    /// Set a named entity's `IsoSprite` visual offset (`frame_offset`; negative
+    /// Y lifts the sprite).  Used to elevate runtime sprites (e.g. the
+    /// unloading container).
+    pub fn set_sprite_offset(&mut self, name: &str, dx: f64, dy: f64, dz: f64) -> i32 {
+        self.engine_mut().set_sprite_offset(name, dx as f32, dy as f32, dz as f32) as i32
     }
 
     /// Spawn a new `IsoSprite` entity cloned from a template entity's
@@ -295,6 +307,79 @@ impl GuestHost {
     /// Stop a wheeled vehicle, clearing its movement path.
     pub fn vehicle_stop(&mut self, name: &str) -> i32 {
         self.engine_mut().vehicle_stop(name) as i32
+    }
+
+    /// Set a wheeled vehicle's speed (tiles per second), mutating its
+    /// `IsoVehicle.speed` (e.g. slow a loaded LRV).
+    pub fn vehicle_set_speed(&mut self, name: &str, speed: f64) -> i32 {
+        self.engine_mut().vehicle_set_speed(name, speed as f32) as i32
+    }
+
+    /// Non-mutating vehicle reachability probe: run the vehicle's A* to
+    /// `(tx, ty)` without driving it.  Returns `1` reachable, `-1` no path,
+    /// `0` pending (call again), `-2` unknown vehicle.  On success the waypoints
+    /// are stored in `Engine::preview_paths` for the demo overlay.
+    pub fn vehicle_probe(&mut self, name: &str, tx: i32, ty: i32) -> i32 {
+        self.engine_mut().vehicle_probe(name, tx, ty)
+    }
+
+    /// Clear a vehicle's drop-preview state (candidate path + probe).  Returns
+    /// `1` when anything was cleared, else `0`.
+    pub fn vehicle_probe_clear(&mut self, name: &str) -> i32 {
+        self.engine_mut().vehicle_probe_clear(name) as i32
+    }
+
+    /// The JSON array of currently RTS-selected entity names.
+    pub fn selected_names(&mut self) -> String {
+        serde_json::to_string(&self.engine().selected_names()).unwrap_or_else(|_| "[]".into())
+    }
+
+    /// Clear the RTS selection set.
+    pub fn selection_clear(&mut self) -> i32 {
+        self.engine_mut().selection_clear();
+        1
+    }
+
+    /// Serialize a named entity's inventory to JSON (`"null"` when it has none).
+    pub fn inventory_dump(&mut self, name: &str) -> String {
+        self.engine().inventory_dump(name).unwrap_or_else(|| "null".into())
+    }
+
+    /// Read a named entity's raw `Inventory.capacity` (`-1` when it has none).
+    pub fn inventory_capacity(&mut self, name: &str) -> i32 {
+        self.engine().inventory_capacity(name).map(|c| c as i32).unwrap_or(-1)
+    }
+
+    /// Add `n` units of an item (by name) to a named entity's inventory,
+    /// returning the amount actually added.
+    pub fn inventory_add(&mut self, name: &str, item: &str, n: i32) -> i32 {
+        if n < 0 {
+            return 0;
+        }
+        self.engine_mut().inventory_add(name, item, n as u32) as i32
+    }
+
+    /// Remove `n` units of an item (by name) from a named entity's inventory,
+    /// returning the amount actually removed.
+    pub fn inventory_remove(&mut self, name: &str, item: &str, n: i32) -> i32 {
+        if n < 0 {
+            return 0;
+        }
+        self.engine_mut().inventory_remove(name, item, n as u32) as i32
+    }
+
+    /// Transfer up to `n` units of an item (by name) between two named
+    /// entities' inventories, returning the amount actually transferred.
+    pub fn inventory_transfer(&mut self, from: &str, to: &str, item: &str, n: i32) -> i32 {
+        if n < 0 {
+            return 0;
+        }
+        self.engine_mut().inventory_transfer(from, to, item, n as u32) as i32
+    }
+
+    /// Serialize an item definition to JSON (empty string when unknown).
+    pub fn item_def(&mut self, name: &str) -> String {
+        self.engine().item_def(name).unwrap_or_default()
     }
 
     /// Read the camera position (x, y) and uniform scale.

--- a/crates/classic-guest/src/worker.js
+++ b/crates/classic-guest/src/worker.js
@@ -117,6 +117,19 @@ var OP_SET_SPRITE_FRAME = 77;
 var OP_SET_SPRITE_COLOR = 78;
 var OP_SPAWN_SPRITE_CLONE = 79;
 var OP_SET_ENABLED = 80;
+var OP_VEHICLE_SET_SPEED = 81;
+var OP_SELECTED_NAMES = 82;
+var OP_SELECTION_CLEAR = 83;
+var OP_INVENTORY_DUMP = 84;
+var OP_INVENTORY_ADD = 85;
+var OP_INVENTORY_REMOVE = 86;
+var OP_INVENTORY_TRANSFER = 87;
+var OP_ITEM_DEF = 88;
+var OP_SET_SPRITE_OFFSET = 89;
+var OP_GET_SPRITE_FRAME = 90;
+var OP_INVENTORY_CAPACITY = 91;
+var OP_VEHICLE_PROBE = 92;
+var OP_VEHICLE_PROBE_CLEAR = 93;
 
 var encoder = new TextEncoder();
 var decoder = new TextDecoder();
@@ -208,8 +221,14 @@ function envImports() {
         set_sprite_frame: function (ptr, len, frame) {
             return hostCall(OP_SET_SPRITE_FRAME, [readStr(ptr, len)], [frame]).ret | 0;
         },
+        get_sprite_frame: function (ptr, len) {
+            return hostCall(OP_GET_SPRITE_FRAME, [readStr(ptr, len)], []).ret;
+        },
         set_sprite_color: function (ptr, len, r, g, b, a) {
             return hostCall(OP_SET_SPRITE_COLOR, [readStr(ptr, len)], [r, g, b, a]).ret | 0;
+        },
+        set_sprite_offset: function (ptr, len, dx, dy, dz) {
+            return hostCall(OP_SET_SPRITE_OFFSET, [readStr(ptr, len)], [dx, dy, dz]).ret | 0;
         },
         spawn_sprite_clone: function (tPtr, tLen, nPtr, nLen) {
             return hostCall(OP_SPAWN_SPRITE_CLONE, [readStr(tPtr, tLen), readStr(nPtr, nLen)], []).ret | 0;
@@ -303,6 +322,57 @@ function envImports() {
         },
         vehicle_stop: function (ptr, len) {
             return hostCall(OP_VEHICLE_STOP, [readStr(ptr, len)], []).ret | 0;
+        },
+        vehicle_set_speed: function (ptr, len, speed) {
+            return hostCall(OP_VEHICLE_SET_SPEED, [readStr(ptr, len)], [speed]).ret | 0;
+        },
+        vehicle_probe: function (ptr, len, tx, ty) {
+            return hostCall(OP_VEHICLE_PROBE, [readStr(ptr, len)], [tx, ty]).ret | 0;
+        },
+        vehicle_probe_clear: function (ptr, len) {
+            return hostCall(OP_VEHICLE_PROBE_CLEAR, [readStr(ptr, len)], []).ret | 0;
+        },
+        selected_names: function (outPtr, outCap) {
+            var r = hostCall(OP_SELECTED_NAMES, [], [outPtr, outCap]);
+            if (r.out.length > 0) writeMem(outPtr, r.out);
+            return r.ret | 0;
+        },
+        selection_clear: function () {
+            return hostCall(OP_SELECTION_CLEAR, [], []).ret | 0;
+        },
+        inventory_dump: function (ptr, len, outPtr, outCap) {
+            var r = hostCall(OP_INVENTORY_DUMP, [readStr(ptr, len)], [outPtr, outCap]);
+            if (r.out.length > 0) writeMem(outPtr, r.out);
+            return r.ret | 0;
+        },
+        inventory_capacity: function (ptr, len) {
+            return hostCall(OP_INVENTORY_CAPACITY, [readStr(ptr, len)], []).ret | 0;
+        },
+        inventory_add: function (ptr, len, itemPtr, itemLen, n) {
+            return hostCall(
+                OP_INVENTORY_ADD,
+                [readStr(ptr, len), readStr(itemPtr, itemLen)],
+                [n],
+            ).ret | 0;
+        },
+        inventory_remove: function (ptr, len, itemPtr, itemLen, n) {
+            return hostCall(
+                OP_INVENTORY_REMOVE,
+                [readStr(ptr, len), readStr(itemPtr, itemLen)],
+                [n],
+            ).ret | 0;
+        },
+        inventory_transfer: function (fromPtr, fromLen, toPtr, toLen, itemPtr, itemLen, n) {
+            return hostCall(
+                OP_INVENTORY_TRANSFER,
+                [readStr(fromPtr, fromLen), readStr(toPtr, toLen), readStr(itemPtr, itemLen)],
+                [n],
+            ).ret | 0;
+        },
+        item_def: function (ptr, len, outPtr, outCap) {
+            var r = hostCall(OP_ITEM_DEF, [readStr(ptr, len)], [outPtr, outCap]);
+            if (r.out.length > 0) writeMem(outPtr, r.out);
+            return r.ret | 0;
         },
         get_camera: function (outPtr) {
             var r = hostCall(OP_GET_CAMERA, [], [outPtr]);

--- a/crates/classic-guest/tests/guest.rs
+++ b/crates/classic-guest/tests/guest.rs
@@ -343,6 +343,131 @@ fn guest_vehicle_imports_are_wired() {
 }
 
 #[test]
+fn guest_selection_and_speed_imports_wired() {
+    with_each_runtime(
+        r#"(module
+            (import "env" "vehicle_set_speed" (func $vss (param i32 i32 f64) (result i32)))
+            (import "env" "vehicle_probe" (func $vprobe (param i32 i32 i32 i32) (result i32)))
+            (import "env" "vehicle_probe_clear" (func $vclear (param i32 i32) (result i32)))
+            (import "env" "selected_names" (func $sel (param i32 i32) (result i32)))
+            (import "env" "selection_clear" (func $clear (result i32)))
+            (import "env" "set_sprite_offset" (func $soff (param i32 i32 f64 f64 f64) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "lrv")
+            (func (export "update") (param f64)
+                (drop (call $vss (i32.const 0) (i32.const 3) (f64.const 1.3)))
+                (drop (call $vprobe (i32.const 0) (i32.const 3) (i32.const 2) (i32.const 0)))
+                (drop (call $vclear (i32.const 0) (i32.const 3)))
+                (drop (call $sel (i32.const 64) (i32.const 64)))
+                (drop (call $clear))
+                (drop (call $soff (i32.const 0) (i32.const 3) (f64.const 0.0) (f64.const -448.0) (f64.const 0.0)))))"#,
+        &GuestLimits::default(),
+        |rt| {
+            let mut engine = Engine::new_for_test();
+            rt.update(&mut engine, 0.016).unwrap();
+        },
+    );
+}
+
+#[test]
+fn guest_inventory_imports_wired() {
+    with_each_runtime(
+        r#"(module
+            (import "env" "inventory_dump" (func $idump (param i32 i32 i32 i32) (result i32)))
+            (import "env" "inventory_add" (func $iadd (param i32 i32 i32 i32 i32) (result i32)))
+            (import "env" "inventory_remove" (func $irem (param i32 i32 i32 i32 i32) (result i32)))
+            (import "env" "inventory_transfer" (func $itrf (param i32 i32 i32 i32 i32 i32 i32) (result i32)))
+            (import "env" "item_def" (func $idef (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "lrv")
+            (data (i32.const 16) "ore")
+            (data (i32.const 32) "rocket")
+            (func (export "update") (param f64)
+                (drop (call $iadd (i32.const 0) (i32.const 3) (i32.const 16) (i32.const 3) (i32.const 1)))
+                (drop (call $irem (i32.const 0) (i32.const 3) (i32.const 16) (i32.const 3) (i32.const 1)))
+                (drop (call $itrf (i32.const 32) (i32.const 6) (i32.const 0) (i32.const 3) (i32.const 16) (i32.const 3) (i32.const 1)))
+                (drop (call $idump (i32.const 0) (i32.const 3) (i32.const 64) (i32.const 64)))
+                (drop (call $idef (i32.const 16) (i32.const 3) (i32.const 128) (i32.const 128)))))"#,
+        &GuestLimits::default(),
+        |rt| {
+            let mut engine = Engine::new_for_test();
+            rt.update(&mut engine, 0.016).unwrap();
+        },
+    );
+}
+
+#[test]
+fn guest_get_sprite_frame_and_inventory_capacity_wired() {
+    with_each_runtime(
+        r#"(module
+            (import "env" "get_sprite_frame" (func $gsf (param i32 i32) (result f64)))
+            (import "env" "inventory_capacity" (func $icap (param i32 i32) (result i32)))
+            (import "env" "set_sprite_frame" (func $ssf (param i32 i32 f64) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "unit")
+            (data (i32.const 16) "rocket")
+            (data (i32.const 32) "copy_a")
+            (data (i32.const 64) "copy_b")
+            (func (export "update") (param f64)
+                (drop (call $ssf (i32.const 32) (i32.const 6)
+                         (call $gsf (i32.const 0) (i32.const 4))))
+                (drop (call $ssf (i32.const 64) (i32.const 6)
+                         (f64.convert_i32_s (call $icap (i32.const 16) (i32.const 6)))))))"#,
+        &GuestLimits::default(),
+        |rt| {
+            let mut engine = Engine::new_for_test();
+            let sprite = IsoSprite {
+                position: Vec3::ZERO,
+                scale: Vec3::ONE,
+                texture: "shippingContainerBody".into(),
+                tilemap: "tilemap".into(),
+                frame: 0.0,
+                frame_name: None,
+                tile_set_size: glam::Vec2::ONE,
+                anchor: glam::Vec2::new(0.5, 0.67),
+                frame_offset: Vec3::ZERO,
+                footprint: vec![],
+                ghost_group: 0,
+                color: [1.0, 1.0, 1.0, 1.0],
+            };
+
+            engine.spawn_named("unit");
+            let unit = *engine.names.get("unit").unwrap();
+            let mut unit_sprite = sprite.clone();
+            unit_sprite.frame = 42.0;
+            engine.world.insert_one(unit, unit_sprite).unwrap();
+
+            engine.spawn_named("copy_a");
+            let copy_a = *engine.names.get("copy_a").unwrap();
+            engine.world.insert_one(copy_a, sprite.clone()).unwrap();
+
+            engine.spawn_named("copy_b");
+            let copy_b = *engine.names.get("copy_b").unwrap();
+            engine.world.insert_one(copy_b, sprite.clone()).unwrap();
+
+            engine.spawn_named("rocket");
+            let rocket = *engine.names.get("rocket").unwrap();
+            engine
+                .world
+                .insert_one(
+                    rocket,
+                    classic_core::inventory::Inventory {
+                        capacity: 7,
+                        kind: "cargo_bay".into(),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+            rt.update(&mut engine, 0.016).unwrap();
+
+            assert_eq!(engine.world.get::<&IsoSprite>(copy_a).unwrap().frame, 42.0);
+            assert_eq!(engine.world.get::<&IsoSprite>(copy_b).unwrap().frame, 7.0);
+        },
+    );
+}
+
+#[test]
 fn guest_was_key_pressed_triggers_action() {
     with_each_runtime(
         r#"(module

--- a/crates/classic-rom/src/manifest.rs
+++ b/crates/classic-rom/src/manifest.rs
@@ -68,6 +68,14 @@ pub struct RomManifest {
     /// per-ROM versioning existed.
     #[serde(default)]
     pub version: Option<String>,
+    /// Item catalog: ROM-namespaced item definitions, interned by the host
+    /// into a per-ROM [`classic_core::inventory::ItemRegistry`] at load.
+    #[serde(default)]
+    pub items: Vec<classic_core::inventory::ItemDef>,
+    /// Inventory types: named per-class capacity multipliers used by the host
+    /// inventory mechanics.
+    #[serde(default)]
+    pub inventory_types: Vec<classic_core::inventory::InventoryType>,
 }
 
 fn default_format_version() -> u32 {
@@ -120,5 +128,32 @@ mod tests {
         let with = r#"{"shaders": [], "textures": [], "animations": [], "version": "0.2.0"}"#;
         let m: RomManifest = serde_json::from_str(with).unwrap();
         assert_eq!(m.version.as_deref(), Some("0.2.0"));
+    }
+
+    #[test]
+    fn items_and_inventory_types_deserialize_and_default_empty() {
+        let json = r#"{
+            "shaders": [],
+            "textures": [],
+            "animations": [],
+            "items": [
+                {"name": "shipping_container", "class": "container",
+                 "stack_rule": {"rule": "unit", "max_per_stack": 1}}
+            ],
+            "inventory_types": [
+                {"name": "cargo_bay", "capacity_mult": [["container", 1.0]]}
+            ]
+        }"#;
+        let m: RomManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.items.len(), 1);
+        assert_eq!(m.items[0].name, "shipping_container");
+        assert_eq!(m.inventory_types.len(), 1);
+        assert_eq!(m.inventory_types[0].name, "cargo_bay");
+
+        // Absent items/inventory_types default to empty.
+        let empty: RomManifest =
+            serde_json::from_str(r#"{"shaders":[],"textures":[],"animations":[]}"#).unwrap();
+        assert!(empty.items.is_empty());
+        assert!(empty.inventory_types.is_empty());
     }
 }


### PR DESCRIPTION
## Motivation

The lunar scene needs an RTS container-logistics loop — unload shipping
containers from the landed rocket, pick them up with the LRV, and drop them
off. That needs two generic host-side systems that don't exist yet: click /
drag-box multi-select with a silhouette highlight, and a ROM-namespaced
item/inventory model. This lands that foundation plus the guest SDK surface
the lunar ROM drives it through.

## Summary of changes

- Add `Selectable` and a host-owned `SelectionSet` (`select_at` / `select_box`
  / `selected_names`) with unit/building group semantics, plus a per-sprite
  selection silhouette in `sheet.frag`.
- Add the inventory catalog (`ItemId` / `ItemClass` / `StackRule` / `ItemDef`
  / `InventoryType` / `Inventory` / `ItemRegistry`) and host inventory I/O
  mechanics (add / remove / query / transfer).
- Expose the new surface to guests (`selected_names`, `selection_clear`,
  `inventory_*`, `item_def`, `vehicle_set_speed`, `vehicle_probe`,
  `vehicle_probe_clear`, `get_sprite_frame`, `set_sprite_offset`,
  `inventory_capacity`) with WAT fixtures.
- Wire RTS selection and a drop-preview path overlay into the demo; right-click
  clears the selection.

## Future follow up

- [ ] Production buildings consuming the inventory I/O rules.
- [ ] Save/load round-trip of live inventories.
- [ ] Full multi-LRV guest support (spawn `lrv_0..lrv_N` with per-LRV state).

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
