### PR TITLE
add a text layout map to the golden trace harness

### DIFF
--- a/.agents/skills/classic-testing/SKILL.md
+++ b/.agents/skills/classic-testing/SKILL.md
@@ -200,6 +200,12 @@ When adding a new end-to-end test scenario, follow this workflow:
    that `begin_frame` always resets state, and that entity spawning
    order is deterministic across init stages).
 
+8. **Read the layout map** — a `CLASSIC_GOLDEN=update` run writes
+   `{golden_dir}/baseline.layout.txt`; a `check` run writes
+   `target/classic-test/baseline.layout.txt`.  Skim it to confirm a
+   sprite/text landed in the expected screen rect without pixel vision
+   (see §6 "Layout map").
+
 ### Interactive debugging
 
 Set `CLASSIC_TEST_FAILFAST=1` to exit on the first assertion failure (there is
@@ -280,6 +286,11 @@ name), `model` (16-element matrix via `glam::Mat4::to_cols_array()`, i.e.
 column-major), `camera_ignored` (bool), and optional `texture`, `frame`,
 `color`.
 
+Each `TraceItem` also carries a `screen` rect (`[x, y, w, h]`, top-left
+origin pixels) computed in pure Rust via `golden::project_rect` — but it is
+`#[serde(skip)]`'d, so it never appears in the JSONL and never affects the
+line-by-line golden comparison.  It only feeds the layout map below.
+
 ### Operation
 
 - **Capture timing**: `golden_capture_frame` defaults to `last_test_step.frame + 1`.
@@ -297,6 +308,25 @@ column-major), `camera_ignored` (bool), and optional `texture`, `frame`,
 - **Baseline location**: `tests/golden/baseline/baseline.trace.jsonl`
   (70 lines, covering 5 `IsoSprite`, 54 `SdfText`, 1 `Sprite`, 1
   `Tilemap`, 7 `UiRect`, 1 `UiSprite`).
+
+### Layout map (CLASSIC_GOLDEN_LAYOUT)
+
+Alongside the trace, the harness emits a **layout map** — a deterministic,
+GPU-free text rendering of *what is drawn where* — so a text-only model can
+"look at" the frame without reading pixels.  It is on by default whenever
+`CLASSIC_GOLDEN` is set (disable with `CLASSIC_GOLDEN_LAYOUT=0`).
+
+- **On `update`**: written to `{CLASSIC_GOLDEN_DIR}/baseline.layout.txt`.
+- **On `check`**: written to `target/classic-test/baseline.layout.txt`
+  (always, not only on mismatch), so an author can read it on a passing run.
+
+Format: a `#`-prefixed header line (frame, viewport, camera pos/scale), a
+`#`-prefixed column header, then one fixed-width line per draw item sorted by
+`order` — `name`, `kind`, `order`, `x y w h` (screen rect), `texture`, `color`.
+The `screen` rect is the axis-aligned bounding box of the item's unit quad
+after `(camera or identity) · model`; for `Tilemap` it is the projected
+iso-extent diamond (`(0,0)..(size_x,size_y)` through `model · iso_matrix`).
+This is not part of `compare_traces`, so it cannot fail a golden run.
 
 ### Pixel golden (CLASSIC_GOLDEN_PNG)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,7 @@ plans/
 | `CLASSIC_GOLDEN_PNG` | Enable pixel PNG capture | off |
 | `CLASSIC_GOLDEN_TOL` | Pixel channel tolerance | 2 |
 | `CLASSIC_GOLDEN_DIR` | Golden baseline directory (per-scene) | `tests/golden/baseline` |
+| `CLASSIC_GOLDEN_LAYOUT` | Emit the text layout map (`baseline.layout.txt`); `0` disables | on with `CLASSIC_GOLDEN` |
 | `CLASSIC_SHADOWS` | `0` disables the directional shadow map | on |
 | `CLASSIC_SHADOW_DEBUG` | Render raw sun visibility (white lit / black occluded) | off |
 | `CLASSIC_NO_UI` | Skip the demo editor/HUD/overlay layer (clean lit scene) | off |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ See [`VERSIONING.md`](VERSIONING.md) for the release policy and process.
 - Worker-ize the web transcode: `.basis` sheets transcode in a dedicated web
   `Worker` (async) with a synchronous main-thread fallback, so large sheets no
   longer block the frame loop.
+- Golden layout map: emit a deterministic, GPU-free `baseline.layout.txt` (one
+  line per draw item with its screen-space rect) alongside the golden trace, so
+  text-only models can introspect a rendered frame.
 
 ## [0.1.1] - 2026-09-01
 

--- a/crates/classic-engine/src/env_config.rs
+++ b/crates/classic-engine/src/env_config.rs
@@ -51,11 +51,17 @@ pub struct EnvConfig {
     /// CLASSIC_SHADOW_DUMP: write the directional shadow depth map to
     /// `<dump_dir>/shadow_depth.png` on the golden-capture frame.
     pub shadow_dump: bool,
+    /// CLASSIC_GOLDEN_LAYOUT: emit the text layout map (`baseline.layout.txt`)
+    /// alongside the golden trace.  Defaults on whenever CLASSIC_GOLDEN is set;
+    /// `0` disables it.
+    pub golden_layout: bool,
 }
 
 static CONFIG: LazyLock<EnvConfig> = LazyLock::new(|| {
     let test: String = read("CLASSIC_TEST");
     let test_active = !test.is_empty() && test != "0";
+    let golden_mode: String = read("CLASSIC_GOLDEN");
+    let golden_layout = !golden_mode.is_empty() && read("CLASSIC_GOLDEN_LAYOUT") != "0";
     EnvConfig {
         max_frames: read("CLASSIC_FRAMES").parse().ok(),
         fixed_dt: read("CLASSIC_FIXED_DT").parse().ok().or_else(|| {
@@ -68,7 +74,7 @@ static CONFIG: LazyLock<EnvConfig> = LazyLock::new(|| {
         forced_width: read("CLASSIC_WIDTH").parse().ok(),
         forced_height: read("CLASSIC_HEIGHT").parse().ok(),
         ui_debug: read_bool("CLASSIC_UI_DEBUG"),
-        golden_mode: read("CLASSIC_GOLDEN"),
+        golden_mode,
         golden_png: read_bool("CLASSIC_GOLDEN_PNG"),
         golden_tol: read("CLASSIC_GOLDEN_TOL").parse().ok().unwrap_or(2),
         headless: read_bool("CLASSIC_HEADLESS"),
@@ -97,6 +103,7 @@ static CONFIG: LazyLock<EnvConfig> = LazyLock::new(|| {
         no_ui: read_bool("CLASSIC_NO_UI"),
         shadow_debug: read_bool("CLASSIC_SHADOW_DEBUG"),
         shadow_dump: read_bool("CLASSIC_SHADOW_DUMP"),
+        golden_layout,
         test,
     }
 });

--- a/crates/classic-engine/src/golden.rs
+++ b/crates/classic-engine/src/golden.rs
@@ -52,6 +52,12 @@ pub struct TraceItem {
     /// Normal-map texture name if the sprite shades with runtime lighting.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub normal: Option<String>,
+    /// Screen-space bounding rect `[x, y, w, h]` (top-left origin, pixels) of
+    /// the draw's unit quad after the camera matrix.  Deterministic and GPU-free;
+    /// emitted only into the sibling layout map — never into the JSONL golden
+    /// trace (hence `#[serde(skip)]`).
+    #[serde(skip)]
+    pub screen: Option<[f32; 4]>,
 }
 
 /// A complete render trace for one capture point (tag + frame).
@@ -101,6 +107,7 @@ pub struct TraceItemParams<'a> {
     pub depth: Option<&'a str>,
     pub depth_range: Option<f32>,
     pub normal: Option<&'a str>,
+    pub screen: Option<[f32; 4]>,
 }
 
 impl TraceCollector {
@@ -135,6 +142,7 @@ impl TraceCollector {
             depth: p.depth.map(|s| s.to_string()),
             depth_range: p.depth_range,
             normal: p.normal.map(|s| s.to_string()),
+            screen: p.screen,
         });
     }
 
@@ -183,6 +191,53 @@ pub fn serialize_trace(trace: &RenderTrace) -> String {
     out
 }
 
+/// Serialise a render trace as a fixed-width layout map: one line per draw item
+/// (sorted by `order`) with its screen-space rect.  This is the text-only frame
+/// artifact for non-vision models — deterministic, GPU-free, and emitted next to
+/// the golden trace, but never part of the line-by-line golden comparison.
+pub fn serialize_layout(trace: &RenderTrace) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    let [vw, vh] = trace.viewport;
+    let [cx, cy, cz] = trace.camera.position;
+    let [sx, sy, sz] = trace.camera.scale;
+    let _ = writeln!(
+        out,
+        "# frame {} viewport {:.0}x{:.0} camera_pos ({:.1},{:.1},{:.1}) scale ({:.3},{:.3},{:.3})",
+        trace.frame, vw, vh, cx, cy, cz, sx, sy, sz
+    );
+    let _ = writeln!(
+        out,
+        "# {:<16} {:<10} {:>10} {:>9} {:>9} {:>9} {:>9}  {:<16} color",
+        "name", "kind", "order", "x", "y", "w", "h", "texture"
+    );
+
+    let mut items: Vec<&TraceItem> = trace.items.iter().collect();
+    items.sort_by(|a, b| a.order.total_cmp(&b.order));
+    for it in items {
+        let rect = match it.screen {
+            Some([x, y, w, h]) => format!("{x:>9.1} {y:>9.1} {w:>9.1} {h:>9.1}"),
+            None => format!("{:>9} {:>9} {:>9} {:>9}", "-", "-", "-", "-"),
+        };
+        let color = it
+            .color
+            .map(|c| format!("[{:.2},{:.2},{:.2},{:.2}]", c[0], c[1], c[2], c[3]))
+            .unwrap_or_default();
+        let _ = writeln!(
+            out,
+            "{:<16} {:<10} {:>10.2} {}  {:<16} {}",
+            it.name,
+            it.kind,
+            it.order,
+            rect,
+            it.texture.clone().unwrap_or_default(),
+            color
+        );
+    }
+    out
+}
+
 /// Compare two traces line-wise.  Returns Ok(()) on match, Err(lines_diff) on mismatch.
 pub fn compare_traces(actual: &str, expected: &str) -> Result<(), Vec<String>> {
     let actual_lines: Vec<&str> = actual.lines().collect();
@@ -211,6 +266,34 @@ fn mat4_to_row(m: &glam::Mat4) -> [f32; 16] {
     m.to_cols_array()
 }
 
+/// Project a model matrix's unit quad `(0,0)..(1,1)` to a screen-space bounding
+/// rect `[x, y, w, h]` (top-left origin, pixels).  `cam` is the camera view
+/// matrix (`Camera::matrix`), which already maps world → screen pixels;
+/// `camera_ignored` substitutes the identity so screen-aligned draws project
+/// their model coords directly.  Pure and GL-free — this is what makes the
+/// layout map deterministic and CI-safe.
+pub fn project_rect(cam: &glam::Mat4, model: &glam::Mat4, camera_ignored: bool) -> [f32; 4] {
+    let cam = if camera_ignored { glam::Mat4::IDENTITY } else { *cam };
+    let corners = [
+        glam::Vec3::new(0.0, 0.0, 0.0),
+        glam::Vec3::new(1.0, 0.0, 0.0),
+        glam::Vec3::new(0.0, 1.0, 0.0),
+        glam::Vec3::new(1.0, 1.0, 0.0),
+    ];
+    let mut min_x = f32::MAX;
+    let mut min_y = f32::MAX;
+    let mut max_x = f32::MIN;
+    let mut max_y = f32::MIN;
+    for c in corners {
+        let p = cam.transform_point3(model.transform_point3(c));
+        min_x = min_x.min(p.x);
+        min_y = min_y.min(p.y);
+        max_x = max_x.max(p.x);
+        max_y = max_y.max(p.y);
+    }
+    [min_x, min_y, max_x - min_x, max_y - min_y]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,5 +307,76 @@ mod tests {
     #[test]
     fn different_traces_compare_unequal() {
         assert!(compare_traces("{\"tag\":\"a\"}", "{\"tag\":\"b\"}").is_err());
+    }
+
+    #[test]
+    fn project_rect_translates_and_scales_unit_quad() {
+        let model = glam::Mat4::from_translation(glam::Vec3::new(10.0, 20.0, 0.0))
+            * glam::Mat4::from_scale(glam::Vec3::new(30.0, 40.0, 1.0));
+        assert_eq!(project_rect(&glam::Mat4::IDENTITY, &model, false), [10.0, 20.0, 30.0, 40.0]);
+    }
+
+    #[test]
+    fn project_rect_camera_ignored_uses_identity() {
+        let model = glam::Mat4::from_translation(glam::Vec3::new(5.0, 6.0, 0.0))
+            * glam::Mat4::from_scale(glam::Vec3::new(7.0, 8.0, 1.0));
+        // A camera that would otherwise shove the quad far off-screen.
+        let cam = glam::Mat4::from_translation(glam::Vec3::new(-1000.0, -1000.0, 0.0));
+        assert_eq!(project_rect(&cam, &model, true), [5.0, 6.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    fn screen_field_is_not_serialized() {
+        let item = TraceItem {
+            order: 0.0,
+            kind: "Sprite".into(),
+            name: "n".into(),
+            model: [0.0; 16],
+            camera_ignored: false,
+            texture: None,
+            frame: None,
+            color: None,
+            depth: None,
+            depth_range: None,
+            normal: None,
+            screen: Some([1.0, 2.0, 3.0, 4.0]),
+        };
+        let json = serde_json::to_string(&item).expect("serialize");
+        assert!(!json.contains("screen"), "screen must not leak into the JSONL: {json}");
+    }
+
+    #[test]
+    fn serialize_layout_renders_items_with_rects() {
+        let item = TraceItem {
+            order: 2.0,
+            kind: "Sprite".into(),
+            name: "rocket".into(),
+            model: [0.0; 16],
+            camera_ignored: false,
+            texture: Some("demo_atlas".into()),
+            frame: None,
+            color: None,
+            depth: None,
+            depth_range: None,
+            normal: None,
+            screen: Some([10.0, 20.0, 30.0, 40.0]),
+        };
+        let trace = RenderTrace {
+            tag: "baseline".into(),
+            frame: 55,
+            viewport: [1280.0, 720.0],
+            camera: CameraSnapshot {
+                position: [1.0, 2.0, 3.0],
+                scale: [1.0, 1.0, 1.0],
+                matrix: [0.0; 16],
+            },
+            counts: BTreeMap::new(),
+            items: vec![item],
+        };
+        let map = serialize_layout(&trace);
+        assert!(map.contains("frame 55"));
+        assert!(map.contains("rocket"));
+        assert!(map.contains("Sprite"));
+        assert!(map.contains("demo_atlas"));
     }
 }

--- a/crates/classic-engine/src/lib.rs
+++ b/crates/classic-engine/src/lib.rs
@@ -3798,6 +3798,17 @@ impl Engine {
                             .get(&nav.tile_set)
                             .map(|t| [t.size.0 as f32 / 8.0, t.size.1 as f32 / 8.0])
                             .unwrap_or([2.0, 1.0]);
+                        let nav_rect = golden::project_rect(
+                            &cam,
+                            &(Mat4::from_translation(tf.position)
+                                * iso_matrix
+                                * Mat4::from_scale(Vec3::new(
+                                    nav.size_x as f32,
+                                    nav.size_y as f32,
+                                    1.0,
+                                ))),
+                            false,
+                        );
                         if let Some(ref mut t) = self.trace {
                             let name = name_by_entity.get(entity).copied().unwrap_or("");
                             t.push(golden::TraceItemParams {
@@ -3812,6 +3823,7 @@ impl Engine {
                                 depth: None,
                                 depth_range: None,
                                 normal: None,
+                                screen: Some(nav_rect),
                             });
                         }
                         gfx.draw_tilemap(
@@ -3872,6 +3884,14 @@ impl Engine {
                     tm.tile_set_pixel_size[1] as f32 / tile_pixel_size[1],
                 ];
 
+                let tm_rect = golden::project_rect(
+                    &cam,
+                    &(Mat4::from_translation(tf.position)
+                        * iso_matrix
+                        * Mat4::from_scale(Vec3::new(tm.size_x as f32, tm.size_y as f32, 1.0))),
+                    false,
+                );
+
                 if let Some(ref mut t) = self.trace {
                     let name = name_by_entity.get(entity).copied().unwrap_or("");
                     t.push(golden::TraceItemParams {
@@ -3886,6 +3906,7 @@ impl Engine {
                         depth: None,
                         depth_range: None,
                         normal: None,
+                        screen: Some(tm_rect),
                     });
                 }
 
@@ -3957,6 +3978,7 @@ impl Engine {
                     depth: draw.depth_map.as_ref().map(|(t, _)| t.as_str()),
                     depth_range: draw.depth_map.as_ref().map(|(_, r)| *r),
                     normal: draw.normal_map.as_deref(),
+                    screen: Some(golden::project_rect(&cam, &draw.model, false)),
                 });
             }
             gfx.draw_iso_sprite(
@@ -4069,6 +4091,11 @@ impl Engine {
                             depth: None,
                             depth_range: None,
                             normal: None,
+                            screen: Some(golden::project_rect(
+                                &cam,
+                                &sprite_model,
+                                sprite.ignore_cam,
+                            )),
                         });
                     }
                     let region = match &uv {
@@ -4112,6 +4139,7 @@ impl Engine {
                             depth: None,
                             depth_range: None,
                             normal: None,
+                            screen: Some(golden::project_rect(&cam, &model, rect.ignore_cam)),
                         });
                     }
                     let cam_mat = if rect.ignore_cam { Mat4::IDENTITY } else { cam };
@@ -4189,6 +4217,7 @@ impl Engine {
                             depth: None,
                             depth_range: None,
                             normal: None,
+                            screen: Some(golden::project_rect(&cam, &model, true)),
                         });
                     }
                     gfx.draw_sprite(
@@ -4313,6 +4342,7 @@ impl Engine {
                             depth: None,
                             depth_range: None,
                             normal: None,
+                            screen: Some(golden::project_rect(&cam, &model, sdf.ignore_cam)),
                         });
                     }
                     let sdf_cam = if sdf.ignore_cam { Mat4::IDENTITY } else { cam };
@@ -4406,6 +4436,38 @@ impl Engine {
                     }
                 }
                 _ => {}
+            }
+
+            // --- text layout map (deterministic, GPU-free; not part of the
+            // line-by-line golden comparison) ---
+            if config.golden_layout {
+                let layout = golden::serialize_layout(&trace);
+                match config.golden_mode.as_str() {
+                    "update" => {
+                        let _ = std::fs::create_dir_all(&baseline_dir);
+                        let layout_path = baseline_dir.join("baseline.layout.txt");
+                        if let Err(e) = std::fs::write(&layout_path, &layout) {
+                            classic_core::cl_warn!(
+                                classic_core::instrument::Chan::Golden,
+                                "golden: failed to write {}: {e}",
+                                layout_path.display()
+                            );
+                        } else {
+                            classic_core::cl_info!(
+                                classic_core::instrument::Chan::Golden,
+                                "golden: wrote {}",
+                                layout_path.display()
+                            );
+                        }
+                    }
+                    "check" => {
+                        let artifact_dir = cwd.join("target/classic-test");
+                        let _ = std::fs::create_dir_all(&artifact_dir);
+                        let layout_path = artifact_dir.join("baseline.layout.txt");
+                        let _ = std::fs::write(&layout_path, &layout);
+                    }
+                    _ => {}
+                }
             }
 
             // --- pixel golden ---


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/frame_layout_trace
base: wkt/web_transcoder_followup
head_oid: 65b0b81caf4229d26c55a2121254fb8f75428efe
base_tip_oid: d460dc5864fc026abd66ac57bd4c6a3c27a82e9a
merge_base_oid: d460dc5864fc026abd66ac57bd4c6a3c27a82e9a
provider_diff_base_oid: unavailable
commit_range: d460dc5864fc026abd66ac57bd4c6a3c27a82e9a..65b0b81caf4229d26c55a2121254fb8f75428efe
diff_range: d460dc5864fc026abd66ac57bd4c6a3c27a82e9a...65b0b81caf4229d26c55a2121254fb8f75428efe
authority: local/prospective
submitted:
  github: 88
-->

## Add a text layout map to the golden trace harness

> **Draft.** Stacked on `wkt/web_transcoder_followup`.

### Motivation

`classic-wgl`'s golden harness emits two artifacts: the `.trace.jsonl` (draw
intent — matrices, sort order, textures) and the `.png` pixel golden (the
literal framebuffer). A text-only model can already read the trace, but the
pixel golden — the ground-truth *result* — is opaque to it. The `PixelAtEntity`
escape hatch samples one pixel at a time and is broken under headless/llvmpipe.

This PR gives the rendered frame a deterministic, GPU-free *text* rendering:
a layout map with one line per draw item and its projected screen rect. A
non-vision model can then "look at" a frame while authoring and debugging e2e
scenarios.

### Summary of changes

- Emit `baseline.layout.txt` alongside the golden trace — a fixed-width map of
  every draw item (sorted by `order`) with its screen-space rect, so a text-only
  model can introspect a rendered frame.

- Add `golden::project_rect` (pure world→screen quad AABB, no GL) and
  `golden::serialize_layout`; carry a serde-skipped `screen` rect on `TraceItem`
  populated at every draw-call push site (tilemap items project their iso
  extent).

- Gate emission with `CLASSIC_GOLDEN_LAYOUT` (on by default with
  `CLASSIC_GOLDEN`, `=0` disables); unit-test the projection, non-serialization,
  and layout rendering, and document the artifact in the `classic-testing`
  skill.

---

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
