### PR TITLE
stream `Rom` entries into the archive writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ See [`VERSIONING.md`](VERSIONING.md) for the release policy and process.
 - Read the vehicle anchors `data[]` artifact as `name → anchors` maps
   (`BTreeMap`), dropping the redundant `name`/`directions`/per-part `texture`
   fields (#89).
+- Stream `Rom` archive entries into the pack writers (`for_each_entry`),
+  avoiding a full `Vec<(String, Vec<u8>)>` materialization.
 
 ## [0.1.1] - 2026-09-01
 

--- a/crates/classic-rom/src/rom.rs
+++ b/crates/classic-rom/src/rom.rs
@@ -60,10 +60,11 @@ impl Rom {
         let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
         let opts = zip::write::SimpleFileOptions::default()
             .compression_method(zip::CompressionMethod::Deflated);
-        for (path, bytes) in self.entries() {
+        self.for_each_entry(|path, bytes| {
             writer.start_file(path, opts)?;
-            writer.write_all(&bytes)?;
-        }
+            writer.write_all(bytes)?;
+            Ok(())
+        })?;
         Ok(writer.finish()?.into_inner())
     }
 
@@ -71,77 +72,83 @@ impl Rom {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn pack_tar_zst(&self) -> anyhow::Result<Vec<u8>> {
         let mut tar = tar::Builder::new(Vec::new());
-        for (path, bytes) in self.entries() {
+        self.for_each_entry(|path, bytes| {
             let mut header = tar::Header::new_gnu();
             header.set_mode(0o644);
             header.set_size(bytes.len() as u64);
-            tar.append_data(&mut header, &path, bytes.as_slice())?;
-        }
+            tar.append_data(&mut header, path, bytes)?;
+            Ok(())
+        })?;
         let tar_bytes = tar.into_inner()?;
         Ok(zstd::bulk::compress(&tar_bytes, 19)?)
     }
 
-    /// The flat list of `(path, bytes)` archive entries, in manifest-first order.
-    fn entries(&self) -> Vec<(String, Vec<u8>)> {
-        let mut out = Vec::new();
-        out.push((MANIFEST_ENTRY.to_string(), self.manifest_json.as_bytes().to_vec()));
-        out.push((self.manifest.state.clone(), self.state.as_bytes().to_vec()));
+    /// Visit every archive entry `(path, bytes)` in manifest-first order,
+    /// borrowing the bytes straight from the resource set (no intermediate
+    /// clone).  `pack_zip`/`pack_tar_zst` stream these directly into their
+    /// writers instead of materialising a `Vec<(String, Vec<u8>)>`.
+    fn for_each_entry(
+        &self,
+        mut f: impl FnMut(&str, &[u8]) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        f(MANIFEST_ENTRY, self.manifest_json.as_bytes())?;
+        f(self.manifest.state.as_str(), self.state.as_bytes())?;
 
         for entry in &self.manifest.manifest.textures {
             if let Some(bytes) = self.resources.textures().get(&entry.name) {
-                out.push((crate::rom_path(&entry.src).to_string(), bytes.clone()));
+                f(crate::rom_path(&entry.src), bytes)?;
             }
             if let (Some(path), Some(bytes)) =
                 (&entry.frames, self.resources.frames().get(&entry.name))
             {
-                out.push((crate::rom_path(path).to_string(), bytes.clone()));
+                f(crate::rom_path(path), bytes)?;
             }
         }
         for entry in &self.manifest.manifest.textures {
             if let Some(path) = &entry.depth {
                 if let Some(bytes) = self.resources.depths().get(&entry.name) {
-                    out.push((crate::rom_path(path).to_string(), bytes.clone()));
+                    f(crate::rom_path(path), bytes)?;
                 }
             }
             if let Some(path) = &entry.normal {
                 if let Some(bytes) = self.resources.normals().get(&entry.name) {
-                    out.push((crate::rom_path(path).to_string(), bytes.clone()));
+                    f(crate::rom_path(path), bytes)?;
                 }
             }
         }
         for entry in &self.manifest.manifest.sdf_fonts {
             if let Some(metrics) = self.resources.fonts().get(&entry.name) {
-                out.push((crate::rom_path(&entry.metrics).to_string(), metrics.clone()));
+                f(crate::rom_path(&entry.metrics), metrics)?;
             }
         }
         for entry in &self.manifest.code {
             if let Some(src) = self.resources.code().get(&entry.name) {
-                out.push((crate::rom_path(&entry.src).to_string(), src.clone()));
+                f(crate::rom_path(&entry.src), src)?;
             }
         }
         for entry in &self.manifest.manifest.animations {
             if let Some(metadata) = self.resources.animations().get(&entry.name) {
                 if let Some(path) = &entry.metadata {
-                    out.push((crate::rom_path(path).to_string(), metadata.clone()));
+                    f(crate::rom_path(path), metadata)?;
                 }
             }
         }
         for entry in &self.manifest.grids {
             if let Some(bytes) = self.resources.grids().get(&entry.name) {
-                out.push((crate::rom_path(&entry.src).to_string(), bytes.clone()));
+                f(crate::rom_path(&entry.src), bytes)?;
             }
         }
         for entry in &self.manifest.manifest.vehicles {
             if let Some(bytes) = self.resources.vehicles().get(&entry.name) {
-                out.push((crate::rom_path(&entry.src).to_string(), bytes.clone()));
+                f(crate::rom_path(&entry.src), bytes)?;
             }
         }
         for entry in &self.manifest.manifest.data {
             if let Some(bytes) = self.resources.data().get(&entry.name) {
-                out.push((crate::rom_path(&entry.src).to_string(), bytes.clone()));
+                f(crate::rom_path(&entry.src), bytes)?;
             }
         }
-        out
+        Ok(())
     }
 }
 


### PR DESCRIPTION
<!-- pr-msg-meta
branch: wkt/rom_stream_entries
base: wkt/format_simplification
head_oid: 551513b205b109ded1f64dbc1dd3a1c65b9b1e56
base_tip_oid: 3c3bd6bbbb6487d6777294325acb0ea9b19e15ec
merge_base_oid: 3c3bd6bbbb6487d6777294325acb0ea9b19e15ec
provider_diff_base_oid: unavailable
commit_range: 3c3bd6bbbb6487d6777294325acb0ea9b19e15ec..551513b205b109ded1f64dbc1dd3a1c65b9b1e56
diff_range: 3c3bd6bbbb6487d6777294325acb0ea9b19e15ec...551513b205b109ded1f64dbc1dd3a1c65b9b1e56
authority: forge-verified
submitted:
  github: ___
-->

## stream `Rom` entries into the archive writers

### Motivation

`Rom::pack_tar_zst` / `pack_zip` call `entries()`, which clones every
resource byte into a fresh `Vec<(String, Vec<u8>)>` before writing the
tar/zip. That's a full extra copy of the ROM's payload — most costly
when classic-roms packs the 9 scene ROMs in parallel (its rayon
fan-out holds several scenes in memory at once).

This replaces `entries()` with a `for_each_entry` callback that
streams borrowed `(path, bytes)` straight into the archive writer. The
tar/zip + zstd output is byte-identical; only the peak-memory
footprint shrinks.

---

### Summary of changes

- Replace `Rom::entries()` with a `for_each_entry` visitor that
  borrows each `(path, &[u8])` from the `ResourceSet`, and rewrite
  `pack_zip` + `pack_tar_zst` to write directly instead of cloning.
  Round-trip tests unchanged.

---

(this pr content was generated in some part by `opencode` using `deepseek-v4-pro` (`deepseek`))
