### PR TITLE
add container inventories with hover tooltip and nav blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ See [`VERSIONING.md`](VERSIONING.md) for the release policy and process.
   `vehicle_set_speed`, `vehicle_probe`, `vehicle_probe_clear`,
   `get_sprite_frame`, `set_sprite_offset`, `inventory_capacity`) (#80).
 - Drop-preview path overlay and right-click deselect in the demo (#80).
+- Container hover tooltip: a `UiKind::Grid` layout, packed-atlas icon sprites,
+  and a host-owned `InventoryUi` overlay showing item icons + counts above a
+  hovered container (#80).
+- Navigation blocking: `ColliderData.blocks_nav` + `set_collider_blocks_nav`
+  rasterize blocking footprints into the nav grid for humanoid and vehicle
+  pathfinding; `vehicle_footprint_radius` lets guests derive pickup/drop
+  clearance from the real footprints (#80).
 
 ## [0.1.0-alpha.0] - 2026-08-28
 

--- a/crates/classic-core/src/collision.rs
+++ b/crates/classic-core/src/collision.rs
@@ -349,6 +349,18 @@ impl PhysicsProvider {
         }
     }
 
+    /// Mark (or clear) a collider as a navigation obstacle.
+    pub fn set_collider_blocks_nav(&mut self, pid: u32, blocks: bool) {
+        if let Some(entry) = self.entries.get_mut(&pid) {
+            entry.collider.blocks_nav = blocks;
+        }
+    }
+
+    /// Whether a collider is marked as a navigation obstacle.
+    pub fn collider_blocks_nav(&self, pid: u32) -> bool {
+        self.entries.get(&pid).map(|e| e.collider.blocks_nav).unwrap_or(false)
+    }
+
     /// Return the pids of enabled colliders whose bounding rect contains the
     /// given screen point, ordered by click priority (desc) then pid (asc) —
     /// the same ordering click dispatch uses.

--- a/crates/classic-core/src/components/mod.rs
+++ b/crates/classic-core/src/components/mod.rs
@@ -616,6 +616,12 @@ pub struct ColliderData {
     /// Coordinate space of `shape`/`position`/`scale`.
     #[serde(default)]
     pub space: ColliderSpace,
+    /// Whether this collider's footprint blocks navigation (human + vehicle
+    /// pathfinding).  Toggled at runtime by guests via
+    /// `set_collider_blocks_nav`; the engine rasterizes blocking footprints
+    /// into the nav grid.
+    #[serde(default)]
+    pub blocks_nav: bool,
 }
 
 impl ColliderData {
@@ -629,6 +635,7 @@ impl ColliderData {
             consumes_click: false,
             click_priority: 0,
             space: ColliderSpace::Screen,
+            blocks_nav: false,
         }
     }
 

--- a/crates/classic-core/src/components/mod.rs
+++ b/crates/classic-core/src/components/mod.rs
@@ -695,6 +695,7 @@ pub enum UiAnchor {
 pub enum UiKind {
     Container,
     Array { vertical: bool, align: UiAlign, spacing: f32 },
+    Grid { columns: u32, col_gap: f32, row_gap: f32, row_align: UiAlign },
     Padding { top: f32, right: f32, bottom: f32, left: f32 },
     Text,
     SdfText,
@@ -706,6 +707,7 @@ impl UiKind {
         match self {
             UiKind::Container => "container",
             UiKind::Array { .. } => "array",
+            UiKind::Grid { .. } => "grid",
             UiKind::Padding { .. } => "padding",
             UiKind::Text => "text",
             UiKind::SdfText => "sdfText",

--- a/crates/classic-core/src/inventory.rs
+++ b/crates/classic-core/src/inventory.rs
@@ -75,6 +75,19 @@ pub struct ItemDef {
     /// Volume per unit item.  Informational for v1.
     #[serde(default)]
     pub volume: f32,
+    /// Icon frame name (resolved through the `icons` packed-atlas frame table).
+    /// `None` means the icon frame == the item `name` (they match by
+    /// convention).  A ROM may set an explicit override for future divergence.
+    #[serde(default)]
+    pub icon: Option<String>,
+}
+
+impl ItemDef {
+    /// The packed-atlas frame name to use for this item's icon, defaulting to
+    /// the item name when no explicit `icon` override is set.
+    pub fn icon_frame_name(&self) -> &str {
+        self.icon.as_deref().unwrap_or(&self.name)
+    }
 }
 
 /// A named inventory type (ROM manifest `inventory_types[]`).  `capacity_mult`
@@ -195,6 +208,7 @@ mod tests {
             stack_rule: StackRule::Bulk { max_per_stack: 100 },
             mass: 1.0,
             volume: 0.5,
+            icon: None,
         }
     }
 
@@ -212,6 +226,7 @@ mod tests {
             stack_rule: StackRule::Gaseous { pressure_factor: 2.0, max_per_stack: 500 },
             mass: 1.1,
             volume: 1.0,
+            icon: None,
         });
         assert_eq!(fuel, 1);
 
@@ -259,6 +274,28 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(def.stack_rule.max_per_stack(), 1);
+    }
+
+    #[test]
+    fn item_def_icon_defaults_to_name() {
+        let def: ItemDef = serde_json::from_value(serde_json::json!({
+            "name": "regolith",
+            "class": "ore",
+            "stack_rule": {"rule": "bulk", "max_per_stack": 50}
+        }))
+        .unwrap();
+        assert_eq!(def.icon, None);
+        assert_eq!(def.icon_frame_name(), "regolith");
+
+        let overridden: ItemDef = serde_json::from_value(serde_json::json!({
+            "name": "regolith",
+            "class": "ore",
+            "stack_rule": {"rule": "bulk", "max_per_stack": 50},
+            "icon": "regolith_alt"
+        }))
+        .unwrap();
+        assert_eq!(overridden.icon.as_deref(), Some("regolith_alt"));
+        assert_eq!(overridden.icon_frame_name(), "regolith_alt");
     }
 
     #[test]

--- a/crates/classic-engine/src/inventory.rs
+++ b/crates/classic-engine/src/inventory.rs
@@ -204,6 +204,14 @@ impl Engine {
         let _ = self.world.insert(to_e, (to_inv,));
         moved
     }
+
+    /// The sorted `(item_id, count)` stacks of a named entity's [`Inventory`]
+    /// (empty if the entity has none).  Host-internal + tests; the guest
+    /// populates contents via `inventory_add` and reads nothing back.
+    pub fn inventory_stacks(&self, name: &str) -> Vec<(ItemId, u32)> {
+        let Some(&entity) = self.names.get(name) else { return Vec::new() };
+        self.world.get::<&Inventory>(entity).map(|inv| inv.stacks.clone()).unwrap_or_default()
+    }
 }
 
 #[cfg(test)]
@@ -219,6 +227,7 @@ mod tests {
                 stack_rule: StackRule::Bulk { max_per_stack: 100 },
                 mass: 1.0,
                 volume: 0.5,
+                icon: None,
             },
             ItemDef {
                 name: "lox".into(),
@@ -226,6 +235,7 @@ mod tests {
                 stack_rule: StackRule::Gaseous { pressure_factor: 4.0, max_per_stack: 500 },
                 mass: 1.1,
                 volume: 1.0,
+                icon: None,
             },
             ItemDef {
                 name: "shipping_container".into(),
@@ -233,6 +243,7 @@ mod tests {
                 stack_rule: StackRule::Unit { max_per_stack: 1 },
                 mass: 2200.0,
                 volume: 33.0,
+                icon: None,
             },
         ];
         let types = vec![

--- a/crates/classic-engine/src/inventory_ui.rs
+++ b/crates/classic-engine/src/inventory_ui.rs
@@ -1,0 +1,261 @@
+//! # Skill: `classic-ui`
+//!
+//! **Read `.claude/skills/classic-ui/SKILL.md` before working on this module.**
+//!
+//! Host-owned container-inventory hover tooltip, rendered through the
+//! retained-mode UI toolkit as a single grid of icon + amount children.
+//!
+//! The guest is a thin *intent* layer: it reports *which* entity is hovered and
+//! *when* to show/hide (via [`Engine::inventory_ui_show`]); the host owns the
+//! inventory data and the rendering.  The guest populates inventory contents
+//! with the generic `inventory_add` import; the tooltip resolves icons and
+//! amounts host-side from the entity's [`Inventory`] + [`ItemRegistry`].
+
+use hecs::Entity;
+
+use classic_core::components::{
+    SdfTextRender, TextJustify, Transform, UiAlign, UiAnchor, UiNode, DEFAULT_SDF_FONT,
+};
+use classic_core::inventory::Inventory;
+use classic_core::sdf_builder::build_sdf_glyph_buffer;
+
+use crate::Engine;
+
+/// Packed-atlas texture holding the item icons (frame name == item name).
+const ICON_TEXTURE: &str = "icons";
+/// Target content size (px) of an icon cell.
+const ICON_SIZE: f32 = 48.0;
+/// SDF scale for the amount labels.
+const TEXT_SCALE: f32 = 0.6;
+const COL_GAP: f32 = 8.0;
+const ROW_GAP: f32 = 4.0;
+/// Gap (px) above the hovered container's ground anchor (the container sprite
+/// extends well above its contact point, so this clears its top edge; tune via
+/// the manual hover check).
+const VERT_OFFSET: f32 = 100.0;
+/// Z layer of the tooltip panel, below (more negative than) the default HUD
+/// (-1000) so the tooltip draws on top of it.  The render list is sorted
+/// descending and drawn forward, so the *smallest* (most-negative) sort key is
+/// drawn last = on top.
+const TOOLTIP_BG_Z: f32 = -1100.0;
+/// Z layer of the icon/amount cells, below the panel so they draw on top of it.
+const TOOLTIP_CELL_Z: f32 = -1200.0;
+const BG_COLOR: [f32; 4] = [0.0, 0.0, 0.0, 0.72];
+const TEXT_COLOR: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+
+/// Host-owned tooltip state: the hover target and the (lazily created) grid,
+/// plus the item signature the grid currently reflects.
+///
+/// A single `UiKind::Grid` is used (no wrapping `Padding`) so the grid owns its
+/// children's absolute layout: `layout_grid` positions cells relative to the
+/// grid's *current* `Transform.position`, so re-running it after moving the grid
+/// drags the cells along with it.  Nested wrappers break this (the wrapper
+/// repositions its child after the child has already laid out its own children).
+#[derive(Default)]
+pub struct InventoryUi {
+    target: Option<Entity>,
+    grid: Option<Entity>,
+    /// The grid's current children (icon + amount per item), despawned on
+    /// rebuild.
+    cells: Vec<Entity>,
+    /// The `(item_id, count)` signature the grid reflects.
+    signature: Vec<(u32, u32)>,
+    /// The entity the grid was last built for (a target switch rebuilds).
+    built_for: Option<Entity>,
+}
+
+impl InventoryUi {
+    /// Set (or clear) the hover target.  Empty target hides the tooltip.
+    pub fn set_target(&mut self, target: Option<Entity>) {
+        self.target = target;
+    }
+
+    /// Reconcile the tooltip with the current hover target.  Called each frame
+    /// from [`Engine::frame`] (via a take-and-restore so `self` can re-borrow
+    /// `engine`).  Rebuilds the grid contents only when the hovered entity or
+    /// its stacks change, but re-projects the panel to the container's screen
+    /// anchor every frame (so it tracks camera pan/zoom).  No-op until the demo
+    /// layer has installed a [`UIManager`].
+    pub fn sync(&mut self, engine: &mut Engine) {
+        let Some(target) = self.target else {
+            self.hide(engine);
+            return;
+        };
+
+        let Some(stacks) =
+            engine.world.get::<&Inventory>(target).ok().map(|inv| inv.stacks.clone())
+        else {
+            self.hide(engine);
+            return;
+        };
+        if stacks.is_empty() {
+            self.hide(engine);
+            return;
+        }
+
+        if self.grid.is_none() {
+            if engine.ui.is_none() {
+                return;
+            }
+            self.build(engine);
+        }
+
+        let changed = self.built_for != Some(target) || self.signature != stacks;
+        if changed {
+            self.rebuild(engine, &stacks);
+            self.signature = stacks;
+            self.built_for = Some(target);
+        }
+
+        self.position(engine, target);
+
+        if let Some(grid) = self.grid {
+            engine.set_enabled(grid, true);
+        }
+    }
+
+    fn hide(&mut self, engine: &mut Engine) {
+        if let Some(grid) = self.grid {
+            engine.set_enabled(grid, false);
+        }
+    }
+
+    /// Create the tooltip grid (hidden until populated).
+    fn build(&mut self, engine: &mut Engine) {
+        let Some(ui) = engine.ui.as_mut() else { return };
+        let grid = ui.spawn_grid(&mut engine.world, 2, COL_GAP, ROW_GAP, UiAlign::Center, BG_COLOR);
+        self.set_z(engine, grid);
+        engine.set_enabled(grid, false);
+        self.grid = Some(grid);
+    }
+
+    /// Rebuild the grid children from `stacks` (icon + amount per item).
+    fn rebuild(&mut self, engine: &mut Engine, stacks: &[(u32, u32)]) {
+        let Some(grid) = self.grid else { return };
+
+        // Despawn the previous cells and reset the grid's child list.
+        for e in self.cells.drain(..) {
+            let _ = engine.world.despawn(e);
+        }
+        if let Ok(mut node) = engine.world.get::<&mut UiNode>(grid) {
+            node.children.clear();
+        }
+
+        // Spawn fresh icon + amount cells in order (row-major, 2 columns).
+        let mut cells = Vec::new();
+        {
+            let Some(ui) = engine.ui.as_mut() else { return };
+            for (item_id, count) in stacks {
+                // Only spawn the icon when its frame resolves in the shared
+                // `icons` sheet — otherwise the UiSprite render arm would fall
+                // back to a blank grid frame.
+                let Some(def) = engine.items.def(*item_id) else { continue };
+                let icon = def.icon_frame_name().to_string();
+                if Engine::resolve_frame(&engine.frame_tables, ICON_TEXTURE, &icon).is_some() {
+                    let se = ui.spawn_sprite_frame(
+                        &mut engine.world,
+                        ICON_TEXTURE,
+                        &icon,
+                        ICON_SIZE,
+                        ICON_SIZE,
+                    );
+                    ui.container_add_child(
+                        &mut engine.world,
+                        grid,
+                        se,
+                        UiAnchor::TopLeft,
+                        UiAnchor::TopLeft,
+                    );
+                    cells.push(se);
+                }
+                let text = count.to_string();
+                let te = ui.spawn_sdf_text(
+                    &mut engine.world,
+                    &text,
+                    TEXT_SCALE,
+                    200.0,
+                    TEXT_COLOR,
+                    TextJustify::Left,
+                );
+                ui.container_add_child(
+                    &mut engine.world,
+                    grid,
+                    te,
+                    UiAnchor::TopLeft,
+                    UiAnchor::TopLeft,
+                );
+                cells.push(te);
+            }
+        }
+        // Measure the freshly spawned amount labels (the render loop only
+        // measures them on the following frame) before the next layout.
+        for e in &cells {
+            self.measure_text(engine, *e);
+        }
+        self.set_z(engine, grid);
+        self.cells = cells;
+    }
+
+    /// Re-project the tooltip to the target's screen anchor and re-run the grid
+    /// layout so the cells track the grid.  Called every frame while hovering.
+    fn position(&mut self, engine: &mut Engine, target: Entity) {
+        let Some(grid) = self.grid else { return };
+
+        let (x, y) = engine
+            .world
+            .get::<&Transform>(target)
+            .map(|t| (t.position.x, t.position.y))
+            .unwrap_or((0.0, 0.0));
+        let Some((sx, sy)) = engine.iso_to_screen_px(x, y) else { return };
+
+        // First layout: size the grid (and place cells at its current spot).
+        if let Some(ui) = engine.ui.as_mut() {
+            ui.layout_standalone(grid, &mut engine.world);
+        }
+        let (w, h) =
+            engine.world.get::<&UiNode>(grid).map(|n| (n.size.x, n.size.y)).unwrap_or((0.0, 0.0));
+
+        if let Ok(mut tf) = engine.world.get::<&mut Transform>(grid) {
+            tf.position.x = sx - w / 2.0;
+            tf.position.y = sy - h - VERT_OFFSET;
+        }
+        // Second layout: re-position the cells under the moved grid.
+        if let Some(ui) = engine.ui.as_mut() {
+            ui.layout_standalone(grid, &mut engine.world);
+        }
+    }
+
+    /// Measure an SDF text cell and write its true size into `UiNode.size`.
+    fn measure_text(&self, engine: &mut Engine, entity: Entity) {
+        let Ok(text) = engine.world.get::<&SdfTextRender>(entity).map(|s| s.text.clone()) else {
+            return;
+        };
+        let scale = engine.world.get::<&Transform>(entity).map(|t| t.scale.x).unwrap_or(1.0);
+        let Some(font) = engine.sdf_fonts.get(DEFAULT_SDF_FONT).cloned() else { return };
+        let buf = build_sdf_glyph_buffer(&font, &text, scale, TextJustify::Left, 0.0);
+        if let Ok(mut node) = engine.world.get::<&mut UiNode>(entity) {
+            node.size.x = buf.text_width;
+            node.size.y = buf.text_height;
+        }
+    }
+
+    /// Set the draw Z: the panel itself gets [`TOOLTIP_BG_Z`] and every
+    /// descendant (the icon/amount cells) gets [`TOOLTIP_CELL_Z`], so the cells
+    /// draw on top of the panel background.
+    fn set_z(&self, engine: &mut Engine, grid: Entity) {
+        if let Ok(mut tf) = engine.world.get::<&mut Transform>(grid) {
+            tf.position.z = TOOLTIP_BG_Z;
+        }
+        let mut stack = vec![grid];
+        while let Some(e) = stack.pop() {
+            if let Ok(node) = engine.world.get::<&UiNode>(e) {
+                for child in &node.children {
+                    if let Ok(mut ctf) = engine.world.get::<&mut Transform>(child.entity) {
+                        ctf.position.z = TOOLTIP_CELL_Z;
+                    }
+                    stack.push(child.entity);
+                }
+            }
+        }
+    }
+}

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -173,6 +173,10 @@ pub struct Engine {
     /// engine can update a named entity's collider in place instead of
     /// re-registering it every frame.
     collider_pids: HashMap<String, u32>,
+    /// Names whose collider is owned by `sync_selectable_colliders` (world-space
+    /// footprint colliders), so the disabled-cleanup pass can disable stale ones
+    /// without touching screen-space `spawn_collider` colliders.
+    selectable_colliders: HashSet<String>,
     /// The host-owned RTS selection set (see `selection.rs`).
     pub selection: selection::SelectionSet,
     /// Active RTS drag-box rubber band, `Some((begin, end))` in screen space
@@ -344,6 +348,7 @@ impl Engine {
             physics: PhysicsProvider::new(),
             collider_names: HashMap::new(),
             collider_pids: HashMap::new(),
+            selectable_colliders: HashSet::new(),
             subscribed: HashSet::new(),
             guest_events: VecDeque::new(),
             guest_hover: None,
@@ -1201,6 +1206,15 @@ impl Engine {
         Some((tm.mouse_iso_pos.x, tm.mouse_iso_pos.y))
     }
 
+    /// Show the container-inventory hover tooltip for a named entity, or hide
+    /// it when `name` is empty.  The host resolves the entity and renders the
+    /// tooltip from its `Inventory`; the guest only supplies *which* entity is
+    /// hovered and *when* to show/hide.
+    pub fn inventory_ui_show(&mut self, name: &str) {
+        let target = if name.is_empty() { None } else { self.names.get(name).copied() };
+        self.inventory_ui.set_target(target);
+    }
+
     /// Project an iso tile coordinate to screen space, using the Tilemap-role
     /// entity's scale.  Returns `None` when no Tilemap-role entity exists.
     pub fn iso_to_screen(&self, x: f32, y: f32) -> Option<(f32, f32)> {
@@ -1477,7 +1491,8 @@ impl Engine {
         jump_cost: f32,
         turn_cost: f32,
     ) -> Option<Vec<(i32, i32)>> {
-        let snapshot = self.build_vehicle_nav_snapshot()?;
+        let obstacles = self.compute_nav_obstacles();
+        let snapshot = self.build_vehicle_nav_snapshot(&obstacles)?;
         let result = pathfinder::find_vehicle_path_snapshot(
             &snapshot,
             from,
@@ -1516,7 +1531,11 @@ impl Engine {
             };
             (nav.size_x, nav.size_y, nav.data.iter().map(|&v| v as i32).collect::<Vec<_>>())
         };
-        let snapshot = Arc::new(pathfinder::NavSnapshot::new(size_x, size_y, data));
+        // Unified obstacles: footprints of `blocks_nav` colliders block both
+        // humanoid and vehicle pathfinding.
+        let obstacles = self.compute_nav_obstacles();
+        let combined: Vec<i32> = data.iter().zip(&obstacles).map(|(&d, &o)| d & o).collect();
+        let snapshot = Arc::new(pathfinder::NavSnapshot::new(size_x, size_y, combined));
         if let Some(worker) = self.pathfinder.as_mut() {
             worker.set_snapshot(Arc::clone(&snapshot));
         }
@@ -1524,7 +1543,7 @@ impl Engine {
 
         // Rebuild + push the vehicle nav snapshot (structural nav + heights +
         // height/tile scale) so the worker can run vehicle A* off-thread too.
-        if let Some(vehicle_snapshot) = self.build_vehicle_nav_snapshot() {
+        if let Some(vehicle_snapshot) = self.build_vehicle_nav_snapshot(&obstacles) {
             if let Some(worker) = self.pathfinder.as_mut() {
                 worker.set_vehicle_snapshot(Arc::clone(&vehicle_snapshot));
             }
@@ -1535,21 +1554,62 @@ impl Engine {
         self.nav_version = self.nav_version.wrapping_add(1);
     }
 
+    /// Build the unified obstacle grid (0 = blocked, 1 = open) from the
+    /// footprints of every non-disabled entity whose collider has `blocks_nav`
+    /// set.  Used for both humanoid and vehicle pathfinding.
+    fn compute_nav_obstacles(&self) -> Vec<i32> {
+        let Some(nav_entity) = self.entity_by_role(RoleKind::NavMesh) else { return Vec::new() };
+        let Ok(nav) = self.world.get::<&NavMesh>(nav_entity) else { return Vec::new() };
+        let (size_x, size_y) = (nav.size_x, nav.size_y);
+        let mut grid = vec![1i32; (size_x * size_y) as usize];
+
+        for (entity, (iso, tf)) in self.world.query::<(&IsoSprite, &Transform)>().iter() {
+            if self.is_disabled(entity) || iso.footprint.is_empty() {
+                continue;
+            }
+            let name = self.debug_name(entity);
+            let Some(&pid) = self.collider_pids.get(&name) else { continue };
+            if !self.physics.collider_blocks_nav(pid) {
+                continue;
+            }
+            // Rasterize the footprint AABB (iso tile coords at the entity position).
+            let mut min_x = f32::INFINITY;
+            let mut max_x = f32::NEG_INFINITY;
+            let mut min_y = f32::INFINITY;
+            let mut max_y = f32::NEG_INFINITY;
+            for pt in &iso.footprint {
+                min_x = min_x.min(tf.position.x + pt.x);
+                max_x = max_x.max(tf.position.x + pt.x);
+                min_y = min_y.min(tf.position.y + pt.y);
+                max_y = max_y.max(tf.position.y + pt.y);
+            }
+            let x0 = (min_x.floor() as i32).clamp(0, size_x - 1);
+            let x1 = (max_x.floor() as i32).clamp(0, size_x - 1);
+            let y0 = (min_y.floor() as i32).clamp(0, size_y - 1);
+            let y1 = (max_y.floor() as i32).clamp(0, size_y - 1);
+            for ty in y0..=y1 {
+                for tx in x0..=x1 {
+                    grid[(ty * size_x + tx) as usize] = 0;
+                }
+            }
+        }
+        grid
+    }
+
     /// Build the [`pathfinder::VehicleNavSnapshot`] the worker uses for vehicle
     /// A*, from the live `NavMesh` (structural nav) and `Tilemap` (heights +
     /// scales).  Returns `None` when either component is missing.
-    fn build_vehicle_nav_snapshot(&self) -> Option<Arc<pathfinder::VehicleNavSnapshot>> {
+    fn build_vehicle_nav_snapshot(
+        &self,
+        obstacles: &[i32],
+    ) -> Option<Arc<pathfinder::VehicleNavSnapshot>> {
         let nav_entity = self.entity_by_role(RoleKind::NavMesh)?;
         let nav = self.world.get::<&NavMesh>(nav_entity).ok()?;
         let size_x = nav.size_x;
         let size_y = nav.size_y;
-        // The terrain nav grid encodes slope-limited *human* walkability, not
-        // obstacles.  A vehicle derives climbability from its own per-request
-        // pitch/roll tolerance, so the shared snapshot's `structural` grid only
-        // needs to gate hard obstacles.  No current vehicle scene (lunar,
-        // lrvtest, container) has any, so treat it as fully open and let
-        // pitch/roll be the sole slope gate.
-        let structural: Vec<i32> = vec![1; (size_x * size_y) as usize];
+        // The vehicle `structural` grid gates hard obstacles (blocking
+        // colliders); slope climbability is derived per-request from pitch/roll.
+        let structural: Vec<i32> = obstacles.to_vec();
 
         let tm_entity = self.entity_by_role(RoleKind::Tilemap)?;
         let tm = self.world.get::<&Tilemap>(tm_entity).ok()?;
@@ -1722,10 +1782,52 @@ impl Engine {
         true
     }
 
-    /// The name of the top gameplay entity under a screen point, if any.
-    pub fn pick_at(&self, x: f32, y: f32) -> Option<String> {
-        let pid = self.physics.point_query(x, y).into_iter().next()?;
-        self.collider_names.get(&pid).cloned()
+    /// The name of the top gameplay entity under a screen point, optionally
+    /// filtered to entities carrying `filter`'s component (empty = any).  The
+    /// filter is a component type name (e.g. `"Inventory"`, `"Selectable"`);
+    /// an unknown name matches nothing.
+    pub fn pick_at(&self, x: f32, y: f32, filter: &str) -> Option<String> {
+        self.physics.point_query(x, y).into_iter().find_map(|pid| {
+            let name = self.collider_names.get(&pid)?;
+            if filter.is_empty() {
+                return Some(name.clone());
+            }
+            let entity = self.names.get(name)?;
+            if self.has_component(*entity, filter) {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Mark (or clear) a named entity's collider as a navigation obstacle.
+    /// Rebuilds the nav snapshots so the change is reflected immediately.
+    /// Returns `false` when the entity has no registered collider.
+    pub fn set_collider_blocks_nav(&mut self, name: &str, blocks: bool) -> bool {
+        if let Some(&pid) = self.collider_pids.get(name) {
+            self.physics.set_collider_blocks_nav(pid, blocks);
+            self.refresh_nav_snapshot();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether `entity` carries the named component.  The empty name matches
+    /// every entity; recognized component type names map to a runtime check.
+    fn has_component(&self, entity: hecs::Entity, name: &str) -> bool {
+        match name {
+            "" => true,
+            "Inventory" => self.world.get::<&classic_core::inventory::Inventory>(entity).is_ok(),
+            "Selectable" => self.world.get::<&Selectable>(entity).is_ok(),
+            "IsoSprite" => self.world.get::<&IsoSprite>(entity).is_ok(),
+            "IsoVehicle" => self.world.get::<&IsoVehicle>(entity).is_ok(),
+            "Sprite" => self.world.get::<&SpriteRender>(entity).is_ok(),
+            "SdfTextRender" => self.world.get::<&SdfTextRender>(entity).is_ok(),
+            "Tilemap" => self.world.get::<&Tilemap>(entity).is_ok(),
+            _ => false,
+        }
     }
 
     /// The name of the top *subscribed* entity under a screen point, if any.

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod env_config;
 pub mod golden;
 pub mod inventory;
+pub mod inventory_ui;
 pub mod selection;
 pub mod ui;
 pub mod vehicle;
@@ -134,23 +135,23 @@ struct SdfTextGpu {
 }
 
 /// A frame resolved through a packed-atlas frame table.
-struct ResolvedFrame {
-    sheet_name: String,
-    uv_rect: [f32; 4],
+pub(crate) struct ResolvedFrame {
+    pub(crate) sheet_name: String,
+    pub(crate) uv_rect: [f32; 4],
     /// Content pixel size (frame rect w/h).
-    size: [f32; 2],
+    pub(crate) size: [f32; 2],
     /// Untrimmed source cell size (0 = unknown).
-    source_size: [u32; 2],
+    pub(crate) source_size: [u32; 2],
     /// Offset of the trimmed content within the source cell.
-    trim_offset: [i32; 2],
+    pub(crate) trim_offset: [i32; 2],
     /// Optional packer-provided anchor, already in trimmed-frame `[0..1]`.
-    anchor: Option<[f32; 2]>,
+    pub(crate) anchor: Option<[f32; 2]>,
     /// Per-sheet normal-map GL texture name (`"{sheet_name}-normal"`), set when
     /// the frame's sheet declares a `normal` companion.
-    normal_tex: Option<String>,
+    pub(crate) normal_tex: Option<String>,
     /// Per-sheet depth-map GL texture name + depth range, set when the frame's
     /// sheet declares a `depth` companion.
-    depth_tex: Option<(String, f32)>,
+    pub(crate) depth_tex: Option<(String, f32)>,
 }
 
 pub struct Engine {
@@ -270,6 +271,9 @@ pub struct Engine {
     guest_worker: Option<classic_worker::GuestWorker>,
     /// Host-owned named-field registry (grid kernels operate over these).
     pub fields: fields::FieldRegistry,
+    /// Host-owned container-inventory tooltip renderer (hover target + icon/
+    /// amount overlay).  Drives the overlay drawn each frame in `frame()`.
+    pub inventory_ui: inventory_ui::InventoryUi,
     nav_gpu: Option<TilemapGpu>,
     debug_frame: u64,
     pre_update_hooks: Vec<UpdateFn>,
@@ -389,6 +393,7 @@ impl Engine {
             next_task_id: 0,
             guest_worker: None,
             fields: fields::FieldRegistry::default(),
+            inventory_ui: inventory_ui::InventoryUi::default(),
             nav_gpu: None,
             debug_frame: 0,
             pre_update_hooks: Vec::new(),
@@ -2396,6 +2401,14 @@ impl Engine {
             }
         }
 
+        // Container-inventory hover tooltip (host-owned).  Reconcile it before
+        // the render list is built so show/hide, content, and position are
+        // atomic with this frame's render — no one-frame lag on hover changes
+        // or camera pan/zoom.  Take-and-restore so `sync` can re-borrow `self`.
+        let mut inventory_ui = std::mem::take(&mut self.inventory_ui);
+        inventory_ui.sync(self);
+        self.inventory_ui = inventory_ui;
+
         // Render-list: sprites + tilemaps + iso sprites
         let mut items: Vec<(f32, hecs::Entity, DrawKind)> = Vec::new();
         for (e, (tf, sprite)) in self.world.query::<(&Transform, &SpriteRender)>().iter() {
@@ -2966,8 +2979,55 @@ impl Engine {
                         .get::<&classic_core::components::UiNode>(*entity)
                         .map(|n| (n.size.x, n.size.y))
                         .unwrap_or((tf.scale.x, tf.scale.y));
-                    let model = Mat4::from_translation(tf.position)
-                        * Mat4::from_scale(Vec3::new(w, h, 1.0));
+                    let frame_ref = sprite
+                        .frame_name
+                        .as_deref()
+                        .and_then(|n| Self::resolve_frame(&self.frame_tables, &sprite.texture, n));
+                    let mut uv: Option<IsoUv> = None;
+                    let model = match &frame_ref {
+                        Some(fr) => {
+                            let sw = if fr.source_size[0] > 0 {
+                                fr.source_size[0] as f32
+                            } else {
+                                fr.size[0]
+                            };
+                            let sh = if fr.source_size[1] > 0 {
+                                fr.source_size[1] as f32
+                            } else {
+                                fr.size[1]
+                            };
+                            let (cw, ch) = (fr.size[0], fr.size[1]);
+                            // Fit the trimmed content into the `(w, h)` box,
+                            // preserving aspect and centered.  The trim offset
+                            // is compensated so the content (not the source
+                            // cell) lands in the middle of the box — icon
+                            // frames are trimmed out of a larger source cell.
+                            let scale =
+                                if cw > 0.0 && ch > 0.0 { (w / cw).min(h / ch) } else { 1.0 };
+                            let (bx, by) = (fr.trim_offset[0] as f32, fr.trim_offset[1] as f32);
+                            let off_x = (w - cw * scale) / 2.0 - bx * scale;
+                            let off_y = (h - ch * scale) / 2.0 - by * scale;
+                            uv = Some((fr.uv_rect, [bx, by], [sw, sh], [cw, ch]));
+                            Mat4::from_translation(Vec3::new(
+                                tf.position.x + off_x,
+                                tf.position.y + off_y,
+                                tf.position.z,
+                            )) * Mat4::from_scale(Vec3::new(sw * scale, sh * scale, 1.0))
+                        }
+                        None => {
+                            Mat4::from_translation(tf.position)
+                                * Mat4::from_scale(Vec3::new(w, h, 1.0))
+                        }
+                    };
+                    let region = match &uv {
+                        Some((uv_rect, trim_offset, source_size, content_size)) => {
+                            SpriteRegion::Uv { uv_rect, trim_offset, source_size, content_size }
+                        }
+                        None => {
+                            let ts = [sprite.tile_set_size.x, sprite.tile_set_size.y];
+                            SpriteRegion::Grid { frame: sprite.frame, tile_set_size: ts }
+                        }
+                    };
                     if let Some(ref mut t) = self.trace {
                         let name = name_by_entity.get(entity).copied().unwrap_or("");
                         t.push(golden::TraceItemParams {
@@ -2984,12 +3044,11 @@ impl Engine {
                             normal: None,
                         });
                     }
-                    let ts = [sprite.tile_set_size.x, sprite.tile_set_size.y];
                     gfx.draw_sprite(
                         &model,
                         &Mat4::IDENTITY,
                         &sprite.texture,
-                        SpriteRegion::Grid { frame: sprite.frame, tile_set_size: ts },
+                        region,
                         true,
                         1.0,
                         &sprite_settings,
@@ -3674,7 +3733,7 @@ impl Engine {
     /// the frame's content pixel size, its trim/anchor metadata, and any
     /// per-sheet normal/depth companion GL texture names.  Returns `None` if
     /// the texture has no frame table or the name is unknown.
-    fn resolve_frame(
+    pub(crate) fn resolve_frame(
         tables: &HashMap<String, FrameTable>,
         texture: &str,
         frame_name: &str,

--- a/crates/classic-engine/src/selection.rs
+++ b/crates/classic-engine/src/selection.rs
@@ -9,7 +9,7 @@
 //! results (collider pid → name → entity) and gates on the [`Selectable`]
 //! component.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 
 use classic_core::collision::polygon_from_verts;
 use classic_core::components::{
@@ -263,12 +263,27 @@ impl Engine {
         }
 
         // Phase 2: register or update colliders in place.
+        let mut active: HashSet<String> = HashSet::new();
         for (name, shape) in updates {
+            active.insert(name.clone());
             if let Some(&pid) = self.collider_pids.get(&name) {
                 self.physics.update_world_shape(pid, shape);
+                self.physics.set_collider_enabled(pid, true);
             } else {
                 self.register_named_collider(&name, ColliderData::world(shape));
             }
+            self.selectable_colliders.insert(name);
+        }
+
+        // Phase 3: disable stale selectable colliders (their entity became
+        // disabled or lost its Selectable), so point_query/pick_at skip them.
+        let stale: Vec<String> =
+            self.selectable_colliders.iter().filter(|n| !active.contains(*n)).cloned().collect();
+        for name in stale {
+            if let Some(&pid) = self.collider_pids.get(&name) {
+                self.physics.set_collider_enabled(pid, false);
+            }
+            self.selectable_colliders.remove(&name);
         }
     }
 }

--- a/crates/classic-engine/src/ui.rs
+++ b/crates/classic-engine/src/ui.rs
@@ -222,6 +222,40 @@ impl UIManager {
         e
     }
 
+    /// Create a grid layout container: children are laid out row-major into
+    /// `columns` columns, each column as wide as its widest child and each row
+    /// as tall as its tallest child.  `row_align` aligns a child vertically
+    /// within its row (`Left` = top, `Center` = middle, `Right` = bottom).
+    pub fn spawn_grid(
+        &mut self,
+        world: &mut World,
+        columns: u32,
+        col_gap: f32,
+        row_gap: f32,
+        row_align: UiAlign,
+        color: [f32; 4],
+    ) -> hecs::Entity {
+        let name = self.gen_name("grid");
+        let e = world.spawn((
+            Transform::new(glam::Vec3::new(0.0, 0.0, self.zlayer as f32), glam::Vec3::ONE),
+            RectRender { color, ignore_cam: true },
+            UiNode {
+                parent: None,
+                children: Vec::new(),
+                size: Vec2::new(10.0, 10.0),
+                anchor: UiAnchor::TopLeft,
+                fixed: false,
+                clip_children: false,
+                scroll_y: 0.0,
+                clip_rect: Vec4::ZERO,
+                kind: UiKind::Grid { columns, col_gap, row_gap, row_align },
+            },
+        ));
+        self.elements.insert(name, e);
+        self.mark_dirty();
+        e
+    }
+
     /// Create a single-child padding wrapper.
     pub fn spawn_padding(
         &mut self,
@@ -274,6 +308,49 @@ impl UIManager {
                 frame,
                 frame_name: None,
                 tile_set_size: glam::Vec2::new(tile_set_size[0], tile_set_size[1]),
+                anchor: glam::Vec2::ZERO,
+            },
+            UiNode {
+                parent: None,
+                children: Vec::new(),
+                size: Vec2::new(width, height),
+                anchor: UiAnchor::TopLeft,
+                fixed: false,
+                clip_children: false,
+                scroll_y: 0.0,
+                clip_rect: Vec4::ZERO,
+                kind: UiKind::Sprite,
+            },
+        ));
+        self.elements.insert(name, e);
+        self.mark_dirty();
+        e
+    }
+
+    /// Create a packed-atlas sprite UI element, addressed by `frame_name`
+    /// through the texture's frame table (e.g. an inventory icon drawn from the
+    /// shared `icons` sheet).  `width`/`height` are the target content pixel
+    /// size; the render arm resolves the frame and scales the trimmed content
+    /// to that box.
+    pub fn spawn_sprite_frame(
+        &mut self,
+        world: &mut World,
+        texture: &str,
+        frame_name: &str,
+        width: f32,
+        height: f32,
+    ) -> hecs::Entity {
+        let name = self.gen_name("sprite-frame");
+        let e = world.spawn((
+            Transform::new(glam::Vec3::new(0.0, 0.0, self.zlayer as f32), glam::Vec3::ONE),
+            SpriteRender {
+                position: glam::Vec3::ZERO,
+                scale: glam::Vec3::ONE,
+                texture: texture.to_string(),
+                ignore_cam: true,
+                frame: 0.0,
+                frame_name: Some(frame_name.to_string()),
+                tile_set_size: glam::Vec2::ONE,
                 anchor: glam::Vec2::ZERO,
             },
             UiNode {
@@ -503,6 +580,9 @@ impl UIManager {
             UiKind::Array { .. } => {
                 self.layout_array(entity, world);
             }
+            UiKind::Grid { .. } => {
+                self.layout_grid(entity, world);
+            }
             UiKind::Padding { .. } => {
                 self.layout_padding(entity, world);
             }
@@ -609,6 +689,99 @@ impl UIManager {
             }
 
             offset += main + spacing;
+        }
+    }
+
+    /// Layout for UIGrid: measure children, size self to a row-major grid of
+    /// `columns` columns, and position each child in its cell.
+    fn layout_grid(&self, entity: hecs::Entity, world: &mut World) {
+        let (columns, col_gap, row_gap, row_align) =
+            match world.get::<&UiNode>(entity).unwrap().kind.clone() {
+                UiKind::Grid { columns, col_gap, row_gap, row_align } => {
+                    (columns, col_gap, row_gap, row_align)
+                }
+                _ => return,
+            };
+        let columns = (columns.max(1)) as usize;
+
+        let children: Vec<hecs::Entity> = world
+            .get::<&UiNode>(entity)
+            .map(|n| n.children.iter().map(|c| c.entity).collect())
+            .unwrap_or_default();
+
+        for &child in &children {
+            self.measure_and_position(child, world);
+        }
+
+        let enabled: Vec<(hecs::Entity, f32, f32)> = children
+            .iter()
+            .filter_map(|&e| {
+                if world.get::<&Disabled>(e).is_ok() {
+                    return None;
+                }
+                world.get::<&UiNode>(e).ok().map(|n| (e, n.size.x, n.size.y))
+            })
+            .collect();
+
+        if enabled.is_empty() {
+            if let Ok(mut node) = world.get::<&mut UiNode>(entity) {
+                node.size = Vec2::ZERO;
+            }
+            if let Ok(mut tf) = world.get::<&mut Transform>(entity) {
+                tf.scale.x = 0.0;
+                tf.scale.y = 0.0;
+            }
+            return;
+        }
+
+        let rows = enabled.len().div_ceil(columns);
+        let mut col_w = vec![0.0_f32; columns];
+        let mut row_h = vec![0.0_f32; rows];
+        for (i, &(_e, w, h)) in enabled.iter().enumerate() {
+            col_w[i % columns] = col_w[i % columns].max(w);
+            row_h[i / columns] = row_h[i / columns].max(h);
+        }
+
+        let total_w: f32 = col_w.iter().sum::<f32>() + col_gap * (columns.saturating_sub(1)) as f32;
+        let total_h: f32 = row_h.iter().sum::<f32>() + row_gap * (rows.saturating_sub(1)) as f32;
+
+        {
+            let mut node = world.get::<&mut UiNode>(entity).unwrap();
+            node.size = Vec2::new(total_w, total_h);
+        }
+        {
+            let mut tf = world.get::<&mut Transform>(entity).unwrap();
+            tf.scale.x = total_w;
+            tf.scale.y = total_h;
+        }
+
+        let (px, py) = {
+            let tf = world.get::<&Transform>(entity).unwrap();
+            (tf.position.x, tf.position.y)
+        };
+
+        // Column start offsets.
+        let mut col_x = vec![0.0_f32; columns];
+        for c in 1..columns {
+            col_x[c] = col_x[c - 1] + col_w[c - 1] + col_gap;
+        }
+        let mut row_y = vec![0.0_f32; rows];
+        for r in 1..rows {
+            row_y[r] = row_y[r - 1] + row_h[r - 1] + row_gap;
+        }
+
+        for (i, &(e, _w, h)) in enabled.iter().enumerate() {
+            let col = i % columns;
+            let row = i / columns;
+            let y_off = match row_align {
+                UiAlign::Left => 0.0,
+                UiAlign::Center => (row_h[row] - h) / 2.0,
+                UiAlign::Right => row_h[row] - h,
+            };
+            if let Ok(mut tf) = world.get::<&mut Transform>(e) {
+                tf.position.x = px + col_x[col];
+                tf.position.y = py + row_y[row] + y_off;
+            }
         }
     }
 

--- a/crates/classic-engine/src/vehicle.rs
+++ b/crates/classic-engine/src/vehicle.rs
@@ -1311,6 +1311,17 @@ impl Engine {
         let had_path = self.preview_paths.remove(name).is_some();
         had_probe || had_path
     }
+
+    /// The max tile radius of a vehicle's collision `path_footprint` (the
+    /// Chebyshev extent `max(|dx|, |dy|)` over its integer cell offsets).
+    /// Guests use it to derive a pick-up/drop clearance from the vehicle's real
+    /// footprint instead of guessing a fixed offset.  Returns `-1.0` when the
+    /// vehicle is unknown.
+    pub fn vehicle_footprint_radius(&self, name: &str) -> f64 {
+        let Some(&ve) = self.names.get(name) else { return -1.0 };
+        let Ok(v) = self.world.get::<&IsoVehicle>(ve) else { return -1.0 };
+        v.path_footprint.iter().map(|(dx, dy)| dx.abs().max(dy.abs())).max().unwrap_or(0) as f64
+    }
 }
 
 #[cfg(test)]

--- a/crates/classic-guest/src/imports.rs
+++ b/crates/classic-guest/src/imports.rs
@@ -425,6 +425,15 @@ macro_rules! install_host_imports {
 
         $linker.func_wrap(
             m,
+            "vehicle_footprint_radius",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32| -> f64 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().vehicle_footprint_radius(&name)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
             "selected_names",
             |mut caller: Caller<'_, $host>, out_ptr: i32, out_cap: i32| -> i32 {
                 let json = caller.data_mut().guest_mut().selected_names();
@@ -537,6 +546,15 @@ macro_rules! install_host_imports {
 
         $linker.func_wrap(
             m,
+            "inventory_ui_show",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().inventory_ui_show(&name)
+            },
+        )?;
+
+        $linker.func_wrap(
+            m,
             "get_camera",
             |mut caller: Caller<'_, $host>, out_ptr: i32| -> i32 {
                 let (x, y, s) = caller.data_mut().guest_mut().get_camera();
@@ -560,8 +578,16 @@ macro_rules! install_host_imports {
         $linker.func_wrap(
             m,
             "pick_at",
-            |mut caller: Caller<'_, $host>, x: f64, y: f64, out_ptr: i32, out_cap: i32| -> i32 {
-                let name = caller.data_mut().guest_mut().pick_at(x, y);
+            |mut caller: Caller<'_, $host>,
+             x: f64,
+             y: f64,
+             filter_ptr: i32,
+             filter_len: i32,
+             out_ptr: i32,
+             out_cap: i32|
+             -> i32 {
+                let filter = $read_str(&mut caller, filter_ptr, filter_len);
+                let name = caller.data_mut().guest_mut().pick_at(x, y, &filter);
                 if out_cap < name.len() as i32 {
                     return -1;
                 }
@@ -572,6 +598,15 @@ macro_rules! install_host_imports {
         $linker.func_wrap(m, "mouse_down", |mut caller: Caller<'_, $host>, btn: i32| -> i32 {
             caller.data_mut().guest_mut().mouse_down(btn)
         })?;
+
+        $linker.func_wrap(
+            m,
+            "set_collider_blocks_nav",
+            |mut caller: Caller<'_, $host>, ptr: i32, len: i32, blocks: i32| -> i32 {
+                let name = $read_str(&mut caller, ptr, len);
+                caller.data_mut().guest_mut().set_collider_blocks_nav(&name, blocks)
+            },
+        )?;
 
         $linker.func_wrap(
             m,

--- a/crates/classic-guest/src/runtime_web.rs
+++ b/crates/classic-guest/src/runtime_web.rs
@@ -1090,6 +1090,22 @@ impl WebWasmRuntime {
             );
         }
 
+        // vehicle_footprint_radius
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "vehicle_footprint_radius",
+                Box::new(move |ptr: i32, len: i32| -> f64 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().vehicle_footprint_radius(&name)
+                }) as Box<dyn FnMut(i32, i32) -> f64>
+            );
+        }
+
         // selected_names
         {
             let host = host.clone();
@@ -1239,6 +1255,22 @@ impl WebWasmRuntime {
             );
         }
 
+        // inventory_ui_show
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "inventory_ui_show",
+                Box::new(move |ptr: i32, len: i32| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().inventory_ui_show(&name)
+                }) as Box<dyn FnMut(i32, i32) -> i32>
+            );
+        }
+
         // get_camera
         {
             let host = host.clone();
@@ -1281,14 +1313,42 @@ impl WebWasmRuntime {
             let mem = mem.clone();
             set_import!(
                 "pick_at",
-                Box::new(move |x: f64, y: f64, out_ptr: i32, out_cap: i32| -> i32 {
-                    let name = host.borrow_mut().pick_at(x, y);
-                    if out_cap < name.len() as i32 {
-                        return -1;
-                    }
-                    let mem = mem.borrow();
-                    write_str(mem.as_ref().unwrap(), out_ptr, &name)
-                }) as Box<dyn FnMut(f64, f64, i32, i32) -> i32>
+                Box::new(
+                    move |x: f64,
+                          y: f64,
+                          filter_ptr: i32,
+                          filter_len: i32,
+                          out_ptr: i32,
+                          out_cap: i32|
+                          -> i32 {
+                        let filter = {
+                            let mem = mem.borrow();
+                            read_str(mem.as_ref().unwrap(), filter_ptr, filter_len)
+                        };
+                        let name = host.borrow_mut().pick_at(x, y, &filter);
+                        if out_cap < name.len() as i32 {
+                            return -1;
+                        }
+                        let mem = mem.borrow();
+                        write_str(mem.as_ref().unwrap(), out_ptr, &name)
+                    },
+                ) as Box<dyn FnMut(f64, f64, i32, i32, i32, i32) -> i32>
+            );
+        }
+
+        // set_collider_blocks_nav
+        {
+            let host = host.clone();
+            let mem = mem.clone();
+            set_import!(
+                "set_collider_blocks_nav",
+                Box::new(move |ptr: i32, len: i32, blocks: i32| -> i32 {
+                    let name = {
+                        let mem = mem.borrow();
+                        read_str(mem.as_ref().unwrap(), ptr, len)
+                    };
+                    host.borrow_mut().set_collider_blocks_nav(&name, blocks)
+                }) as Box<dyn FnMut(i32, i32, i32) -> i32>
             );
         }
 

--- a/crates/classic-guest/src/runtime_worker.rs
+++ b/crates/classic-guest/src/runtime_worker.rs
@@ -142,6 +142,9 @@ const OP_GET_SPRITE_FRAME: i32 = 90;
 const OP_INVENTORY_CAPACITY: i32 = 91;
 const OP_VEHICLE_PROBE: i32 = 92;
 const OP_VEHICLE_PROBE_CLEAR: i32 = 93;
+const OP_INVENTORY_UI_SHOW: i32 = 94;
+const OP_SET_COLLIDER_BLOCKS_NAV: i32 = 95;
+const OP_VEHICLE_FOOTPRINT_RADIUS: i32 = 96;
 
 const WORKER_SRC: &str = include_str!("worker.js");
 
@@ -315,6 +318,7 @@ impl WorkerWasmRuntime {
             OP_VEHICLE_SET_SPEED => (host.vehicle_set_speed(&strs[0], nf(0)) as f64, None),
             OP_VEHICLE_PROBE => (host.vehicle_probe(&strs[0], ni(0), ni(1)) as f64, None),
             OP_VEHICLE_PROBE_CLEAR => (host.vehicle_probe_clear(&strs[0]) as f64, None),
+            OP_VEHICLE_FOOTPRINT_RADIUS => (host.vehicle_footprint_radius(&strs[0]), None),
             OP_SELECTED_NAMES => {
                 let json = host.selected_names();
                 if ni(1) < json.len() as i32 || json.len() as u32 > OUT_BYTES {
@@ -346,6 +350,7 @@ impl WorkerWasmRuntime {
                     (json.len() as f64, Some(json.into_bytes()))
                 }
             }
+            OP_INVENTORY_UI_SHOW => (host.inventory_ui_show(&strs[0]) as f64, None),
             OP_GET_CAMERA => {
                 let (x, y, s) = host.get_camera();
                 (1.0, Some(enc_f64s(&[x, y, s])))
@@ -356,12 +361,15 @@ impl WorkerWasmRuntime {
             }
             OP_SET_GRID => (host.set_grid(ni(0)) as f64, None),
             OP_PICK_AT => {
-                let name = host.pick_at(nf(0), nf(1));
+                let name = host.pick_at(nf(0), nf(1), &strs[0]);
                 if ni(3) < name.len() as i32 || name.len() as u32 > OUT_BYTES {
                     (-1.0, None)
                 } else {
                     (name.len() as f64, Some(name.into_bytes()))
                 }
+            }
+            OP_SET_COLLIDER_BLOCKS_NAV => {
+                (host.set_collider_blocks_nav(&strs[0], ni(0)) as f64, None)
             }
             OP_MOUSE_DOWN => (host.mouse_down(ni(0)) as f64, None),
             OP_MOUSE_RELEASED => (host.mouse_released(ni(0)) as f64, None),

--- a/crates/classic-guest/src/sdk.rs
+++ b/crates/classic-guest/src/sdk.rs
@@ -329,6 +329,14 @@ impl GuestHost {
         self.engine_mut().vehicle_probe_clear(name) as i32
     }
 
+    /// The max tile radius of a vehicle's collision footprint (`max(|dx|,|dy|)`
+    /// over its `path_footprint` cells), `-1.0` when unknown.  Lets a guest
+    /// derive pick-up/drop clearance from the real footprint instead of a magic
+    /// constant.
+    pub fn vehicle_footprint_radius(&mut self, name: &str) -> f64 {
+        self.engine().vehicle_footprint_radius(name)
+    }
+
     /// The JSON array of currently RTS-selected entity names.
     pub fn selected_names(&mut self) -> String {
         serde_json::to_string(&self.engine().selected_names()).unwrap_or_else(|_| "[]".into())
@@ -382,6 +390,13 @@ impl GuestHost {
         self.engine().item_def(name).unwrap_or_default()
     }
 
+    /// Show the container-inventory hover tooltip for a named entity, or hide
+    /// it when `name` is empty.  Returns 1.
+    pub fn inventory_ui_show(&mut self, name: &str) -> i32 {
+        self.engine_mut().inventory_ui_show(name);
+        1
+    }
+
     /// Read the camera position (x, y) and uniform scale.
     pub fn get_camera(&mut self) -> (f64, f64, f64) {
         let (x, y, s) = self.engine().get_camera();
@@ -400,9 +415,15 @@ impl GuestHost {
         1
     }
 
-    /// The name of the top gameplay entity under a screen point (empty if none).
-    pub fn pick_at(&mut self, x: f64, y: f64) -> String {
-        self.engine().pick_at(x as f32, y as f32).unwrap_or_default()
+    /// The name of the top gameplay entity under a screen point, optionally
+    /// filtered to entities carrying `filter`'s component (empty filter = any).
+    pub fn pick_at(&mut self, x: f64, y: f64, filter: &str) -> String {
+        self.engine().pick_at(x as f32, y as f32, filter).unwrap_or_default()
+    }
+
+    /// Mark (or clear) a named entity's collider as a navigation obstacle.
+    pub fn set_collider_blocks_nav(&mut self, name: &str, blocks: i32) -> i32 {
+        self.engine_mut().set_collider_blocks_nav(name, blocks != 0) as i32
     }
 
     /// Whether a mouse button is held (0 = left, 1 = right, 2 = middle).

--- a/crates/classic-guest/src/worker.js
+++ b/crates/classic-guest/src/worker.js
@@ -130,6 +130,9 @@ var OP_GET_SPRITE_FRAME = 90;
 var OP_INVENTORY_CAPACITY = 91;
 var OP_VEHICLE_PROBE = 92;
 var OP_VEHICLE_PROBE_CLEAR = 93;
+var OP_INVENTORY_UI_SHOW = 94;
+var OP_SET_COLLIDER_BLOCKS_NAV = 95;
+var OP_VEHICLE_FOOTPRINT_RADIUS = 96;
 
 var encoder = new TextEncoder();
 var decoder = new TextDecoder();
@@ -332,6 +335,9 @@ function envImports() {
         vehicle_probe_clear: function (ptr, len) {
             return hostCall(OP_VEHICLE_PROBE_CLEAR, [readStr(ptr, len)], []).ret | 0;
         },
+        vehicle_footprint_radius: function (ptr, len) {
+            return hostCall(OP_VEHICLE_FOOTPRINT_RADIUS, [readStr(ptr, len)], []).ret;
+        },
         selected_names: function (outPtr, outCap) {
             var r = hostCall(OP_SELECTED_NAMES, [], [outPtr, outCap]);
             if (r.out.length > 0) writeMem(outPtr, r.out);
@@ -374,6 +380,12 @@ function envImports() {
             if (r.out.length > 0) writeMem(outPtr, r.out);
             return r.ret | 0;
         },
+        inventory_ui_show: function (ptr, len) {
+            return hostCall(OP_INVENTORY_UI_SHOW, [readStr(ptr, len)], []).ret | 0;
+        },
+        set_collider_blocks_nav: function (ptr, len, blocks) {
+            return hostCall(OP_SET_COLLIDER_BLOCKS_NAV, [readStr(ptr, len)], [blocks]).ret | 0;
+        },
         get_camera: function (outPtr) {
             var r = hostCall(OP_GET_CAMERA, [], [outPtr]);
             if (r.out.length > 0) writeMem(outPtr, r.out);
@@ -385,8 +397,8 @@ function envImports() {
         set_grid: function (show) {
             return hostCall(OP_SET_GRID, [], [show]).ret | 0;
         },
-        pick_at: function (x, y, outPtr, outCap) {
-            var r = hostCall(OP_PICK_AT, [], [x, y, outPtr, outCap]);
+        pick_at: function (x, y, filterPtr, filterLen, outPtr, outCap) {
+            var r = hostCall(OP_PICK_AT, [readStr(filterPtr, filterLen)], [x, y, outPtr, outCap]);
             if (r.out.length > 0) writeMem(outPtr, r.out);
             return r.ret | 0;
         },

--- a/crates/classic-guest/tests/guest.rs
+++ b/crates/classic-guest/tests/guest.rs
@@ -349,6 +349,7 @@ fn guest_selection_and_speed_imports_wired() {
             (import "env" "vehicle_set_speed" (func $vss (param i32 i32 f64) (result i32)))
             (import "env" "vehicle_probe" (func $vprobe (param i32 i32 i32 i32) (result i32)))
             (import "env" "vehicle_probe_clear" (func $vclear (param i32 i32) (result i32)))
+            (import "env" "vehicle_footprint_radius" (func $vfpr (param i32 i32) (result f64)))
             (import "env" "selected_names" (func $sel (param i32 i32) (result i32)))
             (import "env" "selection_clear" (func $clear (result i32)))
             (import "env" "set_sprite_offset" (func $soff (param i32 i32 f64 f64 f64) (result i32)))
@@ -358,6 +359,7 @@ fn guest_selection_and_speed_imports_wired() {
                 (drop (call $vss (i32.const 0) (i32.const 3) (f64.const 1.3)))
                 (drop (call $vprobe (i32.const 0) (i32.const 3) (i32.const 2) (i32.const 0)))
                 (drop (call $vclear (i32.const 0) (i32.const 3)))
+                (drop (call $vfpr (i32.const 0) (i32.const 3)))
                 (drop (call $sel (i32.const 64) (i32.const 64)))
                 (drop (call $clear))
                 (drop (call $soff (i32.const 0) (i32.const 3) (f64.const 0.0) (f64.const -448.0) (f64.const 0.0)))))"#,
@@ -463,6 +465,26 @@ fn guest_get_sprite_frame_and_inventory_capacity_wired() {
 
             assert_eq!(engine.world.get::<&IsoSprite>(copy_a).unwrap().frame, 42.0);
             assert_eq!(engine.world.get::<&IsoSprite>(copy_b).unwrap().frame, 7.0);
+        },
+    );
+}
+
+#[test]
+fn guest_inventory_ui_show_wired() {
+    with_each_runtime(
+        r#"(module
+            (import "env" "inventory_ui_show" (func $show (param i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "unit")
+            (func (export "update") (param f64)
+                (drop (call $show (i32.const 0) (i32.const 4)))
+                (drop (call $show (i32.const 0) (i32.const 0)))))"#,
+        &GuestLimits::default(),
+        |rt| {
+            let mut engine = Engine::new_for_test();
+            // Show "unit" then hide with an empty name; the import must not
+            // trap (neither entity needs an Inventory for the intent itself).
+            rt.update(&mut engine, 0.016).unwrap();
         },
     );
 }
@@ -600,8 +622,27 @@ fn pick_at_returns_entity_under_point() {
     engine.register_named_collider("tree", collider);
     engine.physics.begin_frame();
 
-    assert_eq!(engine.pick_at(100.0, 100.0), Some("tree".to_string()));
-    assert_eq!(engine.pick_at(500.0, 500.0), None);
+    assert_eq!(engine.pick_at(100.0, 100.0, ""), Some("tree".to_string()));
+    assert_eq!(engine.pick_at(500.0, 500.0, ""), None);
+}
+
+#[test]
+fn pick_at_filters_by_component() {
+    let mut engine = Engine::new_for_test();
+    engine.spawn_named("crate");
+    assert!(engine.spawn_collider("crate", 50.0, 60.0, 20.0, 10.0));
+
+    engine.spawn_named("container");
+    let entity = *engine.names.get("container").unwrap();
+    engine.world.insert_one(entity, classic_core::inventory::Inventory::default()).unwrap();
+    assert!(engine.spawn_collider("container", 50.0, 60.0, 20.0, 10.0));
+
+    engine.physics.begin_frame();
+
+    // No filter: top collider (crate registered first → lowest pid).
+    assert_eq!(engine.pick_at(50.0, 60.0, ""), Some("crate".to_string()));
+    // Inventory filter: skips crate, returns the inventory-bearing container.
+    assert_eq!(engine.pick_at(50.0, 60.0, "Inventory"), Some("container".to_string()));
 }
 
 #[test]
@@ -781,8 +822,8 @@ fn spawn_collider_and_pick() {
     assert!(engine.subscribe("unit"));
     engine.physics.begin_frame();
 
-    assert_eq!(engine.pick_at(50.0, 60.0), Some("unit".to_string()));
-    assert_eq!(engine.pick_at(500.0, 500.0), None);
+    assert_eq!(engine.pick_at(50.0, 60.0, ""), Some("unit".to_string()));
+    assert_eq!(engine.pick_at(500.0, 500.0, ""), None);
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

The lunar container-logistics loop from #80 unloads shipping containers, but
each container is opaque — there is no way to see what it holds — and a grounded
container does not block movement the way a physical obstacle should.

## Summary of changes

- Item icons (`ItemDef.icon`) + a `UiKind::Grid` layout and a host-owned
  `InventoryUi` overlay that draws item icons + counts above a hovered container.
- `pick_at(…, "Inventory")` component filter so the guest can hover a container
  shape-accurately.
- `ColliderData.blocks_nav` + `set_collider_blocks_nav` rasterize blocking
  footprints into the nav grid for humanoid and vehicle pathfinding, plus
  `vehicle_footprint_radius` so guests derive pick/drop clearance from the real
  footprints.

## Future follow up

- [ ] Expose more `has_component` names / a numeric filter enum for `pick_at`
- [ ] `inventory_transfer` (mule) moving items between containers/buildings

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
